### PR TITLE
[move_func_return] Add a missing return type.

### DIFF
--- a/src/examples/move_func_return/input/annotated_source.rs
+++ b/src/examples/move_func_return/input/annotated_source.rs
@@ -1,4 +1,4 @@
-fn <tspan class="fn" data-hash="0" hash="4">f</tspan>() {
+fn <tspan class="fn" data-hash="0" hash="4">f</tspan>() -> String {
     let <tspan data-hash="1">x</tspan> = <tspan class="fn" data-hash="0" hash="3">String::from</tspan>("hello");
     // ...
     <tspan data-hash="1">x</tspan>

--- a/src/examples/move_func_return/main.rs
+++ b/src/examples/move_func_return/main.rs
@@ -5,7 +5,7 @@ Function String::from();
 Function f();
 Function println!()
 --- END Variable Definitions --- */
-fn f() {
+fn f() -> String {
     let x = String::from("hello"); // !{ Move(String::from()->x) }
     // ...
     x // !{ Move(x->None) }

--- a/src/examples/move_func_return/source.rs
+++ b/src/examples/move_func_return/source.rs
@@ -1,4 +1,4 @@
-fn f() {
+fn f() -> String {
     let x = String::from("hello");
     // ...
     x

--- a/src/examples/move_func_return/vis_code.svg
+++ b/src/examples/move_func_return/vis_code.svg
@@ -168,7 +168,7 @@ object.code_panel {
     </g>
 
     <g id="code">
-        <text class="code" x="20" y="90"> <tspan fill="#AAA">1  </tspan>fn <tspan class="fn" data-hash="0" hash="4">f</tspan>() { </text>
+        <text class="code" x="20" y="90"> <tspan fill="#AAA">1  </tspan>fn <tspan class="fn" data-hash="0" hash="4">f</tspan>() -> String { </text>
         <text class="code" x="20" y="120"> <tspan fill="#AAA">2  </tspan>    let <tspan data-hash="1">x</tspan> = <tspan class="fn" data-hash="0" hash="3">String::from</tspan>("hello"); </text>
         <text class="code" x="20" y="150"> <tspan fill="#AAA">3  </tspan>    // ... </text>
         <text class="code" x="20" y="180"> <tspan fill="#AAA">4  </tspan>    <tspan data-hash="1">x</tspan> </text>


### PR DESCRIPTION
I think there is a missing return type in [move_func_return](https://github.com/rustviz/rustviz/tree/master/src/examples/move_func_return)

```rust
fn f() {
    // - help: try adding a return type: `-> String`
    let x = String::from("hello");
    // ...
    x
}

fn main() {
    let s = f();
    println!("{}", s);
}
```

This PR should fix it.