### PR TITLE
Supplemental documentation + code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ string_from_move_print
 ├── vis_code.svg
 └── vis_timeline.svg
 ```
-Congratulations! You have successfully generated your first visualization! As a last step, add the name of your example to `targetExamples` under [view_examples.sh](rustviz_mdbook/view_examples.sh) and run the script from [rustviz_mdbook](rustviz_mdbook) to see it in your browser.
+Congratulations! You have successfully generated your first visualization! As a last step, add the name of your example to `targetExamples` under [view_examples.sh](rustviz_mdbook/view_examples.sh) and run the script from [rustviz_mdbook](rustviz_mdbook) to see it in your browser. For a more in-depth walkthrough of how rustviz works check out the [README](src/svg_generator/README.md) in `src/svg_generator/`
 
 ## Appendix
 
@@ -186,3 +186,4 @@ Some features are still being built. As of now, we are limited to:
 - No branching logic
 - No looping
 - No explicit lifetime annotation
+- No shadowed variables

--- a/src/svg_generator/svg_frontend/line_styles.rs
+++ b/src/svg_generator/svg_frontend/line_styles.rs
@@ -1,39 +1,7 @@
-pub enum LineStyle {
-    OwnerLine,
-    RefValueLine,
-    RefDataLine,
-}
-
 pub enum OwnerLine {
     // what is the owner's current status?
     Solid,     // you can assign to, write and read from this owner
     Hollow,    // you can only read the data from this RAP.
     Dotted,    // you cannot read nor write the data from this RAP temporarily (borrowed away by a mut reference)
     Empty,     // you cannot read nor write the data from this RAP forever (moved)
-}
-
-
-// Will show up as colorful or grayed out
-pub enum RefValueLine {
-    // can you reassign the ref (self) to something else right after this line? Depend on & or &mut 
-    // (i.e. static object will never be re-assignable. For mutable objects, it depends)
-    // if there is a current borrowing on a mutable object, then it is not reassignable
-    
-    // This will show up as a colorful line
-    Reassignable,           // this ref is declared as 
-                            // mut ref = &x;
-                            // or 
-                            // mut ref = &mut x;
-                            // and currently no second-level reference is borrowing from it. So you can in fact reassign it. 
-    // This will be a grayed out line
-    NotReassignable,        // anything else.
-}
-
-// NOTE that the style coincide with OwnerLine, but we use the data structure to distinguish the semantics internally 
-pub enum RefDataLine {
-    // can you change the data this reference points to? I.e. you might need to dereference multiple times
-    Solid,     // we can r/w data
-    Hollow,    // can only read data
-    Dotted,    // cannot read or write, because self is borrowed by yet another &mut
-    Empty,     // you cannot read nor write the data from this RAP forever (after last use)
 }

--- a/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1,7 +1,7 @@
 extern crate handlebars;
 
 use crate::data::{StructsInfo, VisualizationData, Visualizable, ExternalEvent, State, ResourceAccessPoint, Event, LINE_SPACE};
-use crate::svg_frontend::line_styles::{RefDataLine, RefValueLine, OwnerLine};
+use crate::svg_frontend::line_styles::OwnerLine;
 use handlebars::Handlebars;
 use std::collections::BTreeMap;
 use serde::Serialize;
@@ -714,53 +714,6 @@ fn determine_owner_line_styles(
         // partialprivilege ~= immutable, otherwise it would be an error
         (State::PartialPrivilege{..}, _) => OwnerLine::Hollow, // let (mut) a = 5;
         _ => OwnerLine::Empty, // Otherwise its empty
-    }
-}
-
-// DEAD CODE
-fn _determine_stat_ref_line_styles(
-    rap: &ResourceAccessPoint,
-    state: &State
-) -> (RefDataLine, RefValueLine) {
-    match (state, rap.is_mut()) {
-        (State::FullPrivilege, _) => (
-            RefDataLine::Solid,
-            if rap.is_mut() {RefValueLine::Reassignable} else {RefValueLine::NotReassignable},
-        ),
-        (State::PartialPrivilege{..}, false) => (
-            RefDataLine::Hollow,
-            RefValueLine::NotReassignable,
-        ),
-        (State::PartialPrivilege{..}, true) => (
-            RefDataLine::Hollow,
-            RefValueLine::Reassignable,     // potentially wrong. Not taking second level 
-                                            // borrowing into account
-        ),
-        _ => (                              // TODO: not finished
-            RefDataLine::Hollow,
-            RefValueLine::NotReassignable,
-        )
-    }
-}
-
-// DEAD CODE
-fn _determine_mut_ref_line_styles(
-    rap: &ResourceAccessPoint,
-    state: &State
-) -> (RefDataLine, RefValueLine) {
-    match (state, rap.is_mut()) {
-        (State::FullPrivilege, false) => (
-            RefDataLine::Solid,
-            RefValueLine::NotReassignable,
-        ),
-        (State::FullPrivilege, true) => (
-            RefDataLine::Solid,
-            RefValueLine::Reassignable,
-        ),
-        _ => ( // TODO: not finished
-            RefDataLine::Hollow,
-            RefValueLine::NotReassignable,
-        )
     }
 }
 


### PR DESCRIPTION
Added a more in-depth explanation of rustviz in the README in src/svg_generator under the header "Understanding rustviz". Removed some dead code from timeline_panel.rs and line_styles.rs.