### PR TITLE
fix: runner Dockerfile COPY path missed during runner/ → playground/runner/ move

### DIFF
--- a/playground/runner/Dockerfile
+++ b/playground/runner/Dockerfile
@@ -64,7 +64,7 @@ RUN rustup toolchain install ${RUST_NIGHTLY} \
 COPY --from=builder /usr/local/bin/cargo-rv-plugin /usr/local/cargo/bin/
 COPY --from=builder /usr/local/bin/rv-plugin-driver /usr/local/cargo/bin/
 
-COPY runner/rv-runner.sh /usr/local/bin/rv-runner
+COPY playground/runner/rv-runner.sh /usr/local/bin/rv-runner
 RUN chmod +x /usr/local/bin/rv-runner
 
 USER runner


### PR DESCRIPTION
## Summary

The runner image build is failing on \`main\` after the consolidation merge:

\`\`\`
#21 [runtime 5/7] COPY runner/rv-runner.sh /usr/local/bin/rv-runner
ERROR: failed to compute cache key: "/runner/rv-runner.sh": not found
\`\`\`

The \`playground/runner/Dockerfile\` had a stale COPY path that the path-substitution sweep in the rustviz2 reorg missed. Build context is the repo root (per \`.github/workflows/build.yml\`'s \`context: .\`), and \`runner/\` lived there pre-reorg. After the directory was moved to \`playground/runner/\`, the COPY needed to follow.

## Change

\`\`\`diff
-COPY runner/rv-runner.sh /usr/local/bin/rv-runner
+COPY playground/runner/rv-runner.sh /usr/local/bin/rv-runner
\`\`\`

The other COPYs in this Dockerfile already used the repo-rooted form (\`rust-toolchain.toml\`, \`Cargo.lock\`, \`rustviz2-plugin/\`) and were unaffected — only the \`rv-runner.sh\` entrypoint copy was broken.

## Test plan

- [ ] Next runner-image CI run passes both arch builds