### PR TITLE
playground: deploy at rustviz.github.io org root, not /playground/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,19 +1,22 @@
 name: pages
 
 # Builds the Vite SPA in `pages` mode and pushes the resulting dist/
-# tree to the `rustviz/playground` repo, which has GitHub Pages enabled
-# and serves it at https://rustviz.github.io/playground/.
+# tree to the `rustviz/rustviz.github.io` repo — GitHub's special
+# user/org-page repo name. Anything pushed to that repo's default
+# branch is served at https://rustviz.github.io/ (org root, no path
+# prefix).
 #
 # Setup the repo owner needs to do once before this workflow can run:
-#   1. Create the receiving repo:
-#        gh repo create rustviz/playground --public \
+#   1. Create the receiving repo (named exactly <org>.github.io for
+#      GitHub to serve it as the org page at the root URL):
+#        gh repo create rustviz/rustviz.github.io --public \
 #          --description "Static front-end for the RustViz playground"
-#   2. On rustviz/playground, enable GitHub Pages:
+#   2. On rustviz/rustviz.github.io, enable GitHub Pages:
 #        Settings → Pages → Source: Deploy from a branch → main / root.
 #   3. Generate a deploy keypair:
 #        ssh-keygen -t ed25519 -f /tmp/playground_deploy_key -N "" \
 #          -C "playground-deploy"
-#   4. Add the *public* key to rustviz/playground:
+#   4. Add the *public* key to rustviz/rustviz.github.io:
 #        Settings → Deploy keys → Add key, paste /tmp/playground_deploy_key.pub,
 #        check "Allow write access".
 #   5. Add the *private* key to rustviz/rustviz:
@@ -53,11 +56,11 @@ jobs:
         run: npm run build:pages
         working-directory: playground/frontend
 
-      - name: Deploy to rustviz/playground
+      - name: Deploy to rustviz/rustviz.github.io
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
-          external_repository: rustviz/playground
+          external_repository: rustviz/rustviz.github.io
           publish_branch: main
           publish_dir: playground/frontend/dist
           # Helpful when diagnosing a botched deploy: each commit on the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ checker's view of the program rather than a hand-curated approximation.
 RustViz is a project of the [Future of Programming Lab](https://fplab.mplse.org/)
 at the University of Michigan.
 
-> **Try it live:** <https://rustviz.github.io/playground/>
+> **Try it live:** <https://rustviz.github.io/>
 
 ![screenshot placeholder](rustviz2-plugin/src/svg_generator/rv2_example.png)
 
@@ -64,7 +64,7 @@ default it spares the rustup toolchain and the cargo `target/` tree).
 
 The hosted playground lets you paste a snippet into a CodeMirror editor and
 get back the visualization with no local install. Available at
-<https://rustviz.github.io/playground/>; the SPA loads from GitHub Pages
+<https://rustviz.github.io/>; the SPA loads from GitHub Pages
 and the compile API is on Fly.io. You can also run the same playground
 locally — it's the [`playground/`](playground/) crate in this workspace.
 
@@ -149,7 +149,7 @@ top-level directory:
 | **`rustviz2-plugin/`**| The rustc plugin — the heart of the project. Walks HIR/MIR for a single-file crate and emits a code-panel + timeline-panel SVG on stdout. Built on Will Crichton's `rustc_plugin` / `rustc_utils` crates (same family as Flowistry / Aquascope). Produces the `cargo-rv-plugin` and `rv-plugin-driver` binaries. Pinned to nightly-2025-08-20 via `rust-toolchain.toml`. |
 | **`rustviz2/`**       | User-facing Rust library + the `rustviz` CLI. The library exposes `Rustviz::new(code)` which shells out to the plugin; the CLI (`rustviz svg`, `rustviz html`, `rustviz init`) wraps it with file I/O and self-contained-HTML output. The shared tooltip JS for hover behavior also lives here, exported as `rustviz2::HELPERS_JS`. |
 | **`mdbook-rustviz/`** | An [mdBook](https://rust-lang.github.io/mdBook/) preprocessor. Replaces ` ```rv ` fenced code blocks with embedded RustViz SVGs at build time. Includes a `test-book/` worked example. The full hands-on tutorial that uses it is in a [separate repo](https://github.com/rustviz/tutorial). |
-| **`playground/`**     | The web playground: Actix-web backend + a Vite/React/CodeMirror frontend. Hosted at <https://rustviz.github.io/playground/> with the compile API at <https://rustviz-playground.fly.dev/>. The same binary works as an all-in-one server for local dev. The per-request Docker sandbox image, deploy artifacts, and security threat model all live alongside it under `playground/`. |
+| **`playground/`**     | The web playground: Actix-web backend + a Vite/React/CodeMirror frontend. Hosted at <https://rustviz.github.io/> with the compile API at <https://rustviz-playground.fly.dev/>. The same binary works as an all-in-one server for local dev. The per-request Docker sandbox image, deploy artifacts, and security threat model all live alongside it under `playground/`. |
 | `setup.sh`            | One-shot dev bootstrap: installs the toolchain, builds the plugin, builds the frontend, builds the runner image. Run once after cloning. |
 | `uninstall.sh`        | Reverse of `setup.sh`. Removes the cargo-installed binaries + the local docker runner image + frontend artifacts; spares the rustup toolchain and `target/` by default (override with `--toolchain` / `--target` / `--everything`). |
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -3,7 +3,7 @@
 The playground is a small web app — a CodeMirror editor that POSTs Rust
 snippets to a sandboxed backend, which renders them through the RustViz
 plugin and returns the two SVG panels. Hosted at
-<https://rustviz.github.io/playground/> with the compile API at
+<https://rustviz.github.io/> with the compile API at
 <https://rustviz-playground.fly.dev/>.
 
 The same `rustviz-playground` binary works as an all-in-one server (SPA + API
@@ -41,9 +41,9 @@ set `RV_RUNNER=local`. **Never** do this on a public deployment — see
 
 Production runs in two pieces:
 
-- **Static SPA on GitHub Pages**, at <https://rustviz.github.io/playground/>.
+- **Static SPA on GitHub Pages**, at <https://rustviz.github.io/>.
   Built from `playground/frontend/` by `.github/workflows/pages.yml` and
-  pushed to the `rustviz/playground` repo on every change. Loads instantly
+  pushed to the `rustviz/rustviz.github.io` repo on every change. Loads instantly
   even when no one has visited recently.
 - **Compile API on Fly.io**, at <https://rustviz-playground.fly.dev/>.
   Ten Machines provisioned, all auto-stopping when idle; the edge proxy
@@ -117,17 +117,17 @@ failure, in addition to GitHub's default email-on-failure notification.
 
 ```sh
 # 1. Create the receiving repo
-gh repo create rustviz/playground --public \
+gh repo create rustviz/rustviz.github.io --public \
   --description "Static front-end for the RustViz playground"
 
-# 2. Enable Pages on rustviz/playground via Settings → Pages →
+# 2. Enable Pages on rustviz/rustviz.github.io via Settings → Pages →
 #    Source: Deploy from a branch → main / root.
 
 # 3. Generate a deploy keypair
 ssh-keygen -t ed25519 -f /tmp/playground_deploy_key -N "" -C playground-deploy
 
-# 4. Add the *public* key as a write-enabled deploy key on rustviz/playground
-gh api -X POST repos/rustviz/playground/keys \
+# 4. Add the *public* key as a write-enabled deploy key on rustviz/rustviz.github.io
+gh api -X POST repos/rustviz/rustviz.github.io/keys \
   -f title=playground-deploy -F read_only=false \
   -f key="$(cat /tmp/playground_deploy_key.pub)"
 
@@ -141,8 +141,8 @@ rm /tmp/playground_deploy_key /tmp/playground_deploy_key.pub
 After that, every push to `main` (when the change touches
 `playground/frontend/**`) triggers `.github/workflows/pages.yml`, which
 builds the SPA in `pages` mode and pushes the `dist/` tree to
-`rustviz/playground` for serving at
-<https://rustviz.github.io/playground/>.
+`rustviz/rustviz.github.io` for serving at
+<https://rustviz.github.io/>.
 
 ### Adding a new SPA origin
 

--- a/playground/SECURITY.md
+++ b/playground/SECURITY.md
@@ -85,7 +85,7 @@ entrypoint. There is no shell access surface in the playground HTTP path.
 ### 3. CORS allowlist on the API
 
 The static SPA is served from GitHub Pages at
-`https://rustviz.github.io/playground/`, so cross-origin requests to the
+`https://rustviz.github.io/`, so cross-origin requests to the
 Fly API are required and gated by an explicit `actix-cors` allowlist in
 `playground/src/main.rs`. The allowlist is the *only* control over which
 sites can drive the API from a browser:

--- a/playground/frontend/index.html
+++ b/playground/frontend/index.html
@@ -10,7 +10,7 @@
   <body>
     <h1>RustViz Playground</h1>
     <p>
-      Welcome! <a href="https://github.com/rustviz/rustviz2/">RustViz</a>
+      Welcome! <a href="https://github.com/rustviz/rustviz/">RustViz</a>
       is a tool to visualize an approximation of the compile-time reasoning
       of <a href="https://www.rust-lang.org/">Rust's</a> Borrow Checker.
     </p>
@@ -41,7 +41,7 @@
       <p>
         If you come across an example that exposes some bug in our
         visualization please submit an issue on the
-        <a href="https://github.com/rustviz/rustviz2/issues">repo</a> with
+        <a href="https://github.com/rustviz/rustviz/issues">repo</a> with
         the example code and error message (if applicable).
       </p>
     </div>

--- a/playground/frontend/vite.config.ts
+++ b/playground/frontend/vite.config.ts
@@ -16,17 +16,21 @@ const channelMatch = rustToolchainContent.match(/channel\s*=\s*"([^"]+)"/);
 const rustVersion = channelMatch ? channelMatch[1] : 'unknown';
 
 // Two build modes:
-//   * default (`npm run build`): emits a same-origin SPA at base = '/'
-//     intended to be served by rv-serve from frontend/dist/.
-//   * pages (`npm run build:pages`, --mode pages): emits an SPA at
-//     base = '/playground/' intended to be served by GitHub Pages at
-//     https://rustviz.github.io/playground/, with API requests pointed
-//     at the Fly origin via VITE_API_BASE in .env.pages.
+//   * default (`npm run build`): emits a same-origin SPA intended to
+//     be served by the playground binary from frontend/dist/.
+//   * pages (`npm run build:pages`, --mode pages): emits an SPA
+//     intended to be served by GitHub Pages at
+//     https://rustviz.github.io/, with API requests pointed at the
+//     Fly origin via VITE_API_BASE in .env.pages.
 //
-// `npm run dev` proxies API + asset paths to a locally-running rv-serve
-// at :8080 so you can iterate without CORS plumbing.
+// Both modes use base = '/'. The Pages site is hosted at the org
+// root (rustviz/rustviz.github.io repo), not under a /playground
+// path prefix, so no asset rewriting is needed in either case.
+//
+// `npm run dev` proxies API + asset paths to a locally-running
+// playground at :8080 so you can iterate without CORS plumbing.
 export default defineConfig(({ mode }) => ({
-  base: mode === 'pages' ? '/playground/' : '/',
+  base: '/',
   plugins: [react()],
   define: {
     __RUST_VERSION__: JSON.stringify(rustVersion),


### PR DESCRIPTION
## Summary

Drop the \`/playground/\` URL prefix the SPA shipped under so the playground lives at the cleaner \`https://rustviz.github.io/\`. Once the receiving repo is renamed \`rustviz/playground\` → \`rustviz/rustviz.github.io\`, GitHub Pages serves it at the org root with no path prefix.

## Functional changes

| File | Diff |
|---|---|
| \`playground/frontend/vite.config.ts\` | \`base = mode === 'pages' ? '/playground/' : '/'\` → \`base = '/'\`. Both build modes now emit root-relative asset paths. Verified \`npm run build:pages\` produces \`<script src="/assets/...">\` (was \`/playground/assets/...\`). |
| \`.github/workflows/pages.yml\` | \`external_repository: rustviz/playground\` → \`rustviz/rustviz.github.io\`. The deploy-key auth flow doesn't reliably follow GitHub's repo-rename redirect, so pinning to the post-rename name avoids depending on it. |

## Doc / cosmetic sweeps

- \`https://rustviz.github.io/playground/\` → \`https://rustviz.github.io/\` in \`README.md\`, \`playground/README.md\`, \`playground/SECURITY.md\`, and the \`pages.yml\` comment block.
- \`rustviz/playground\` repo references updated to \`rustviz/rustviz.github.io\` in the same files.
- \`playground/frontend/index.html\` had two stale \`github.com/rustviz/rustviz2\` links from before the consolidation merge — flipped to \`rustviz/rustviz\` while in the area.

## Order of operations on merge

1. **Land this PR.** Workflow still targets \`rustviz/playground\` until then, which keeps deploys working via redirect (just with a deprecation warning).
2. **Rename \`rustviz/playground\` → \`rustviz/rustviz.github.io\`** on GitHub: Settings → rename.
3. Next push to \`main\` deploys to the renamed repo, which GitHub serves at \`rustviz.github.io/\` (org root).

If you do (2) before (1) lands, the existing workflow will still deploy via redirect — just with the deprecation warning. Cleanest is merge-first, rename-second.

## Test plan

- [x] \`npm run build:pages\` succeeds, \`dist/index.html\` references \`/assets/...\` (no \`/playground/\` prefix)
- [x] \`grep -rnE "rustviz\\.github\\.io/playground/|rustviz/playground[^/-]"\` comes back empty across docs, configs, and the index.html template
- [ ] Post-merge + post-rename: SPA loads at \`https://rustviz.github.io/\` with no 404s in network panel