### PR TITLE
test: verify cross-repo tutorial dispatch fires on plugin changes

### DIFF
--- a/rustviz2-plugin/src/lib.rs
+++ b/rustviz2-plugin/src/lib.rs
@@ -1,4 +1,5 @@
 // This file is based on the rust plugin example.
+// (Test edit to verify rustviz/tutorial cross-repo dispatch — PR #62.)
 #![feature(
   rustc_private,
   box_patterns,


### PR DESCRIPTION
Comment-only one-line edit to \`rustviz2-plugin/src/lib.rs\` to exercise the path filter from #62. Merging this should trigger:

1. The \`build\` job runs (full workspace build, no behaviour change)
2. \`dispatch-tutorial\` runs after build:
   - \`Detect plugin-affecting changes\` outputs \`affected=true\`
   - \`Trigger rustviz/tutorial deploy\` runs and dispatches the tutorial workflow
3. A new run appears in https://github.com/rustviz/tutorial/actions

After confirming, I'll open a follow-up PR to revert the comment.

(Confirmed Test A separately: the merge of #62 itself only touched \`.github/workflows/build.yml\` and the dispatch step skipped, as expected.)