### PR TITLE
Revert the dispatch-test comment from #63

### DIFF
--- a/rustviz2-plugin/src/lib.rs
+++ b/rustviz2-plugin/src/lib.rs
@@ -1,5 +1,4 @@
 // This file is based on the rust plugin example.
-// (Test edit to verify rustviz/tutorial cross-repo dispatch — PR #62.)
 #![feature(
   rustc_private,
   box_patterns,


### PR DESCRIPTION
Removes the placeholder `(Test edit to verify rustviz/tutorial cross-repo dispatch — PR #62.)` comment that #63 added to `rustviz2-plugin/src/lib.rs`. The dispatch was confirmed working: rustviz/rustviz run 25403622398 fired `Trigger rustviz/tutorial deploy` after `Detect plugin-affecting changes` flagged `affected=true`, and rustviz/tutorial got a fresh `workflow_dispatch` run (id 25403739139) that completed successfully.

Merging this PR will (correctly) trigger another tutorial dispatch, since it touches `rustviz2-plugin/`. That's expected — the cross-repo handshake is meant to fire on any plugin-side change.