### PR TITLE
plugin: `// rustviz: skip` and `// rustviz: hide` markers

### DIFF
--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -16,18 +16,13 @@ const API_BASE: string = import.meta.env.VITE_API_BASE ?? '';
 
 declare function helpers(param: string): void;
 
-const defaultExample: string = `
-fn main() {
-    let mut x = 7;
-    let mut z = 6;
-    let mut a = &mut x;
-    let mut c = &mut z;
-    let mut b = &mut a;
-    b = &mut c;
-    println!("x {}", *a);
-    println!("z {}", **b);
-}
-`.trim();
+// Seed the editor with the first dropdown example (Motivation →
+// "Hands-on tutorial") so first-time visitors land on a snippet that
+// actually exercises ownership, borrowing, and the
+// `// rustviz: skip` / `// rustviz: hide` markers — instead of an
+// abstract `let mut x = 7; let mut a = &mut x; …` chain that doesn't
+// motivate anything. Single source of truth lives in examples.ts.
+const defaultExample: string = exampleGroups[0].examples[0].code;
 
 class Editor {
   private view: EditorView;

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -92,8 +92,14 @@ const ExamplePicker = ({ onSelect }: ExamplePickerProps) => {
   return (
     <div className="example-picker">
       <label htmlFor="example-select">Examples:</label>
-      <select id="example-select" defaultValue="" onChange={handleChange}>
-        <option value="">— pick a preloaded example —</option>
+      {/* Default to "0:0" — Motivation → "Hands-on tutorial" — to
+          match the editor's seed snippet (defaultExample). React's
+          `defaultValue` only sets initial state; it doesn't fire
+          onChange, so we don't double-load the same code. The
+          placeholder option is gone because the dropdown is never
+          empty — the editor always has a selected snippet from the
+          start. */}
+      <select id="example-select" defaultValue="0:0" onChange={handleChange}>
         {exampleGroups.map((group, gIdx) => (
           <optgroup key={group.chapter} label={group.chapter}>
             {group.examples.map((ex, eIdx) => (

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -52,6 +52,7 @@ export const exampleGroups: ExampleGroup[] = [
         name: "Hands-on tutorial",
         code: `fn main() {
     let mut s = String::from("hello");
+    let mut q = String::from("skipped"); // rustviz: skip
 
     let r1 = &s;
     let r2 = &s;
@@ -61,9 +62,8 @@ export const exampleGroups: ExampleGroup[] = [
     clear_string(r3);
 }
 
-fn compare_strings(_a: &String, _b: &String) -> bool { // rustviz: hide
-    // body elided
-    true
+fn compare_strings(a: &String, b: &String) -> bool { // rustviz: hide
+    *a == *b
 }
 
 fn clear_string(_s: &mut String) { // rustviz: hide

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -61,12 +61,12 @@ export const exampleGroups: ExampleGroup[] = [
     clear_string(r3);
 }
 
-fn compare_strings(_a: &String, _b: &String) -> bool {
+fn compare_strings(_a: &String, _b: &String) -> bool { // rustviz: hide
     // body elided
     true
 }
 
-fn clear_string(_s: &mut String) {
+fn clear_string(_s: &mut String) { // rustviz: hide
     // body elided
 }`,
       },

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -119,7 +119,22 @@ pub struct ExprVisitor<'a, 'tcx:'a> {
 
 
   pub inside_branch: bool,
-  pub fn_ret: bool
+  pub fn_ret: bool,
+
+  // Source lines (1-indexed) carrying a `// rustviz: skip` marker.
+  // Used by visit_local to suppress events for marked `let`s and by
+  // plugin.rs to bypass body traversal of marked fns. Owned by the
+  // plugin's RV1Helper; visitors get a borrow for the duration of
+  // each fn-body walk.
+  pub skip_lines: &'a std::collections::HashSet<usize>,
+
+  // Names of RAPs registered for `let` bindings that landed on a
+  // skip line. We still register the RAP so any non-skipped use of
+  // the variable elsewhere can resolve, but every event whose source
+  // or destination references one of these names is dropped before
+  // it reaches the renderer — which is what gives the variable no
+  // timeline column.
+  pub skip_raps: std::collections::HashSet<String>,
 }
 
 impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
@@ -280,7 +295,59 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     }
   }
 
+  /// True iff `event` references a RAP whose name is in `skip_raps`.
+  /// Covers every variant of ExternalEvent — `ResourceAccessPoint_extract`
+  /// returns Anonymous for `GoOutOfScope` / `OwnerDropAtReassign` /
+  /// `InitRefParam` / `RefDie`, so we match them explicitly here
+  /// instead of relying on it.
+  fn event_touches_skipped(&self, event: &ExternalEvent) -> bool {
+    let touches_ty = |r: &ResourceTy| -> bool {
+      match r {
+        ResourceTy::Value(rap) | ResourceTy::Deref(rap) => {
+          self.skip_raps.contains(rap.name())
+        }
+        _ => false,
+      }
+    };
+    match event {
+      ExternalEvent::Bind { from, to, .. }
+      | ExternalEvent::Copy { from, to, .. }
+      | ExternalEvent::Move { from, to, .. }
+      | ExternalEvent::StaticBorrow { from, to, .. }
+      | ExternalEvent::StaticDie { from, to, .. }
+      | ExternalEvent::MutableBorrow { from, to, .. }
+      | ExternalEvent::MutableDie { from, to, .. }
+      | ExternalEvent::RefDie { from, to, .. }
+      | ExternalEvent::PassByStaticReference { from, to, .. }
+      | ExternalEvent::PassByMutableReference { from, to, .. } => {
+        touches_ty(from) || touches_ty(to)
+      }
+      ExternalEvent::GoOutOfScope { ro, .. }
+      | ExternalEvent::OwnerDropAtReassign { ro, .. } => {
+        self.skip_raps.contains(ro.name())
+      }
+      ExternalEvent::InitRefParam { param, .. } => {
+        self.skip_raps.contains(param.name())
+      }
+      // Branch events bundle child events; we don't recurse into
+      // them here. A skipped variable that only appears inside a
+      // branch could still leak through — fix when the need arises.
+      ExternalEvent::Branch { .. } => false,
+    }
+  }
+
   pub fn add_external_event(&mut self, line_num: usize, event: ExternalEvent) {
+    // Drop events whose source or destination is a `// rustviz: skip`-
+    // marked variable. The marked RAP still exists (so non-skipped
+    // code that references it doesn't crash on lookup), but every
+    // arrow that touches it disappears — no init Bind, no later
+    // Move/Copy/Borrow, no end-of-scope return — and because the
+    // renderer only materialises a timeline when a hash sees its
+    // first event, a RAP with zero events never gets a column.
+    if self.event_touches_skipped(&event) {
+      return;
+    }
+
     self.preprocessed_events.push((line_num, event.clone()));
     let resourceaccesspoint = ResourceAccessPoint_extract(&event);
     match (resourceaccesspoint.0, resourceaccesspoint.1, &event) {

--- a/rustviz-plugin/src/plugin.rs
+++ b/rustviz-plugin/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{HashMap, BTreeMap, HashSet};
 use simplelog::*;
 use std::fs::OpenOptions;
 use log::error;
@@ -75,6 +75,11 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
     }
   }
   let a_map: BTreeMap<usize, String> = line_map.clone();
+  // Lines carrying a `// rustviz: skip` marker. Borrowed by every
+  // per-fn ExprVisitor so visit_local can short-circuit on marked
+  // `let`s, and consulted directly here to bypass body traversal of
+  // marked fns.
+  let skip_lines: HashSet<usize> = testing_helper.skip_lines.clone();
   let mut a_line_map: BTreeMap<usize, Vec<String>> = BTreeMap::new();
   let mut owner_to_hash: HashMap<String, usize> = HashMap::new();
   let mut pre_events: Vec<(usize, ExternalEvent)> = Vec::new();
@@ -118,6 +123,15 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
             let output = matches!(fn_sig.decl.output, FnRetTy::Return(_));
             let fn_start_line = tcx.sess.source_map().lookup_char_pos(fn_sig.span.lo()).line;
 
+            // Marker on the fn signature line — leave the body
+            // un-traced. Call sites in non-skipped fns will still
+            // emit events whose endpoint is the Function RAP for
+            // this fn (created by `add_fn` when the call is
+            // visited), so moves into / out of it still appear.
+            if skip_lines.contains(&fn_start_line) {
+              continue;
+            }
+
             let mut visitor = ExprVisitor {
               tcx,
               mir_body: body,
@@ -137,6 +151,8 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
               unique_id: &mut ids,
               inside_branch: false,
               fn_ret: output,
+              skip_lines: &skip_lines,
+              skip_raps: HashSet::new(),
             };
             visitor.visit_body(hir_body);
             visitor.print_lifetimes();
@@ -169,6 +185,15 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
         };
         let fn_start_line = tcx.sess.source_map().lookup_char_pos(fn_sig.span.lo()).line;
 
+        // Marker on the fn signature line — leave the body
+        // un-traced. Call sites in non-skipped fns will still emit
+        // events whose endpoint is the Function RAP for this fn
+        // (created by `add_fn` when the call is visited), so moves
+        // into / out of it still appear.
+        if skip_lines.contains(&fn_start_line) {
+          continue;
+        }
+
         let mut visitor = ExprVisitor {
           tcx,
           mir_body: body,
@@ -187,7 +212,9 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
           id_map: & mut owner_to_hash,
           unique_id: & mut ids,
           inside_branch: false,
-          fn_ret: output
+          fn_ret: output,
+          skip_lines: &skip_lines,
+          skip_raps: HashSet::new(),
         };
         visitor.visit_body(hir_body);
         visitor.print_lifetimes();

--- a/rustviz-plugin/src/plugin.rs
+++ b/rustviz-plugin/src/plugin.rs
@@ -75,11 +75,18 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
     }
   }
   let a_map: BTreeMap<usize, String> = line_map.clone();
-  // Lines carrying a `// rustviz: skip` marker. Borrowed by every
-  // per-fn ExprVisitor so visit_local can short-circuit on marked
-  // `let`s, and consulted directly here to bypass body traversal of
-  // marked fns.
+  // Lines carrying a `// rustviz: skip` or `// rustviz: hide`
+  // marker. Both kinds bypass body traversal here and visit_local
+  // suppression in the per-fn visitor; the `hide` subset is also
+  // consulted below to compute `hidden_source_lines`, which the
+  // renderer uses to drop the entire fn from the displayed source.
   let skip_lines: HashSet<usize> = testing_helper.skip_lines.clone();
+  let hide_marker_lines: HashSet<usize> = testing_helper.hide_lines.clone();
+  // Filled below with every source line that belongs to a `hide`-
+  // marked fn (signature through closing brace, plus the immediately
+  // preceding blank line if any — keeps the surrounding spacing
+  // tidy when fns at the end of the file are removed).
+  let mut hidden_source_lines: HashSet<usize> = HashSet::new();
   let mut a_line_map: BTreeMap<usize, Vec<String>> = BTreeMap::new();
   let mut owner_to_hash: HashMap<String, usize> = HashMap::new();
   let mut pre_events: Vec<(usize, ExternalEvent)> = Vec::new();
@@ -129,6 +136,19 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
             // this fn (created by `add_fn` when the call is
             // visited), so moves into / out of it still appear.
             if skip_lines.contains(&fn_start_line) {
+              if hide_marker_lines.contains(&fn_start_line) {
+                let body_end_line = tcx.sess.source_map()
+                  .lookup_char_pos(hir_body.value.span.hi()).line;
+                for l in fn_start_line..=body_end_line {
+                  hidden_source_lines.insert(l);
+                }
+                if fn_start_line >= 2
+                  && a_map.get(&(fn_start_line - 1))
+                    .map(|s| s.trim().is_empty()).unwrap_or(false)
+                {
+                  hidden_source_lines.insert(fn_start_line - 1);
+                }
+              }
               continue;
             }
 
@@ -191,6 +211,19 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
         // (created by `add_fn` when the call is visited), so moves
         // into / out of it still appear.
         if skip_lines.contains(&fn_start_line) {
+          if hide_marker_lines.contains(&fn_start_line) {
+            let body_end_line = tcx.sess.source_map()
+              .lookup_char_pos(hir_body.value.span.hi()).line;
+            for l in fn_start_line..=body_end_line {
+              hidden_source_lines.insert(l);
+            }
+            if fn_start_line >= 2
+              && a_map.get(&(fn_start_line - 1))
+                .map(|s| s.trim().is_empty()).unwrap_or(false)
+            {
+              hidden_source_lines.insert(fn_start_line - 1);
+            }
+          }
           continue;
         }
 
@@ -272,7 +305,7 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
     .collect();
 
   // Pass information to svg-generator
-  match testing_helper.generate_vis(line_map2, pre_events, & mut a_line_map, rap_map.len() + 1, fn_start_lines, args.write_to_cwd) {
+  match testing_helper.generate_vis(line_map2, pre_events, & mut a_line_map, rap_map.len() + 1, fn_start_lines, hidden_source_lines, args.write_to_cwd) {
     Ok(_) => {}
     Err(e) => {
       eprintln!("{}", e);

--- a/rustviz-plugin/src/rustviz_library/rv.rs
+++ b/rustviz-plugin/src/rustviz_library/rv.rs
@@ -3,7 +3,7 @@ use crate::svg_generator::{
   svg_frontend::svg_generation
 };
 use anyhow::Result;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub struct Rustviz{
   code_panel_svg : String,
@@ -18,6 +18,7 @@ impl Rustviz {
     ev_map: BTreeMap<usize, Vec<ExternalEvent>>,
     num_raps: usize,
     fn_start_lines: HashMap<u64, usize>,
+    hidden_source_lines: HashSet<usize>,
   ) -> Result<Rustviz>{
     /* ******************************************
             --- Build VisualizationData ---
@@ -33,7 +34,7 @@ impl Rustviz {
     /* ******************************************
             --- Render SVG images ---
     ****************************************** */
-    let res = svg_generation::render_svg(a_src_str, src_str, &mut vd);
+    let res = svg_generation::render_svg(a_src_str, src_str, &mut vd, &hidden_source_lines);
     Ok(Rustviz {
       code_panel_svg : res.0,
       timeline_panel_svg: res.1

--- a/rustviz-plugin/src/svg_generator/svg_frontend/svg_generation.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/svg_generation.rs
@@ -160,9 +160,81 @@ pub fn render_svg(
     annotated_src_str: &str,
     source_rs_str: &str,
     visualization_data: &mut VisualizationData,
+    hide_lines: &HashSet<usize>,
 ) -> (String, String){
     info!("preprocessed events : {:#?}", visualization_data.preprocess_external_events);
     info!("ev_line_map: {:#?}", visualization_data.event_line_map);
+
+    // First, drop any source lines that the plugin marked with the
+    // `// rustviz: hide` form (the whole fn body, plus its leading
+    // blank line) and shift every line-keyed structure down to
+    // close the gap. Done before the fn-blank-line padding pass
+    // below so that pass operates on the post-hide layout — `prev`
+    // checks for fn neighbours, etc., reflect what the user will
+    // actually see.
+    let (post_hide_a, post_hide_s) = if hide_lines.is_empty() {
+        (annotated_src_str.to_string(), source_rs_str.to_string())
+    } else {
+        let mut sorted: Vec<usize> = hide_lines.iter().copied().collect();
+        sorted.sort();
+        let removed_set: HashSet<usize> = hide_lines.iter().copied().collect();
+        // Number of hidden lines strictly less than `l`.
+        let removed_before = move |l: usize| -> usize {
+            sorted.iter().take_while(|&&r| r < l).count()
+        };
+        let shift = |l: usize| -> usize { l - removed_before(l) };
+
+        let pruned_a: String = annotated_src_str
+            .lines()
+            .enumerate()
+            .filter(|(i, _)| !removed_set.contains(&(i + 1)))
+            .map(|(_, l)| l)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let pruned_s: String = source_rs_str
+            .lines()
+            .enumerate()
+            .filter(|(i, _)| !removed_set.contains(&(i + 1)))
+            .map(|(_, l)| l)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Drop fn_start_lines pointing into a hidden range (the fn
+        // is gone), shift the rest.
+        visualization_data
+            .fn_start_lines
+            .retain(|_, l| !removed_set.contains(l));
+        for v in visualization_data.fn_start_lines.values_mut() {
+            *v = shift(*v);
+        }
+
+        // Drop events on hidden lines (events inside hidden fn
+        // bodies); shift line numbers on the rest. Branch events
+        // recurse via `shift_event_lines` and use the same closure.
+        visualization_data
+            .preprocess_external_events
+            .retain(|(l, _)| !removed_set.contains(l));
+        for (l, ev) in visualization_data.preprocess_external_events.iter_mut() {
+            *l = shift(*l);
+            shift_event_lines(ev, &shift);
+        }
+
+        let shifted_elm: BTreeMap<usize, Vec<ExternalEvent>> = visualization_data
+            .event_line_map
+            .iter()
+            .filter(|(k, _)| !removed_set.contains(k))
+            .map(|(k, v)| {
+                let mut v = v.clone();
+                for sub in v.iter_mut() { shift_event_lines(sub, &shift); }
+                (shift(*k), v)
+            })
+            .collect();
+        visualization_data.event_line_map = shifted_elm;
+
+        (pruned_a, pruned_s)
+    };
+    let annotated_src_str: &str = post_hide_a.as_str();
+    let source_rs_str: &str = post_hide_s.as_str();
 
     // Force a blank source line before each non-first fn that doesn't
     // already have one. Without this, per-fn labels (which are placed

--- a/rustviz-plugin/src/utils.rs
+++ b/rustviz-plugin/src/utils.rs
@@ -10,19 +10,30 @@ use std::fs::File;
 
 use crate::expr_visitor::RapData;
 
-/// Recognise the user-facing `// rustviz: skip` marker. We match the
-/// trimmed body of a `//` line comment against `rustviz: skip` (with
-/// the colon's surrounding whitespace optional) so trailing prose
+/// Two flavours of marker we recognise on a `//` line comment.
+/// `Skip` keeps the source visible but stops tracing the marked item;
+/// `Hide` (fn-only in semantics) additionally removes the entire item
+/// from the rendered code panel.
+#[derive(Clone, Copy, Debug)]
+pub enum SkipKind {
+    Skip,
+    Hide,
+}
+
+/// Recognise `// rustviz: skip` and `// rustviz: hide`. Match the
+/// trimmed body of a `//` line comment against one of those keywords
+/// (the colon's surrounding whitespace is optional) so trailing prose
 /// (`// rustviz: skip — see issue #42`) still counts.
-fn line_has_skip_marker(line: &str) -> Option<usize> {
+fn line_skip_marker(line: &str) -> Option<(usize, SkipKind)> {
     let comment_start = line.find("//")?;
     let body = line[comment_start + 2..].trim_start();
     let mut rest = body.strip_prefix("rustviz")?.trim_start();
     rest = rest.strip_prefix(':')?.trim_start();
-    if rest.starts_with("skip") {
-        let after = &rest[4..];
-        if after.is_empty() || after.starts_with(|c: char| c.is_whitespace()) {
-            return Some(comment_start);
+    for &(kw, kind) in &[("skip", SkipKind::Skip), ("hide", SkipKind::Hide)] {
+        if let Some(after) = rest.strip_prefix(kw) {
+            if after.is_empty() || after.starts_with(|c: char| c.is_whitespace()) {
+                return Some((comment_start, kind));
+            }
         }
     }
     None
@@ -124,11 +135,15 @@ pub fn annotate_enum_variant(
 pub struct RV1Helper {
   source_str: String,
   source_path: PathBuf,
-  /// Lines (1-indexed) whose source carries a `// rustviz: skip`
-  /// marker. The marker has been stripped from `source_str` and the
-  /// returned line map already, but the plugin still needs the line
-  /// numbers to suppress events / fn-body traversal at those sites.
+  /// Lines (1-indexed) whose source carries a `// rustviz: skip` or
+  /// `// rustviz: hide` marker. Both kinds suppress the marked
+  /// item's body trace; `hide` additionally tells the renderer to
+  /// remove the whole item from the displayed code panel. The
+  /// markers themselves have been stripped from `source_str` and
+  /// the returned line map already.
   pub skip_lines: HashSet<usize>,
+  /// Subset of `skip_lines` carrying the `hide` keyword (fn-only).
+  pub hide_lines: HashSet<usize>,
 }
 
 impl RV1Helper {
@@ -137,6 +152,7 @@ impl RV1Helper {
       source_str: String::new(),
       source_path: PathBuf::new(),
       skip_lines: HashSet::new(),
+      hide_lines: HashSet::new(),
     }
   }
   pub fn initialize_line_map(&mut self) -> Result<BTreeMap<usize, String>> {
@@ -156,9 +172,14 @@ impl RV1Helper {
         // still index correctly.
         let mut res_str = String::with_capacity(contents.len());
         let mut skip_lines: HashSet<usize> = HashSet::new();
+        let mut hide_lines: HashSet<usize> = HashSet::new();
         for (i, line) in contents.lines().enumerate() {
-          if let Some(idx) = line_has_skip_marker(line) {
-            skip_lines.insert(i + 1);
+          if let Some((idx, kind)) = line_skip_marker(line) {
+            let line_num = i + 1;
+            skip_lines.insert(line_num);
+            if matches!(kind, SkipKind::Hide) {
+              hide_lines.insert(line_num);
+            }
             res_str.push_str(line[..idx].trim_end());
           } else {
             res_str.push_str(line);
@@ -168,6 +189,7 @@ impl RV1Helper {
 
         self.source_str = res_str.clone();
         self.skip_lines = skip_lines;
+        self.hide_lines = hide_lines;
 
         let lines: Vec<&str> = res_str.lines().collect();
         for (line_num, line_content) in lines.iter().enumerate() {
@@ -190,6 +212,7 @@ impl RV1Helper {
     a_map: & mut BTreeMap<usize, Vec<String>>,
     num_raps: usize,
     fn_start_lines: HashMap<u64, usize>,
+    hidden_source_lines: HashSet<usize>,
     write_to_cwd: bool) -> Result<()> {
     let mut keys_to_remove: Vec<usize> = Vec::new();
     for (k, v) in line_map.iter() {
@@ -207,7 +230,7 @@ impl RV1Helper {
 
 
     // send stuff to RV1
-    let rv = Rustviz::new(&annotated_source_str, &self.source_str, p_events, line_map, num_raps, fn_start_lines)?;
+    let rv = Rustviz::new(&annotated_source_str, &self.source_str, p_events, line_map, num_raps, fn_start_lines, hidden_source_lines)?;
 
     if write_to_cwd { // write the SVG files
       self.source_path.pop(); // just write to inside cwd

--- a/rustviz-plugin/src/utils.rs
+++ b/rustviz-plugin/src/utils.rs
@@ -2,13 +2,31 @@ use anyhow::{Result, anyhow};
 use log::info;
 use rustc_middle::ty::TyCtxt;
 use crate::svg_generator::data::ExternalEvent;
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{HashMap, BTreeMap, HashSet};
 use std::{path::PathBuf, fs};
 use std::env::current_dir;
 use crate::rustviz_library::rv::Rustviz;
 use std::fs::File;
 
 use crate::expr_visitor::RapData;
+
+/// Recognise the user-facing `// rustviz: skip` marker. We match the
+/// trimmed body of a `//` line comment against `rustviz: skip` (with
+/// the colon's surrounding whitespace optional) so trailing prose
+/// (`// rustviz: skip — see issue #42`) still counts.
+fn line_has_skip_marker(line: &str) -> Option<usize> {
+    let comment_start = line.find("//")?;
+    let body = line[comment_start + 2..].trim_start();
+    let mut rest = body.strip_prefix("rustviz")?.trim_start();
+    rest = rest.strip_prefix(':')?.trim_start();
+    if rest.starts_with("skip") {
+        let after = &rest[4..];
+        if after.is_empty() || after.starts_with(|c: char| c.is_whitespace()) {
+            return Some(comment_start);
+        }
+    }
+    None
+}
 
 // toplevel annotation helpers
 pub fn annotate_struct_field (
@@ -105,37 +123,58 @@ pub fn annotate_enum_variant(
 
 pub struct RV1Helper {
   source_str: String,
-  source_path: PathBuf
+  source_path: PathBuf,
+  /// Lines (1-indexed) whose source carries a `// rustviz: skip`
+  /// marker. The marker has been stripped from `source_str` and the
+  /// returned line map already, but the plugin still needs the line
+  /// numbers to suppress events / fn-body traversal at those sites.
+  pub skip_lines: HashSet<usize>,
 }
 
 impl RV1Helper {
   pub fn new () -> RV1Helper {
-    RV1Helper { source_str: String::new(), source_path: PathBuf::new() }
+    RV1Helper {
+      source_str: String::new(),
+      source_path: PathBuf::new(),
+      skip_lines: HashSet::new(),
+    }
   }
   pub fn initialize_line_map(&mut self) -> Result<BTreeMap<usize, String>> {
     self.source_path = current_dir()?;
     self.source_path = self.source_path.join("src/lib.rs"); // could change this to whatever
     info!("source path {:#?}", self.source_path);
-  
+
     let mut line_map: BTreeMap<usize, String> = BTreeMap::new();
-  
-  
+
     match fs::read_to_string(self.source_path.clone()) {
       Ok(contents) => {
-        self.source_str = contents.clone(); // allows for comments in source string
-        let mut res_str: String = String::new();
-        // remove all comments from main string
-        for line in contents.lines() {
-          res_str.push_str(line);
+        // Detect the `// rustviz: skip` marker per line and strip the
+        // comment from the displayed source. The line numbering is
+        // preserved (we keep blank lines where the marker was the
+        // only thing on the line) so spans coming back from rustc —
+        // which sees the original file with the comments intact —
+        // still index correctly.
+        let mut res_str = String::with_capacity(contents.len());
+        let mut skip_lines: HashSet<usize> = HashSet::new();
+        for (i, line) in contents.lines().enumerate() {
+          if let Some(idx) = line_has_skip_marker(line) {
+            skip_lines.insert(i + 1);
+            res_str.push_str(line[..idx].trim_end());
+          } else {
+            res_str.push_str(line);
+          }
           res_str.push('\n');
-  
         }
+
+        self.source_str = res_str.clone();
+        self.skip_lines = skip_lines;
+
         let lines: Vec<&str> = res_str.lines().collect();
         for (line_num, line_content) in lines.iter().enumerate() {
           line_map.insert(line_num + 1, line_content.to_string());
         }
       }
-  
+
       Err(e) => {
         return Err(anyhow!("Error with reading source file : {}", e));
       }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -839,6 +839,8 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
     if local.span.from_expansion() {
       return;
     }
+    let local_line = self.tcx.sess.source_map().lookup_char_pos(local.span.lo()).line;
+    let is_skipped = self.skip_lines.contains(&local_line);
     match local.pat.kind {
       PatKind::Binding(binding_annotation, ann_hirid, ident, _op_pat) => {
         let lhs_var:String = ident.to_string();
@@ -854,24 +856,37 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           }
         } else {
           match is_copyable {
-            true => Evt::Copy, 
+            true => Evt::Copy,
             false => Evt::Move
           }
         };
         match local.init { // init refers to RHS of let
           Some(expr) => {
-            self.visit_expr(expr);
-            // Figure out what LHS is and add it to list of RAPs
-            self.define_lhs(lhs_var.clone(), bool_of_mut(binding_annotation.1), expr, lhs_ty);
-            self.match_rhs(ResourceTy::Value(self.raps.get(&lhs_var).unwrap().rap.to_owned()), expr, e);
+            if is_skipped {
+              // Marker on this `let` — register the LHS RAP so any
+              // later mention of the variable still resolves (and
+              // get the source-line annotation) but mark it in
+              // skip_raps so add_external_event drops every event
+              // that touches it. We deliberately don't visit the
+              // RHS so events emitted on its behalf (e.g. a
+              // String::from move into the var) also disappear —
+              // those touch the skipped LHS too.
+              self.define_lhs(lhs_var.clone(), bool_of_mut(binding_annotation.1), expr, lhs_ty);
+              self.skip_raps.insert(lhs_var);
+            } else {
+              self.visit_expr(expr);
+              // Figure out what LHS is and add it to list of RAPs
+              self.define_lhs(lhs_var.clone(), bool_of_mut(binding_annotation.1), expr, lhs_ty);
+              self.match_rhs(ResourceTy::Value(self.raps.get(&lhs_var).unwrap().rap.to_owned()), expr, e);
+            }
           }
            _ => {} // in the case of a declaration ex: let a; nothing happens, currently unhandled logic
         }
       }
       _ => { warn!("unrecognized local pattern") }
     }
-    
-    
+
+
     if let Some(els) = local.els {
       self.visit_block(els);
     }


### PR DESCRIPTION
## Summary
Two new comment markers the user can place on `let` and fn signature lines to keep an item out of the rendered visualization, plus a refresh of the playground's first-load experience that uses both markers to demonstrate themselves.

```rust
fn main() {
    let mut s = String::from("hello");
    let mut q = String::from("skipped"); // rustviz: skip

    let r1 = &s;
    let r2 = &s;
    assert!(compare_strings(r1, r2));

    let r3 = &mut s;
    clear_string(r3);
}

fn compare_strings(a: &String, b: &String) -> bool { // rustviz: hide
    *a == *b
}

fn clear_string(_s: &mut String) { // rustviz: hide
    // body elided
}
```

Renders as 11 lines: `main`'s body without the `q` comment, the helper fns gone, but the call-site fn-name colouring and parameter-pass arrows still drawn.

## The two markers
- **`// rustviz: skip`** — works on a `let` or fn signature line. The item stays in the source but the plugin stops tracing it.
  - On a `let`: the LHS RAP is registered (so non-skipped uses still resolve), but the RHS is not visited and every event whose endpoint references the marked variable is dropped before reaching the renderer. With zero events the renderer never materialises a timeline column for that hash.
  - On a fn signature: body traversal is skipped entirely. Function RAPs are created lazily at call sites (`add_fn` in `match_arg`), so moves and borrows passed in still draw arrows from the caller's variable to the fn-icon dot. The fn body remains visible in the code panel — only the *trace* is suppressed.
  - Marker comment is stripped from the displayed source so the line renders without the trailing `// rustviz: skip` text. Line numbering preserved (we keep the line, just blank the comment) so rustc's span-based indexing into the original file still resolves.

- **`// rustviz: hide`** — fn-only. Same body-skip behaviour as above, plus the fn's entire line range (signature through closing brace, plus the immediately-preceding blank line) is dropped from the rendered code panel and every line-keyed structure downstream is shifted down by the count of preceding hidden lines. So the rendered numbering goes 1, 2, 3, … with no gaps.

Recognised forms: `// rustviz: skip` / `// rustviz:skip` and `// rustviz: hide` / `// rustviz:hide`. Trailing prose allowed (`// rustviz: hide — see issue #42`).

## Pipeline
1. `RV1Helper::initialize_line_map` recognises both keywords on each line, strips the comment, and records `skip_lines` (covers both kinds) and a `hide_lines` subset.
2. `plugin.rs` consults `skip_lines` to bypass body traversal for marked fns; for `hide`-marked fns it expands the marker line into the full line range of the fn item via `hir_body.value.span.hi()` (the closing brace) and accumulates `hidden_source_lines`.
3. `expr_visitor` carries a `&HashSet<usize>` of skip lines and a `skip_raps: HashSet<String>`. `visit_local` short-circuits on marked `let`s; `add_external_event` filters every event whose endpoint references a skipped RAP (covers `Bind` / `Move` / `Copy` / `Borrow` / `Die` / `RefDie` / `Pass*Ref` / `GoOutOfScope` / `OwnerDropAtReassign` / `InitRefParam`).
4. `Rustviz::new` and `render_svg` take `hidden_source_lines` and run a hide pre-pass before everything else: drop those lines from both source strings, then shift `fn_start_lines`, every event's line number, and `event_line_map` keys down. Branch sub-events recurse via the existing `shift_event_lines` helper.

## Playground refresh
Bundled here because both touch the same example surface and want to demo themselves on first load:
- Default editor snippet is now Motivation → "Hands-on tutorial" (pulled from `exampleGroups[0].examples[0].code` so the two stay in sync) instead of an abstract `let mut x = 7; let mut a = &mut x; …` chain that doesn't motivate anything.
- That example now demonstrates everything: a normal `let`, a `// rustviz: skip` on `q`, and `// rustviz: hide` on the two helpers. `compare_strings` gets a real `*a == *b` body (params un-underscored) so removing the `hide` marker reveals real code.
- The example dropdown defaults to "Hands-on tutorial" instead of the "— pick a preloaded example —" placeholder, since the editor is never actually empty on load. React's `defaultValue` doesn't fire onChange, so the editor isn't re-loaded with the same code on mount.

## Scope / known limitations
- `Branch` events bundle child events; the visitor's filter doesn't recurse into them. A skipped variable that only appears inside an `if`/`match` branch could still leak through. Fix when the need arises.
- `let y = x;` where `x` is skipped: the Move from `x` to `y` is dropped (touches a skipped RAP), so `y` ends up with no acquire event but its scope-end event still fires. Slightly odd visually, but consistent with the documented "events touching the skipped variable disappear" rule.
- `// rustviz: hide` on a `let` is treated the same as `skip` (the whole-fn semantics don't translate).

## Test plan
- [x] `cargo build -p rustviz-plugin` clean
- [x] Smoke test: skipped `let` has no timeline column, marker stripped, neighbours unaffected
- [x] Smoke test: skipped fn body not traversed, call-site `Move arg → fn` arrow still drawn
- [x] Smoke test: hidden fn fully removed from code panel, line numbering renumbers without gaps, call site preserved
- [x] Smoke test: new default snippet renders 11 rows with the right markers stripped/hidden
- [x] Dropdown reads "Hands-on tutorial" on first load (matches the seeded editor)
- [ ] CI green
- [ ] Pages preview shows the new behaviour after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)