### PR TITLE
playground: redesign UI as titlebar + resizable 3-panel layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,26 @@ RustViz 2 is a research tool. It supports a meaningful subset of Rust but
 not all of it. Currently unsupported (or known to misbehave):
 
 - For-loops
-- Conditional `let` bindings
-- Borrows that occur inside conditionals
-- Lifetime annotations beyond the simple cases the
-  [`Excerpt<'a>`](https://github.com/rustviz/tutorial/blob/master/src/structs.md)
-  tutorial example covers
-- Some borrows over struct members
+- Bindings or borrows inside an `if` or `match` branch body (the
+  conditional itself can return a value into a `let`, but tracking
+  events inside the branch isn't supported)
+- Closures — captures (whether by reference or by `move`) aren't
+  drawn as arrows, so the visualization silently omits the capture
+  event
+- Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
+  objects (`Box<dyn T>`)
+- Indexing or slicing collections like `Vec` (string slices like
+  `&s[..]` on a `String` do work)
+- The `?` operator (and other desugaring-heavy forms like
+  `async`/`await`)
+- Some struct field access patterns: chaining a method onto a field
+  (`r.field.method()`), nested field access (`r.a.b`), and field
+  access through a reference (`(&r).field`). Plain `r.field` and
+  `&r.field` work.
+- Inherent methods (`impl S { fn ... }`) are fragile — the
+  Rectangle/area pattern (`fn area(&self) -> u32 { self.width *
+  self.height }`) works, but minor variants (e.g. a one-field
+  `fn get(&self) -> i32 { self.n }`) crash.
 
 The plugin has a TODO list with more detail in
 [`rustviz-plugin/README.md`](rustviz-plugin/README.md).
@@ -231,6 +245,19 @@ them in dependency order (`rustviz-plugin` and `rustviz-lib` first,
 then `rustviz-cli` and `mdbook-rustviz`). A `CRATES_IO_TOKEN` repo
 secret with `publish-new` + `publish-update` scope on those four crate
 names is required.
+
+## Credits
+
+RustViz is a project of the
+[Future of Programming Lab](https://web.eecs.umich.edu/~comar/) at the
+University of Michigan. The plugin is built on
+[`rustc_plugin`](https://github.com/cognitive-engineering-lab/rustc_plugin) /
+[`rustc_utils`](https://github.com/cognitive-engineering-lab/rustc_plugin)
+by [Will Crichton](https://willcrichton.net/), and ports several
+MIR / borrow-fact helpers from
+[Aquascope](https://github.com/cognitive-engineering-lab/aquascope)
+(another visualization tool for Rust) by
+[Gavin Gray](https://gavinleroy.com/).
 
 ## License
 

--- a/playground/frontend/index.html
+++ b/playground/frontend/index.html
@@ -3,56 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>RustViz playground</title>
+    <title>RustViz Playground</title>
     <link rel="icon" href="data:;base64,=" />
     <script src="ex-assets/helpers.js"></script>
   </head>
   <body>
-    <h1>RustViz Playground</h1>
-    <p>
-      Welcome! <a href="https://github.com/rustviz/rustviz/">RustViz</a>
-      is a tool to visualize an approximation of the compile-time reasoning
-      of <a href="https://www.rust-lang.org/">Rust's</a> Borrow Checker.
-    </p>
-
-    <p>
-      You can try out RustViz by writing a Rust program in the editor below,
-      then clicking the "Generate Visualization" button to convert your
-      example code into an SVG diagram.
-    </p>
-
-    <div>
-      <p>
-        Please note: RustViz is a research tool, so it doesn't work for
-        some Rust programs. These are a few common Rust features that
-        remain unimplemented by our plugin and as a result may result in
-        undefined behavior when visualized:
-      </p>
-      <ul style="margin-left: 50px;">
-        <li>For loops</li>
-        <li>Conditional let bindings</li>
-        <li>Borrows that occur inside of conditionals</li>
-        <li>Chained method calls</li>
-        <li>Lifetime annotations</li>
-        <li>Borrows over struct members</li>
-      </ul>
-    </div>
-    <div>
-      <p>
-        If you come across an example that exposes some bug in our
-        visualization please submit an issue on the
-        <a href="https://github.com/rustviz/rustviz/issues">repo</a> with
-        the example code and error message (if applicable).
-      </p>
-    </div>
-
-    <!-- React mounts the example-picker dropdown here via createPortal
-         (see src/App.tsx). It needs to live above the editor in DOM
-         order, but our React app's main root is below the editor for
-         legacy reasons, so the portal lets us keep one App component
-         and still place the picker above. -->
-    <div id="example-picker"></div>
-    <div id="editor"></div>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/playground/frontend/package-lock.json
+++ b/playground/frontend/package-lock.json
@@ -19,7 +19,8 @@
         "@codemirror/view": "^6.28.4",
         "axios": "^1.7.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-resizable-panels": "^2.1.9"
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
@@ -1990,6 +1991,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/rollup": {

--- a/playground/frontend/package.json
+++ b/playground/frontend/package.json
@@ -21,7 +21,8 @@
     "@codemirror/view": "^6.28.4",
     "axios": "^1.7.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-resizable-panels": "^2.1.9"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import './index.css';
 import { extensions } from './setup';
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import axios from 'axios';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import ErrorCard from './ErrorCard';
 import { exampleGroups } from './examples';
 
@@ -24,22 +24,20 @@ declare function helpers(param: string): void;
 // motivate anything. Single source of truth lives in examples.ts.
 const defaultExample: string = exampleGroups[0].examples[0].code;
 
+// Thin wrapper around CodeMirror's EditorView so the React layer can
+// hold a single `Editor` instance across renders without re-creating
+// the underlying view (which would lose cursor position, undo
+// history, etc.). Owns its own DOM insertion via the constructor's
+// `parent` arg.
 class Editor {
   private view: EditorView;
 
-  public constructor (
-    editorContainer: HTMLElement,
-    code: string = defaultExample,
-  ) {
-    let initial_state = EditorState.create({
+  public constructor(editorContainer: HTMLElement, code: string = defaultExample) {
+    const initial_state = EditorState.create({
       doc: code,
-      extensions: extensions
+      extensions: extensions,
     });
-    
-    this.view = new EditorView({
-      state: initial_state,
-      parent: editorContainer
-    });
+    this.view = new EditorView({ state: initial_state, parent: editorContainer });
   }
 
   public getCurrentCode(): string {
@@ -50,11 +48,7 @@ class Editor {
   // example-picker dropdown when the user selects a preloaded snippet.
   public setCurrentCode(code: string): void {
     this.view.dispatch({
-      changes: {
-        from: 0,
-        to: this.view.state.doc.length,
-        insert: code,
-      },
+      changes: { from: 0, to: this.view.state.doc.length, insert: code },
     });
   }
 
@@ -63,23 +57,170 @@ class Editor {
   }
 }
 
-// Dropdown above the editor that loads a preloaded example into the
-// editor when selected. Examples come from `examples.ts`, vendored
-// from the rustviz-tutorial repo. We render this via createPortal
-// from inside App so the picker has access to the editor instance,
-// even though it visually lives in #example-picker (which sits above
-// the editor in DOM order, while the rest of the React app mounts
-// into #root below the editor).
+// Top-of-page bar. Title on the left, the rustc / plugin version
+// stamp on the right (kept here instead of below the editor so it
+// reads as masthead metadata rather than competing with the editor /
+// visualization for attention).
+const TitleBar: React.FC = () => (
+  <header className="titlebar">
+    <div className="titlebar-left">
+      <h1 className="titlebar-title">
+        <a href="https://github.com/rustviz/rustviz/" target="_blank" rel="noreferrer">
+          RustViz
+        </a>{' '}
+        Playground
+      </h1>
+      <a
+        className="titlebar-callout"
+        href="https://rustviz.github.io/tutorial/"
+        target="_blank"
+        rel="noreferrer"
+        title="Open the RustViz tutorial in a new tab"
+      >
+        New to Rust? Read our visual tutorial →
+      </a>
+    </div>
+    <div className="titlebar-meta">
+      <code>rustc {__RUST_VERSION__}</code>
+      <code>rustviz-plugin {__PLUGIN_VERSION__}</code>
+      {/* shields.io social-style badge updates dynamically; no JS
+          fetch needed and the SVG inlines the current star count.
+          Rightmost so it's the last thing the eye lands on. */}
+      <a
+        className="titlebar-stars"
+        href="https://github.com/rustviz/rustviz"
+        target="_blank"
+        rel="noreferrer"
+        title="Star us on GitHub"
+      >
+        <img
+          src="https://img.shields.io/github/stars/rustviz/rustviz?style=social&label=Star"
+          alt="GitHub stars"
+          height={20}
+        />
+      </a>
+    </div>
+  </header>
+);
+
+// Static prose pane. Same content the index.html used to carry, just
+// moved into the React tree so the resizable layout owns every
+// region of the page.
+const Description: React.FC = () => (
+  <div className="description">
+    <p>
+      Welcome!{' '}
+      <a href="https://github.com/rustviz/rustviz/" target="_blank" rel="noreferrer">
+        RustViz
+      </a>{' '}
+      is a tool to visualize an approximation of the compile-time reasoning of{' '}
+      <a href="https://www.rust-lang.org/" target="_blank" rel="noreferrer">
+        Rust's
+      </a>{' '}
+      borrow checker.
+    </p>
+    <p>
+      Try it out by writing a Rust program in the editor on the right, then clicking
+      the <strong>Generate Visualization</strong> button. The diagram appears in the
+      bottom panel.
+    </p>
+    <h3>Annotation markers</h3>
+    <p>You can keep individual items out of the visualization with comment markers:</p>
+    <ul>
+      <li>
+        <code>// rustviz: skip</code> on a <code>let</code> or <code>fn</code> line —
+        the item stays in the source but is omitted from the trace.
+      </li>
+      <li>
+        <code>// rustviz: hide</code> on a <code>fn</code> line — additionally
+        removes the entire fn from the rendered code panel; call sites still draw
+        their arrows.
+      </li>
+    </ul>
+    <h3>Known limitations</h3>
+    <p>RustViz is a research tool. It supports a meaningful subset of Rust but not all of it — these features are unsupported or known to misbehave:</p>
+    <ul>
+      <li>For-loops</li>
+      <li>
+        Bindings or borrows inside an <code>if</code> or <code>match</code>{' '}
+        branch body (the conditional itself can return a value into a{' '}
+        <code>let</code>, but tracking events inside the branch isn't supported)
+      </li>
+      <li>
+        Closures — captures (whether by reference or by{' '}
+        <code>move</code>) aren't drawn as arrows, so the visualization
+        silently omits the capture event
+      </li>
+      <li>
+        Smart-pointer wrappers (<code>Box</code>, <code>Rc</code>,{' '}
+        <code>Arc</code>, <code>RefCell</code>) and trait objects (
+        <code>Box&lt;dyn T&gt;</code>)
+      </li>
+      <li>
+        Indexing or slicing collections like <code>Vec</code> (string slices
+        like <code>&amp;s[..]</code> on a <code>String</code> do work)
+      </li>
+      <li>
+        The <code>?</code> operator (and other desugaring-heavy forms like{' '}
+        <code>async</code>/<code>await</code>)
+      </li>
+      <li>
+        Some struct field access patterns: chaining a method onto a field (
+        <code>r.field.method()</code>), nested field access (<code>r.a.b</code>),
+        and field access through a reference (<code>(&amp;r).field</code>).
+        Plain <code>r.field</code> and <code>&amp;r.field</code> work.
+      </li>
+      <li>
+        Inherent methods (<code>impl S {'{ fn ... }'}</code>) are fragile —
+        the Rectangle/area pattern (<code>fn area(&amp;self) -&gt; u32 {'{'} self.width * self.height {'}'}</code>)
+        works, but minor variants (e.g. a one-field <code>fn get(&amp;self) -&gt; i32 {'{'} self.n {'}'}</code>)
+        crash
+      </li>
+    </ul>
+    <p>
+      If you find an example that exposes a bug, please open an issue on the{' '}
+      <a href="https://github.com/rustviz/rustviz/issues" target="_blank" rel="noreferrer">
+        repo
+      </a>{' '}
+      with the snippet and error message.
+    </p>
+    <h3>Credits</h3>
+    <p>
+      RustViz is a project of the{' '}
+      <a href="https://web.eecs.umich.edu/~comar/" target="_blank" rel="noreferrer">
+        Future of Programming Lab
+      </a>{' '}
+      at the University of Michigan. The plugin is built on{' '}
+      <a href="https://github.com/cognitive-engineering-lab/rustc_plugin" target="_blank" rel="noreferrer">
+        <code>rustc_plugin</code> / <code>rustc_utils</code>
+      </a>{' '}
+      by{' '}
+      <a href="https://willcrichton.net/" target="_blank" rel="noreferrer">
+        Will Crichton
+      </a>
+      , and ports several MIR / borrow-fact helpers from{' '}
+      <a href="https://github.com/cognitive-engineering-lab/aquascope" target="_blank" rel="noreferrer">
+        Aquascope
+      </a>{' '}
+      (another visualization tool for Rust) by{' '}
+      <a href="https://gavinleroy.com/" target="_blank" rel="noreferrer">
+        Gavin Gray
+      </a>
+      .
+    </p>
+  </div>
+);
+
 type ExamplePickerProps = {
   onSelect: (code: string) => void;
 };
 
-// The picker stays interactive even while a /submit-code request is in
-// flight. Picking a fresh example mid-load aborts the previous request
-// (see inflightRef in App) and starts a new one — the user can change
-// their mind and the wrong response can never overwrite the right
-// one.
-const ExamplePicker = ({ onSelect }: ExamplePickerProps) => {
+// The picker stays interactive even while a /submit-code request is
+// in flight. Picking a fresh example mid-load aborts the previous
+// request (see inflightRef in App) and starts a new one — the user
+// can change their mind and the wrong response can never overwrite
+// the right one.
+const ExamplePicker: React.FC<ExamplePickerProps> = ({ onSelect }) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
     if (!value) return;
@@ -91,14 +232,11 @@ const ExamplePicker = ({ onSelect }: ExamplePickerProps) => {
 
   return (
     <div className="example-picker">
-      <label htmlFor="example-select">Examples:</label>
+      <label htmlFor="example-select">Example:</label>
       {/* Default to "0:0" — Motivation → "Hands-on tutorial" — to
           match the editor's seed snippet (defaultExample). React's
           `defaultValue` only sets initial state; it doesn't fire
-          onChange, so we don't double-load the same code. The
-          placeholder option is gone because the dropdown is never
-          empty — the editor always has a selected snippet from the
-          start. */}
+          onChange, so we don't double-load the same code. */}
       <select id="example-select" defaultValue="0:0" onChange={handleChange}>
         {exampleGroups.map((group, gIdx) => (
           <optgroup key={group.chapter} label={group.chapter}>
@@ -114,7 +252,7 @@ const ExamplePicker = ({ onSelect }: ExamplePickerProps) => {
   );
 };
 
-const App = () => {
+const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isErr, setErr] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -122,14 +260,15 @@ const App = () => {
   const [code_svg, setCodeSvg] = useState<string | null>(null);
   const [timeline_svg, setTimelineSvg] = useState<string | null>(null);
 
+  // The CodeMirror editor needs a real DOM node to attach to. Create
+  // it once when the host div mounts; tear it down on unmount so
+  // React 18 StrictMode's dev-mode double-invocation of this effect
+  // doesn't leave a second CodeMirror instance attached.
+  const editorHostRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    const editorElement = document.getElementById('editor')!;
-    if (!editorElement) return;
-    const newEditor = new Editor(editorElement);
+    if (!editorHostRef.current) return;
+    const newEditor = new Editor(editorHostRef.current);
     setEditor(newEditor);
-    // Dispose the EditorView on unmount so React 18 StrictMode's
-    // dev-mode double-invocation of this effect doesn't leave a
-    // second CodeMirror instance attached to #editor.
     return () => {
       newEditor.destroy();
       setEditor(null);
@@ -180,7 +319,7 @@ const App = () => {
       if (inflightRef.current !== controller) return;
 
       if (axios.isAxiosError(error) && error.response) {
-        setError(error.response.data); // Extract and set error message
+        setError(error.response.data);
       } else {
         setError('An unexpected error occurred');
       }
@@ -196,71 +335,88 @@ const App = () => {
     }
   };
 
+  // Auto-fire the visualization on the seed snippet so the bottom
+  // panel never starts empty.
   useEffect(() => {
-    handleClick(); // Call handleClick when the component mounts
+    handleClick();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
-
 
   const handleExampleSelect = (code: string) => {
     if (!editor) return;
     editor.setCurrentCode(code);
-    // Auto-fire the visualization. CodeMirror's dispatch is synchronous
-    // so getCurrentCode() inside handleClick() will see the just-set
-    // code on the next line.
+    // Auto-fire the visualization. CodeMirror's dispatch is
+    // synchronous so getCurrentCode() inside handleClick() will see
+    // the just-set code on the next line.
     handleClick();
   };
 
-  // The picker has to mount above the editor in DOM order, but the
-  // editor itself lives in vanilla index.html (not inside React). Use
-  // createPortal to render the picker into the #example-picker
-  // placeholder while keeping it part of App's component tree (so it
-  // can call into the editor via state).
-  const pickerHost = typeof document !== 'undefined'
-    ? document.getElementById('example-picker')
-    : null;
-
   return (
-    <div id="page-wrapper" className="page-wrapper">
-      {pickerHost && createPortal(
-        <ExamplePicker onSelect={handleExampleSelect} />,
-        pickerHost
-      )}
-      <button className="cm-button large-button" id="gen-button" onClick={handleClick} disabled={isLoading}>
-        {isLoading ? <>Generating<span className="ellipsis"></span></> : 'Generate Visualization'}
-      </button>
-      <p className="rust-version">
-        Compiles with <code>rustc {__RUST_VERSION__}</code> and{' '}
-        <code>rustviz-plugin {__PLUGIN_VERSION__}</code>
-      </p>
-      {isLoading && (
-        <div className="loading-status">
-          <p className="loading-message">
-            Generating visualization<span className="ellipsis"></span>
-          </p>
-          <p className="loading-note">
-            The first request after a quiet period can take up to ~30 s
-            while the compile server wakes up; subsequent requests are
-            fast.
-          </p>
-        </div>
-      )}
-      {isErr && error ? <ErrorCard err_string={error} /> :
-        <div className="page">
-          <div className="flex-container vis_block" style={{ marginLeft: '50px' }}>
-            <div
-              className="ex2 code_panel"
-              dangerouslySetInnerHTML={{ __html: code_svg ?? "" }}
-            />
-            <div
-              className="ex2 tl_panel"
-              style={{ width: 'auto' }}
-              dangerouslySetInnerHTML={{ __html: timeline_svg ?? "" }}
-              onMouseEnter={() => helpers('ex2')}
-            />
-          </div>
-        </div>
-      }
+    <div className="app-shell">
+      <TitleBar />
+      <PanelGroup direction="vertical" className="main-split" autoSaveId="rustviz-vertical">
+        {/* Top row: prose on the left, code editor on the right. */}
+        <Panel defaultSize={40} minSize={15}>
+          <PanelGroup direction="horizontal" autoSaveId="rustviz-top-horizontal">
+            <Panel defaultSize={35} minSize={15} className="panel description-panel">
+              <Description />
+            </Panel>
+            <PanelResizeHandle className="resize-handle resize-handle-vertical" />
+            <Panel defaultSize={65} minSize={25} className="panel editor-panel">
+              <div className="editor-toolbar">
+                <ExamplePicker onSelect={handleExampleSelect} />
+                <button
+                  className="cm-button generate-button"
+                  onClick={handleClick}
+                  disabled={isLoading}
+                >
+                  {isLoading ? <>Generating<span className="ellipsis"></span></> : 'Generate Visualization'}
+                </button>
+              </div>
+              <div className="editor-host" ref={editorHostRef} />
+            </Panel>
+          </PanelGroup>
+        </Panel>
+
+        <PanelResizeHandle className="resize-handle resize-handle-horizontal" />
+
+        {/* Bottom row: visualization (or error). Stretches to fill
+            whatever vertical space is left. */}
+        <Panel defaultSize={60} minSize={15} className="panel viz-panel">
+          {isLoading && (
+            <div className="loading-status">
+              <p className="loading-message">
+                Generating visualization<span className="ellipsis"></span>
+              </p>
+              <p className="loading-note">
+                The first request after a quiet period can take up to ~30 s while the
+                compile server wakes up; subsequent requests are fast.
+              </p>
+            </div>
+          )}
+          {/* Keep the previous render visible while a fresh one is in
+              flight — losing it on every Generate click feels worse
+              than briefly showing stale arrows. */}
+          {isErr && error ? (
+            <ErrorCard err_string={error} />
+          ) : (
+            <div className="viz-content">
+              <div className="flex-container vis_block">
+                <div
+                  className="ex2 code_panel"
+                  dangerouslySetInnerHTML={{ __html: code_svg ?? '' }}
+                />
+                <div
+                  className="ex2 tl_panel"
+                  style={{ width: 'auto' }}
+                  dangerouslySetInnerHTML={{ __html: timeline_svg ?? '' }}
+                  onMouseEnter={() => helpers('ex2')}
+                />
+              </div>
+            </div>
+          )}
+        </Panel>
+      </PanelGroup>
     </div>
   );
 };

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -1,107 +1,327 @@
+/* ─── Base ──────────────────────────────────────────────────────── */
+
+:root {
+  --bg: #fafafa;
+  --bg-panel: #ffffff;
+  --bg-titlebar: #2b2b2b;
+  --fg: #1f1f1f;
+  --fg-muted: #6e6e6e;
+  --fg-titlebar: #f5f5f5;
+  --fg-titlebar-muted: #b8b8b8;
+  --border: #e1e1e1;
+  --border-strong: #cdcdcd;
+  --accent: #cc7116;
+  --accent-hover: #b86310;
+  --accent-disabled: #d8b793;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
+  --titlebar-height: 48px;
+  --radius: 6px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
 body {
-  font: 16px "Helvetica Neue", "Open Sans", Arial, sans-serif;  
+  font: 14px/1.5 "Inter", "Helvetica Neue", "Open Sans", system-ui, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  overflow: hidden; /* layout owns the scroll */
 }
 
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
 
-h1 {
-  margin-top: 0;
-  font-weight: bold;
-  text-align: center;
+code {
+  font-family: "Source Code Pro", "SF Mono", Consolas, "Ubuntu Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 5px;
+  border-radius: 3px;
 }
 
-p {
-  max-width: 800px;
-  margin-left: 50px;
+/* ─── App shell ─────────────────────────────────────────────────── */
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
 }
 
-
-/* Sized to fit ~120 monospace characters of code + the line-number
-   gutter + the 5px border on each side, using a fixed pixel width
-   instead of `width: 50%`. With the percentage-based width the box
-   resized whenever the viewport did, so the right edge floated
-   relative to the prose; users now get a predictable column the
-   same way real code editors do. The `max-width` is a guard for
-   narrow windows: it lets the box shrink below 1060 px when the
-   viewport gets too small to fit, instead of overflowing past the
-   right edge.
-   The 1060 px figure is approximate — derived from a 14 px monospace
-   font where '0' is ~8.4 px wide, so 120 chars ≈ 1008 px, plus ~40 px
-   for a 4-digit line-number gutter, plus 10 px of border. Tweak if a
-   future font change throws the alignment off. */
-#editor {
-    height: 300px;
-    width: 1060px;
-    max-width: calc(100% - 100px);
-    margin-left: 50px;
+.main-split {
+  flex: 1;
+  min-height: 0; /* let the panels actually shrink */
 }
 
-/* Stretch editor to fit inside its containing div */
-.cm-editor {
-    height: 100%;
-    width: 100%;
-    border-style: solid;
-    border-width: 5px;
-    border-radius: 5px;
-    /* Pin the font-size so the column width above (1060 px) remains a
-       reasonable approximation of "120 chars". Without this the box
-       would render at the user-agent default (often 16 px), which
-       would make 120 chars overflow the box. */
-    font-size: 14px;
+/* ─── Titlebar ──────────────────────────────────────────────────── */
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--titlebar-height);
+  padding: 0 20px;
+  background: var(--bg-titlebar);
+  color: var(--fg-titlebar);
+  border-bottom: 1px solid #1a1a1a;
+  flex-shrink: 0;
+  gap: 16px;
 }
 
-/* Button styles */
-.large-button {
-  padding: 20px 40px; /* Increase padding to make the button larger */
-  margin: 50px; /* Add a 50px margin on all sides */
-  font-size: 16px; /* Increase the font size for better readability */
-  /* Hold the button width steady so it doesn't visibly shrink when its
-     label switches from "Generate Visualization" to "Generating…". */
-  min-width: 280px;
+.titlebar-left {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 0;
 }
+
+.titlebar-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.titlebar-title a {
+  color: var(--accent);
+}
+.titlebar-title a:hover { text-decoration: none; }
+
+.titlebar-callout {
+  font-size: 13px;
+  color: var(--fg-titlebar);
+  background: rgba(204, 113, 22, 0.18);
+  border: 1px solid rgba(204, 113, 22, 0.5);
+  padding: 4px 12px;
+  border-radius: 999px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.titlebar-callout:hover {
+  background: rgba(204, 113, 22, 0.32);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.titlebar-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--fg-titlebar-muted);
+  white-space: nowrap;
+}
+.titlebar-meta code {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--fg-titlebar);
+  font-size: 11px;
+}
+
+.titlebar-stars {
+  display: inline-flex;
+  align-items: center;
+  /* shields.io renders a slightly off-baseline image; nudge it
+     down a touch so it lines up with the version codes next to it. */
+  margin-bottom: -2px;
+}
+.titlebar-stars img { display: block; }
+
+/* ─── Panels (the resizable regions themselves) ─────────────────── */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  overflow: hidden; /* per-panel scroll lives on the inner container */
+  min-height: 0;
+  min-width: 0;
+}
+
+.description-panel,
+.viz-panel {
+  background: var(--bg-panel);
+}
+
+.description {
+  padding: 20px 24px;
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+  max-width: 80ch;
+  line-height: 1.55;
+}
+
+.description h3 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin: 24px 0 8px;
+}
+
+.description p { margin: 8px 0; }
+.description ul { margin: 6px 0 14px; padding-left: 22px; }
+.description li { margin: 3px 0; }
+.description code { font-size: 12px; }
+
+/* ─── Editor panel (top-right) ──────────────────────────────────── */
+
+.editor-panel {
+  background: var(--bg-panel);
+}
+
+.editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: #f6f6f6;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.example-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.example-picker label {
+  color: var(--fg-muted);
+  font-weight: 500;
+}
+.example-picker select {
+  font: inherit;
+  padding: 4px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  cursor: pointer;
+  max-width: 280px;
+}
+.example-picker select:hover { border-color: var(--fg-muted); }
 
 .cm-button {
-  background-color: #cc7116; /* Example background color */
-  color: white; /* Example text color */
-  border: none; /* Remove default border */
-  border-radius: 5px; /* Example border radius */
-  cursor: pointer; /* Change cursor on hover */
-  /* Add other styles as needed */
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 500;
+  transition: background 120ms ease;
 }
-
+.cm-button:hover:not(:disabled) { background: var(--accent-hover); }
 .cm-button:disabled {
-  background-color: #ccc; /* Change background color when disabled */
-  cursor: not-allowed; /* Change cursor when disabled */
+  background: var(--accent-disabled);
+  cursor: not-allowed;
 }
 
-.loader {
-  border: 2px solid rgba(0, 0, 0, 0.1);
-  border-left-color: #000;
-  border-radius: 50%;
-  width: 16px;
-  height: 16px;
-  animation: spin 1s linear infinite;
+.generate-button {
+  margin-left: auto;
+  padding: 6px 16px;
+  font-size: 13px;
+  min-width: 180px;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+.editor-host {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
-/* Loading status block under the rust-version note while a /submit-code
-   request is in flight. The button's own animated label indicates
-   "doing work"; this block adds a textual cue + a note about the
-   cold-start latency the Fly compile server can introduce after
-   auto-stop. Stacks naturally under .rust-version (rust-version's
-   bottom margin provides the gap). */
+/* CodeMirror itself fills the editor host. Border lives on the host
+   container, not the editor, so there's no double border with the
+   panel chrome. */
+.cm-editor {
+  height: 100%;
+  width: 100%;
+  font-size: 13px;
+}
+.cm-editor .cm-scroller {
+  font-family: "Source Code Pro", "SF Mono", Consolas, "Ubuntu Mono", Menlo, monospace;
+}
+
+/* ─── Visualization panel (bottom) ──────────────────────────────── */
+
+.viz-panel { background: #f1f1f1; }
+
+.viz-content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 20px;
+}
+
+/* Restore the side-by-side layout for the two SVG panels the plugin
+   returns (code panel + timeline panel). */
+.flex-container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+}
+.code_panel { flex-shrink: 0; }
+.tl_panel { flex-shrink: 0; }
+
+/* ─── Resize handles ────────────────────────────────────────────── */
+
+/* Vertical handle = the bar BETWEEN top and bottom rows (drag up/down).
+   Horizontal handle = the bar BETWEEN left and right (drag left/right).
+   Names follow the axis the user is dragging along, which is the
+   convention `react-resizable-panels` uses internally. */
+.resize-handle {
+  position: relative;
+  background: var(--border);
+  transition: background 120ms ease;
+}
+.resize-handle:hover,
+.resize-handle[data-resize-handle-state="hover"],
+.resize-handle[data-resize-handle-state="drag"] {
+  background: var(--accent);
+}
+
+.resize-handle-horizontal {
+  height: 4px;
+  cursor: row-resize;
+}
+
+.resize-handle-vertical {
+  width: 4px;
+  cursor: col-resize;
+}
+
+/* ─── Loading + error chrome ────────────────────────────────────── */
+
 .loading-status {
-  margin-top: 0;
+  padding: 24px;
+  color: var(--fg-muted);
 }
 .loading-message {
-  font-size: 18px;
-  margin-bottom: 4px;
+  font-size: 16px;
+  color: var(--fg);
+  margin: 0 0 6px;
 }
-/* Animated ellipsis: render fixed "..." but reveal one dot at a time by
-   animating the visible width in 4 steps (0 → 3 dots, then loops). */
+.loading-note {
+  font-size: 13px;
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* Animated ellipsis: render fixed "..." but reveal one dot at a time
+   by animating the visible width in 4 steps (0 → 3 dots, then loops). */
 .ellipsis::after {
   display: inline-block;
   vertical-align: bottom;
@@ -113,62 +333,3 @@ p {
 @keyframes ellipsis {
   to { width: 1.5em; }
 }
-.loading-note {
-  font-size: 14px;
-  color: #666;
-  margin-top: 0;
-}
-
-/* Toolchain note under the button. Small + subdued because it's
-   informational metadata, not user-facing UI; we want users to glance
-   at it and immediately know which rustc their snippet runs against
-   without it competing with the editor and visualization for
-   attention.
-   margin-top: -50px fully cancels the button's 50px bottom margin so
-   this paragraph sits directly under the button with no gap; the
-   loading-status block (when present) and the result panel both stack
-   below it using rust-version's own bottom margin as the gap, so
-   they can never overlap. */
-.rust-version {
-  font-size: 13px;
-  color: #888;
-  margin-top: -50px;
-  margin-bottom: 16px;
-}
-.rust-version code {
-  font-size: 13px;
-}
-
-/* Preloaded-example dropdown above the editor. Aligned with the
-   editor's left margin (50px) so it visually anchors to the same
-   column as the code box and the rest of the prose. */
-.example-picker {
-  margin: 0 0 8px 50px;
-  font-size: 14px;
-}
-.example-picker label {
-  margin-right: 8px;
-}
-.example-picker select {
-  font-size: 14px;
-  padding: 4px 8px;
-  max-width: 360px;
-}
-
-
-/* 
-.flex-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  flex-wrap: nowrap;
-  flex-shrink: 0;
-}
-
-.tl_panel {
-  flex-grow: 0;
-}
-
-.code_panel {
-  flex-grow: 1;
-} */

--- a/rustviz-plugin/README.md
+++ b/rustviz-plugin/README.md
@@ -44,12 +44,26 @@ RustViz is a teaching tool — it supports a meaningful subset of Rust,
 not all of it. Currently unsupported (or known to misbehave):
 
 - For-loops
-- Conditional `let` bindings
-- Borrows that occur inside conditionals
-- Some borrows over struct members
-- Lifetime annotations beyond what the
-  [`Excerpt<'a>`](https://github.com/rustviz/tutorial/blob/master/src/structs.md)
-  tutorial example covers
+- Bindings or borrows inside an `if` or `match` branch body (the
+  conditional itself can return a value into a `let`, but tracking
+  events inside the branch isn't supported)
+- Closures — captures (whether by reference or by `move`) aren't
+  drawn as arrows, so the visualization silently omits the capture
+  event
+- Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
+  objects (`Box<dyn T>`)
+- Indexing or slicing collections like `Vec` (string slices like
+  `&s[..]` on a `String` do work)
+- The `?` operator (and other desugaring-heavy forms like
+  `async`/`await`)
+- Some struct field access patterns: chaining a method onto a field
+  (`r.field.method()`), nested field access (`r.a.b`), and field
+  access through a reference (`(&r).field`). Plain `r.field` and
+  `&r.field` work.
+- Inherent methods (`impl S { fn ... }`) are fragile — the
+  Rectangle/area pattern (`fn area(&self) -> u32 { self.width *
+  self.height }`) works, but minor variants (e.g. a one-field
+  `fn get(&self) -> i32 { self.n }`) crash.
 
 ### To fix / implement
 


### PR DESCRIPTION
## Summary
Replaces the prose-then-controls-then-output flow that used to scroll off the bottom of the viewport with a fixed-height shell that fits everything on one screen.

### Layout
- **Titlebar** (dark, full-width). On the left: "RustViz Playground" + an orange callout pill linking to the visual tutorial. On the right: rustc / plugin version codes followed by a shields.io GitHub-stars badge linking to the repo.
- **Top row** (default 40% height, resizable). Description on the left (the prose that used to live in `index.html` plus a new Credits paragraph); editor on the right with a toolbar that has the example dropdown + Generate button.
- **Bottom row** (default 60%). The two visualization SVGs. Loading status now appears *above* the previous render so picking a new example doesn't blank the diagram while a fresh one is in flight.

All three regions are resized with [`react-resizable-panels`](https://github.com/bvaughn/react-resizable-panels) (v2); sizes persist via `autoSaveId` so a user's layout sticks across reloads.

### Accuracy pass on the limitations list
Drive-by, while we were touching the description copy. Empirically verified with the running plugin and updated in three places (playground UI, main README, plugin README):

- **Dropped** the broad "lifetime annotations beyond `Excerpt<'a>`" bullet — every common form works (function lifetimes, struct lifetime params, `'static`, multiple lifetimes, lifetime bounds, HRTB).
- **Replaced** "Some borrows over struct members" with the specific patterns that crash: `r.field.method()`, `r.a.b`, `(&r).field`. Plain `r.field` and `&r.field` work.
- **Added** an inherent-method bullet noting the Rectangle/area pattern works but minor variants crash (matches user-reported behaviour).
- **Added** bullets for closures (silent capture omission), smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`), trait objects, Vec indexing, and the `?` operator — all things the plugin crashes on but the docs didn't mention.

Each new failure mode also has its own GitHub issue (#70-#80) with a minimal repro and a sketch of the expected visualization where the rendering decision isn't obvious.

### Credits paragraph (new)
Added to both the in-app description and the main README. Leads with "RustViz is a project of the Future of Programming Lab at the University of Michigan", then attributes Will Crichton's `rustc_plugin` / `rustc_utils` (the framework the plugin is built on) and Gavin Gray's Aquascope (source of the borrowed MIR / borrow-fact helpers).

## Test plan
- [x] `npm run build` clean (`tsc -b && vite build`)
- [x] Local playground renders the new layout end-to-end; resize handles work; layout persists across reloads
- [x] Hands-on tutorial snippet renders with all three marker forms (`skip` on `q`, `hide` on the helpers) intact
- [x] Loading status overlays the previous render instead of blanking it
- [x] Tutorial pill, stars badge, and credits paragraph all link to the right places
- [ ] CI green
- [ ] Pages preview shows the new layout once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)