### PR TITLE
plugin: don't panic on field-projection / impl-method shapes (fixes #71, #73)

### DIFF
--- a/rustviz-plugin/src/annotated_source_gen.rs
+++ b/rustviz-plugin/src/annotated_source_gen.rs
@@ -5,7 +5,7 @@
 //! The logic is quite simple, visit each part of a function body and replace each RAP as it appears in the source string
 //! with a new string. (It's a little more complicated but this is the gist)
 
-use crate::{expr_visitor::ExprVisitor, expr_visitor_utils::{hirid_to_var_name, span_to_line}};
+use crate::{expr_visitor::ExprVisitor, expr_visitor_utils::{expr_to_rap_name, hirid_to_var_name, span_to_line}};
 use rustc_hir::{Expr, ExprKind, QPath, Stmt, StmtKind, LetStmt, Pat, PatKind};
 use rustc_span::Span;
 
@@ -151,9 +151,18 @@ pub fn annotate_expr(& mut self, expr: &'tcx Expr) {
         }
         _ => {}
       }
-      let rcvr_name = hirid_to_var_name(rcvr.hir_id, &self.tcx).unwrap();
-      self.annotate_src(rcvr_name.clone(), rcvr.span, false, *self.raps.get(&rcvr_name).unwrap().rap.hash());
-
+      // Same handling as the visitor's MethodCall arm: receivers
+      // like `r.s` are Field expressions, not bare paths, so use
+      // `expr_to_rap_name` to derive the qualified name. If we
+      // can't resolve a RAP, skip annotation for this receiver
+      // rather than panic — the annotation is purely for source-
+      // panel coloring; missing it just leaves the receiver
+      // un-styled.
+      if let Some(rcvr_name) = expr_to_rap_name(rcvr, &self.tcx) {
+        if let Some(rd) = self.raps.get(&rcvr_name) {
+          self.annotate_src(rcvr_name.clone(), rcvr.span, false, *rd.rap.hash());
+        }
+      }
     }
     ExprKind::Assign(exp1, exp2, _) | ExprKind::AssignOp(_, exp1, exp2) => {
       self.annotate_expr(exp1);

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -815,7 +815,16 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       self.add_ev(line_num, Evt::Bind, lhs.clone(), ResourceTy::Anonymous, false);
       for field in expr_fields.iter() {
           let new_lhs_name = format!("{}.{}", lhs.name(), field.ident.as_str());
-          let field_rap = self.raps.get(&new_lhs_name).unwrap().rap.to_owned();
+          // Skip fields whose RAP we never registered. The most
+          // common case is a struct field whose type is itself a
+          // struct (`R { a: A { b: ... } }`): define_lhs registers
+          // `r.a` but doesn't recurse to add `r.a.b`, so the inner
+          // struct's expansion lands here without an entry. Better
+          // to lose the per-field event than crash the whole render.
+          let field_rap = match self.raps.get(&new_lhs_name) {
+            Some(rd) => rd.rap.to_owned(),
+            None => continue,
+          };
           let field_ty = self.tcx.typeck(field.expr.hir_id.owner).node_type(field.expr.hir_id);
           let is_copyable = self.tcx.type_is_copy_modulo_regions(rustc_middle::ty::TypingEnv::post_analysis(self.tcx, field.expr.hir_id.owner), field_ty);
           let e = if field_ty.is_ref() {
@@ -847,16 +856,19 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       }
     },
 
-    ExprKind::Field(expr, id) => {
-      match expr {
-        Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-          let line_num = span_to_line(&p.span, &self.tcx);
-          let name = self.tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          let total_name = format!("{}.{}", name, id.as_str());
-          let rhs_rap = self.raps.get(&total_name).unwrap().rap.to_owned();
+    ExprKind::Field(inner, id) => {
+      // Walk the receiver to a qualified name; emit the event only
+      // if we actually have a RAP under that name. Anything else
+      // (nested field access we never registered, `self.field` in
+      // an impl method, fields through a deref/borrow) falls
+      // through silently rather than panicking.
+      if let Some(base) = expr_to_rap_name(inner, &self.tcx) {
+        let total_name = format!("{}.{}", base, id.as_str());
+        if let Some(rd) = self.raps.get(&total_name) {
+          let line_num = span_to_line(&inner.span, &self.tcx);
+          let rhs_rap = rd.rap.to_owned();
           self.add_ev(line_num, evt, lhs, ResourceTy::Value(rhs_rap), false);
         }
-        _ => panic!("unexpected field expr")
       }
     }
     // explicitly using return keyword

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -63,6 +63,37 @@ pub fn hirid_to_var_name(id: HirId, tcx: &TyCtxt) -> Option<String> {
   }
 }
 
+/// Walk a chain of `Path` / `Field` / `AddrOf` / `Unary` / `DropTemps`
+/// expressions and produce the qualified RAP name, e.g. `r`, `r.s`,
+/// `r.a.b`, or `self.n`. Returns `None` for anything outside that
+/// chain — calls, blocks, literals, etc. — since those don't have a
+/// stable RAP name to look up.
+///
+/// Rationale: the visitor used to inline a one-arm match for
+/// `Field(Path(...), ident)` everywhere it needed a struct-field RAP
+/// name and `panic!("unexpected field expr")` on every other shape.
+/// That panicked on `r.a.b` (nested), `(&r).s` (field through a
+/// reference), `self.field` (in impl methods where `self.field`
+/// isn't a registered RAP), and the receiver of `r.s.method()`.
+/// Centralizing the walk lets us return `None` instead, which the
+/// callers map to "skip this event" / "Anonymous resource" rather
+/// than crashing the plugin.
+pub fn expr_to_rap_name(expr: &Expr, tcx: &TyCtxt) -> Option<String> {
+  match expr.kind {
+    ExprKind::Path(QPath::Resolved(_, p)) => {
+      Some(tcx.hir_name(p.segments[0].hir_id).as_str().to_owned())
+    }
+    ExprKind::Field(inner, ident) => {
+      let base = expr_to_rap_name(inner, tcx)?;
+      Some(format!("{}.{}", base, ident.as_str()))
+    }
+    ExprKind::AddrOf(_, _, inner)
+    | ExprKind::Unary(_, inner)
+    | ExprKind::DropTemps(inner) => expr_to_rap_name(inner, tcx),
+    _ => None,
+  }
+}
+
 pub fn bool_of_mut (m: Mutability) -> bool {
   match m {
     Mutability::Not => {
@@ -241,20 +272,29 @@ pub fn get_live_of_expr(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapDat
         }
         _ => {
           let name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          HashSet::from([raps.get(&name).unwrap().rap.to_owned()])
+          // Same fallback as the Path arm in get_rap: an unknown
+          // name (macro-synthetic local, `self` in an impl method,
+          // etc.) becomes an empty live set rather than a crash.
+          match raps.get(&name) {
+            Some(rd) => HashSet::from([rd.rap.to_owned()]),
+            None => HashSet::new(),
+          }
         }
       }
     }
-    ExprKind::Field(expr, ident) => {
-      match expr {
-        Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-          let name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          let field_name: String = ident.as_str().to_owned();
-          let total_name = format!("{}.{}", name, field_name);
-          HashSet::from([raps.get(&total_name).unwrap().rap.to_owned()])
+    ExprKind::Field(inner, ident) => {
+      // Live-set extraction: emit the qualified field RAP if we
+      // know it; otherwise return empty rather than panic. Callers
+      // accumulate live sets across an expression tree, so a
+      // missing one just means we under-report liveness for that
+      // sub-expression, which is preferable to crashing.
+      if let Some(base) = expr_to_rap_name(inner, tcx) {
+        let total_name = format!("{}.{}", base, ident.as_str());
+        if let Some(rd) = raps.get(&total_name) {
+          return HashSet::from([rd.rap.to_owned()]);
         }
-        _ => { panic!("unexpected field expr") }
-      } 
+      }
+      HashSet::new()
     }
     ExprKind::AddrOf(_, _, exp) | ExprKind::Unary(_, exp) 
     | ExprKind::DropTemps(exp) => {
@@ -543,22 +583,24 @@ pub fn get_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> Re
         None => { panic!("invalid expr for getting rap") }
       }
     }
-    ExprKind::Field(expr, ident) => {
-      match expr {
-        Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-          let name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          let field_name: String = ident.as_str().to_owned();
-          let total_name = format!("{}.{}", name, field_name);
-          ResourceTy::Value(raps.get(&total_name).unwrap().rap.to_owned())
+    ExprKind::Field(inner, ident) => {
+      // Walk the receiver to a qualified name, then look it up. Any
+      // shape we can't name (call result, block, etc.) — or a name
+      // we don't have a RAP for — falls back to Anonymous so the
+      // surrounding event still records.
+      if let Some(base) = expr_to_rap_name(inner, tcx) {
+        let total_name = format!("{}.{}", base, ident.as_str());
+        if let Some(rd) = raps.get(&total_name) {
+          return ResourceTy::Value(rd.rap.to_owned());
         }
-        _ => { panic!("unexpected field expr") }
-      } 
+      }
+      ResourceTy::Anonymous
     }
     _ => ResourceTy::Anonymous
   }
 }
 
-// Almost the same as get_rap but we don't care about any anonymous owners 
+// Almost the same as get_rap but we don't care about any anonymous owners
 // which is why we return a RAP instead of a ResourceTy
 pub fn fetch_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> Option<ResourceAccessPoint> {
   match expr.kind {
@@ -574,16 +616,17 @@ pub fn fetch_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> 
         None => { panic!("invalid expr for fetching rap") }
       }
     }
-    ExprKind::Field(expr, ident) => {
-      match expr {
-        Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-          let name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          let field_name: String = ident.as_str().to_owned();
-          let total_name = format!("{}.{}", name, field_name);
-          Some(raps.get(&total_name).unwrap().rap.to_owned())
+    ExprKind::Field(inner, ident) => {
+      // Same logic as get_rap's Field arm, but return None instead
+      // of Anonymous since fetch_rap callers don't carry a separate
+      // "anonymous" sentinel.
+      if let Some(base) = expr_to_rap_name(inner, tcx) {
+        let total_name = format!("{}.{}", base, ident.as_str());
+        if let Some(rd) = raps.get(&total_name) {
+          return Some(rd.rap.to_owned());
         }
-        _ => { panic!("unexpected field expr") }
-      } 
+      }
+      None
     }
     _ => None
   }
@@ -640,21 +683,23 @@ pub fn find_lender(rhs: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>, bo
         }
       }
     }
-    ExprKind::Field(expr, ident) => {
-      match expr {
-        Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-          let mut name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-          name = format!("{}.{}", name, ident.as_str());
-          if borrow_map.contains_key(&name) {
-            borrow_map.get(&name).unwrap().to_owned().lender
-          }
-          else{
-            ResourceTy::Value(raps.get(&name).unwrap().rap.to_owned())
-          }
+    ExprKind::Field(inner, ident) => {
+      // Walk to a qualified name; check borrow_map first (the field
+      // might itself be a registered borrower with a known lender),
+      // then fall back to raps. Unknown names return Anonymous so
+      // the surrounding `let p = &r.unknown.field;` still records a
+      // borrow site, just without a recorded lender.
+      if let Some(base) = expr_to_rap_name(inner, tcx) {
+        let name = format!("{}.{}", base, ident.as_str());
+        if let Some(rd) = borrow_map.get(&name) {
+          return rd.to_owned().lender;
         }
-        _ => { panic!("unexpected field expr") }
-      } 
+        if let Some(rd) = raps.get(&name) {
+          return ResourceTy::Value(rd.rap.to_owned());
+        }
+      }
+      ResourceTy::Anonymous
     }
-  _ => { panic!("unexpected rhs lender expr {:#?}", rhs) }
+  _ => ResourceTy::Anonymous,
   }
 }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -219,8 +219,23 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           }
           _ => {}
         }
-        let rcvr_name = hirid_to_var_name(rcvr.hir_id, &self.tcx).unwrap();
-        let rcvr_rap = self.raps.get(&rcvr_name).unwrap().rap.to_owned();
+        // The receiver of `r.s.method()` is a Field expression, not
+        // a bare path, so `hirid_to_var_name` can't name it.
+        // `expr_to_rap_name` walks Path / Field / AddrOf chains and
+        // returns the qualified name we registered the receiver
+        // under (e.g. `r.s`). If we can't resolve a RAP for the
+        // receiver — unregistered nested field, `self.field` in an
+        // impl method, etc. — bail out of the rest of the
+        // method-call processing rather than crash; the call site
+        // simply produces no event for this method.
+        let rcvr_name = match expr_to_rap_name(rcvr, &self.tcx) {
+          Some(n) => n,
+          None => return,
+        };
+        let rcvr_rap = match self.raps.get(&rcvr_name) {
+          Some(rd) => rd.rap.to_owned(),
+          None => return,
+        };
         self.update_rap(&rcvr_rap, line_num);
         let fn_rap = self.raps.get(&fn_name).unwrap().rap.to_owned();
         // typecheck


### PR DESCRIPTION
Fixes #71 and #73. Also removes the panic in #72 and #74 but the rendering work for those is still pending — see "Scope" below.

## What was happening
Field-expression handling lived inline in five places (\`get_rap\`, \`fetch_rap\`, \`get_live_of_expr\`, \`find_lender\`, \`match_rhs\`'s Field arm), each with the same one-arm match:

\`\`\`rust
match expr {
    Expr { kind: ExprKind::Path(QPath::Resolved(_, p)), .. } => { /* compose total_name and unwrap raps.get(...) */ }
    _ => panic!("unexpected field expr"),
}
\`\`\`

Plus \`visitor.rs\` and \`annotated_source_gen.rs\` both unwrapped \`hirid_to_var_name(rcvr.hir_id)\` for the method receiver, which returns None for anything but a bare path.

That covered all four panic patterns the issues describe:
- **#71 \`r.s.method()\`** — receiver is a Field expression, \`hirid_to_var_name\` returns None
- **#72 \`r.a.b\` nested struct** — inner struct's fields aren't registered (\`define_lhs\` doesn't recurse on Struct-typed fields), so the constructor's Field-arm lookup fails
- **#73 \`(&r).field\`** — receiver isn't \`Path.field\`, hits the literal \`panic!\` arm
- **#74 \`impl S { fn ... }\` returning \`self.field\`** — \`self.field\` isn't a registered RAP in the method body's frame; the function-tail \`fetch_rap\` panics on it

The fragility wasn't a single root cause — it was four distinct sites built on the same brittle match, so one fix is the same shape repeated.

## Fix
Centralize the receiver-name walk in a new helper:

\`\`\`rust
pub fn expr_to_rap_name(expr: &Expr, tcx: &TyCtxt) -> Option<String>
\`\`\`

Handles \`Path\`, \`Field\` (recursing — \`r.a.b\`), \`AddrOf\`, \`Unary\`, and \`DropTemps\`. Returns the qualified RAP name (\`r\`, \`r.s\`, \`r.a.b\`, \`self.n\`) or None for non-namable shapes (calls, blocks, literals).

Then replace every Field-arm panic site with: walk to a name, look it up, return \`Anonymous\` / \`None\` / empty / \`continue\` when the name doesn't resolve. Same for the method-call sites in \`visitor.rs\` and \`annotated_source_gen.rs\` — \`hirid_to_var_name(...).unwrap()\` becomes \`expr_to_rap_name\` + a graceful return.

## Scope (empirically verified arrow-by-arrow)

| Issue | Panic gone? | Expected visualization renders? |
|---|---|---|
| **#71** \`r.s.method()\` | ✅ | ✅ — \`push_str reads from/writes to r.s\` arrow appears |
| **#73** \`(&r).s\` | ✅ | ✅ — identical arrows to the \`&r.s\` baseline |
| #72 \`r.a.b\` | ✅ | ❌ — read event still not emitted (\`define_lhs\` doesn't recurse into nested struct fields, so the RAP for \`r.a.b\` doesn't exist; my fix returns \`Anonymous\` which short-circuits the event) |
| #74 impl method \`self.field\` | ✅ | ❌ — call-site \`r → get\` arrow still missing (orthogonal pre-existing limitation: ref-argument call sites don't emit PassByRef events for any fn, not introduced by this PR) |

This PR closes #71 and #73 (fully fixed) and leaves #72 and #74 open for the visualization work, which is a separate effort from the panic.

## Test plan
- [x] Each of the four issue reproductions renders instead of panicking
- [x] #71 and #73 produce the expected arrows (verified against the \`&r.s\` baseline)
- [x] Dropdown's Rectangle (with \`print_area\` indirection) still renders unchanged
- [x] Dropdown's "Mutable borrow (method call)" still renders unchanged
- [x] Default snippet (Hands-on tutorial with \`skip\` / \`hide\` markers) still renders unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)