### PR TITLE
plugin: register nested struct fields as RAPs (fixes #72)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -37,6 +37,54 @@ const EXPECTED_OK: &[&str] = &[
     "ownershipFunctions",
     "testStaticB",
     "testMutB",
+    // Field-projection / nested-struct cases — see expected-arrows
+    // table below for the per-snippet shape we're locking in.
+    "nested_struct_borrow",
+    "nested_struct_move",
+    "nested_struct_passref",
+    "field_method_call",
+    "field_through_ref",
+];
+
+/// Specific arrow tooltips each snippet must produce. The check is
+/// containment (extra arrows are fine), so adding new tracked events
+/// to the plugin doesn't break these tests — only removing the
+/// listed ones does. Each tuple is (snippet stem, list of expected
+/// arrow tooltips, in-source order doesn't matter).
+///
+/// "Arrow tooltip" = the human-readable string the renderer puts on
+/// the `data-tooltip-text` attribute of an arrow `<g>`. We compare
+/// the un-HTML-escaped form so multi-segment names like `r.a.b` and
+/// punctuation render naturally.
+///
+/// These tests are the regression bar for issues #71 (`r.s.method()`),
+/// #72 (nested-struct reads / borrows / moves), and #73 (`(&r).s`).
+const EXPECTED_ARROWS: &[(&str, &[&str])] = &[
+    // #72
+    ("nested_struct_borrow", &[
+        "Move from String::from to r.a.b",
+        "Immutable borrow from r.a.b to p",
+        "Return immutably borrowed resource from p to r.a.b",
+    ]),
+    ("nested_struct_move", &[
+        "Move from String::from to r.a.b",
+        "Move from r.a.b to x",
+    ]),
+    ("nested_struct_passref", &[
+        "Move from String::from to r.a.b",
+        "read_a reads from r.a",
+    ]),
+    // #71
+    ("field_method_call", &[
+        "Move from String::from to r.s",
+        "push_str reads from/writes to r.s",
+    ]),
+    // #73
+    ("field_through_ref", &[
+        "Move from String::from to r.s",
+        "Immutable borrow from r.s to p",
+        "Return immutably borrowed resource from p to r.s",
+    ]),
 ];
 
 fn corpus_dir() -> PathBuf {
@@ -95,6 +143,83 @@ fn assert_well_formed(name: &str, rv: &Rustviz) {
         timeline.contains("tooltip-trigger"),
         "{}: timeline has no tooltip-trigger elements (annotations missing)",
         name
+    );
+}
+
+/// Extract every arrow tooltip from a rendered timeline panel.
+///
+/// The renderer wraps each arrow in `<g class="tooltip-trigger"
+/// data-tooltip-text="...">` inside `<g id="arrows">`. Tooltip text
+/// is HTML-escaped (`&lt;` / `&gt;` / `&quot;`) and contains nested
+/// `<span>` markup that we strip before comparing — what we want is
+/// the human-visible string ("Immutable borrow from r.a.b to p").
+fn arrow_tooltips(timeline_svg: &str) -> Vec<String> {
+    let arrows_start = match timeline_svg.find("<g id=\"arrows\">") {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let body = &timeline_svg[arrows_start..];
+    let mut out = Vec::new();
+    for chunk in body.split("data-tooltip-text=\"").skip(1) {
+        let raw = match chunk.find('"') {
+            Some(end) => &chunk[..end],
+            None => continue,
+        };
+        // Un-HTML-escape the small set the renderer emits.
+        let unescaped = raw
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&amp;", "&");
+        // Strip nested span markup; what's left is the visible text.
+        let mut clean = String::with_capacity(unescaped.len());
+        let mut in_tag = false;
+        for ch in unescaped.chars() {
+            if ch == '<' { in_tag = true; continue; }
+            if ch == '>' { in_tag = false; continue; }
+            if !in_tag { clean.push(ch); }
+        }
+        out.push(clean);
+    }
+    out
+}
+
+#[test]
+fn corpus_expected_arrows_present() {
+    let mut failures = Vec::new();
+    for (name, expected) in EXPECTED_ARROWS {
+        let res = std::panic::catch_unwind(|| {
+            let rv = run_with_local_backend(name);
+            let actual = arrow_tooltips(&rv.timeline_panel_string());
+            let mut missing: Vec<&str> = Vec::new();
+            for want in *expected {
+                if !actual.iter().any(|a| a == want) {
+                    missing.push(*want);
+                }
+            }
+            if !missing.is_empty() {
+                panic!(
+                    "missing arrows {:?}; actual arrows were:\n  {}",
+                    missing,
+                    actual.join("\n  ")
+                );
+            }
+        });
+        if let Err(payload) = res {
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "<non-string panic>".to_string());
+            failures.push(format!("{}: {}", name, msg));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} arrow assertions failed:\n  {}",
+        failures.len(),
+        EXPECTED_ARROWS.len(),
+        failures.join("\n  ")
     );
 }
 

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -546,54 +546,13 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
           let owner_hash = self.rap_hashes as u64;
           let parent_is_copy = self.ty_is_copy(ty, expr.hir_id.owner);
           self.add_struct(name.clone(), owner_hash, false, mutability, parent_is_copy, self.current_scope,!self.inside_branch);
-          // Resolve each field's substituted type so we can tell
-          // which fields are references (a `Excerpt<'a> { p: &'a
-          // str }` has p: &str at construction time, modelled as
-          // a StaticRef RAP that's a member of the parent struct)
-          // versus owned values (registered as Struct members
-          // exactly as before).
-          let generic_args = match ty.kind() {
-            TyKind::Adt(_, args) => *args,
-            _ => unreachable!("ty.is_adt() but kind is not Adt"),
-          };
-          for field in ty.ty_adt_def().unwrap().all_fields() {
-            let field_name = format!("{}.{}", name.clone(), field.name.as_str());
-            let field_ty = field.ty(self.tcx, generic_args);
-            if field_ty.is_ref() {
-              let ref_mutability = bool_of_mut(field_ty.ref_mutability().unwrap());
-              // The field's lender is whatever the user passed in
-              // for that field at the construction site; we wire
-              // that up later in match_rhs's Struct arm via the
-              // already-computed get_ref_data path. For now, seed
-              // borrow_map with Anonymous lender as a placeholder
-              // so the renderer can still draw the ref-line; the
-              // Struct arm will overwrite it.
-              if ref_mutability {
-                self.add_mut_ref_member(field_name.clone(), mutability,
-                    self.current_scope, !self.inside_branch, Some(owner_hash));
-              } else {
-                self.add_static_ref_member(field_name.clone(), mutability,
-                    self.current_scope, !self.inside_branch, Some(owner_hash));
-              }
-              // The borrow stored in this field is alive for as
-              // long as the parent struct is — so the loan
-              // extends to the end of the enclosing scope, same
-              // policy as fn-param refs which also borrow for
-              // the full body. Without this the ref-line
-              // trapezoid collapses (assigned_at == lifetime).
-              self.borrow_map.insert(field_name, RefData {
-                lender: ResourceTy::Anonymous,
-                assigned_at: expr_to_line(&expr, &self.tcx),
-                lifetime: self.current_scope,
-                ref_mutability,
-                aliasing: VecDeque::new(),
-              });
-            } else {
-              let field_is_copy = self.ty_is_copy(field_ty, expr.hir_id.owner);
-              self.add_struct(field_name, owner_hash, true, mutability, field_is_copy,
-                  self.current_scope, !self.inside_branch);
-            }
-          }
+          self.register_struct_members(
+            &name,
+            ty,
+            owner_hash,
+            mutability,
+            expr,
+          );
         },
         AdtKind::Union => {
           warn!("lhs union not implemented yet")
@@ -610,6 +569,84 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     else {
       let is_copy = self.ty_is_copy(ty, expr.hir_id.owner);
       self.add_owner(name, mutability, is_copy, self.current_scope, !self.inside_branch);
+    }
+  }
+
+  /// Register `prefix.field` RAPs for every field of a struct type,
+  /// recursing into nested structs so accesses like `r.a.b` resolve.
+  ///
+  /// `top_owner_hash` is the timeline-grouping key for the outermost
+  /// struct — every nested member shares it so the renderer keeps
+  /// the whole tree under a single struct group, the same way flat
+  /// struct members already share their parent's group today.
+  ///
+  /// Reference fields (e.g. `Excerpt<'a> { p: &'a str }`) get the
+  /// same StaticRef/MutRef-member treatment as before, with a
+  /// placeholder Anonymous lender that the Struct arm of `match_rhs`
+  /// overwrites once it sees the construction-site initializer.
+  /// Owned struct fields recurse so `r.a.b.c` etc. land in `raps`
+  /// under their qualified names; Field-arm lookups in
+  /// `expr_visitor_utils` then find them and emit events instead of
+  /// silently giving up.
+  fn register_struct_members(
+    &mut self,
+    prefix: &str,
+    ty: Ty<'tcx>,
+    top_owner_hash: u64,
+    mutability: bool,
+    construction_expr: &'tcx Expr<'tcx>,
+  ) {
+    let generic_args = match ty.kind() {
+      TyKind::Adt(_, args) => *args,
+      _ => unreachable!("register_struct_members called with non-Adt ty"),
+    };
+    let owner_id = construction_expr.hir_id.owner;
+    let assigned_at = expr_to_line(&construction_expr, &self.tcx);
+    for field in ty.ty_adt_def().unwrap().all_fields() {
+      let field_name = format!("{}.{}", prefix, field.name.as_str());
+      let field_ty = field.ty(self.tcx, generic_args);
+      if field_ty.is_ref() {
+        let ref_mutability = bool_of_mut(field_ty.ref_mutability().unwrap());
+        if ref_mutability {
+          self.add_mut_ref_member(field_name.clone(), mutability,
+              self.current_scope, !self.inside_branch, Some(top_owner_hash));
+        } else {
+          self.add_static_ref_member(field_name.clone(), mutability,
+              self.current_scope, !self.inside_branch, Some(top_owner_hash));
+        }
+        // Same lender-placeholder rationale as the flat case before
+        // the refactor: borrow stored in this field outlives the
+        // statement, so stretch the loan to the enclosing scope so
+        // the ref-line trapezoid actually has a non-degenerate range.
+        self.borrow_map.insert(field_name, RefData {
+          lender: ResourceTy::Anonymous,
+          assigned_at,
+          lifetime: self.current_scope,
+          ref_mutability,
+          aliasing: VecDeque::new(),
+        });
+      } else {
+        let field_is_copy = self.ty_is_copy(field_ty, owner_id);
+        self.add_struct(field_name.clone(), top_owner_hash, true, mutability, field_is_copy,
+            self.current_scope, !self.inside_branch);
+        // Recurse for nested struct fields. Skip enums / unions
+        // (only struct ADTs are flattened today) and skip the
+        // special-owner builtins like `String` whose internals
+        // we deliberately don't expose.
+        if field_ty.is_adt() && !ty_is_special_owner(&self.tcx, &field_ty) {
+          if let Some(adt_def) = field_ty.ty_adt_def() {
+            if matches!(adt_def.adt_kind(), AdtKind::Struct) {
+              self.register_struct_members(
+                &field_name,
+                field_ty,
+                top_owner_hash,
+                mutability,
+                construction_expr,
+              );
+            }
+          }
+        }
+      }
     }
   }
 

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -472,6 +472,17 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     let arg_ty = tycheck_results.node_type(arg.hir_id);
     let is_copyable = self.tcx.type_is_copy_modulo_regions(rustc_middle::ty::TypingEnv::post_analysis(self.tcx, arg.hir_id.owner), arg_ty);
     let from_ro = get_rap(arg, &self.tcx, &self.raps);
+    // Extend the lifetime of any reference RAP this arg touches so a
+    // ref passed as a fn argument shows its dotted lifetime line out
+    // to the call site. Critical for macro args like
+    // `println!("{}", p)`: visit_expr bails on macro-expanded
+    // children before reaching the inner Path that would normally
+    // call update_rap, so without this nudge the ref's lifetime
+    // stays pinned to its declaration line and the renderer draws a
+    // degenerate (zero-height) ref-line.
+    if let ResourceTy::Value(rap) | ResourceTy::Deref(rap) = &from_ro {
+      self.update_rap(rap, line_num);
+    }
     let to_ro = ResourceTy::Value(self.raps.get(&fn_name).unwrap().rap.to_owned());
     // type-check the arg and add event accordingly
     if arg_ty.is_ref() {

--- a/rustviz-plugin/src/mir_data.rs
+++ b/rustviz-plugin/src/mir_data.rs
@@ -107,10 +107,17 @@ impl <'a, 'tcx> ExprVisitor<'a, 'tcx> {
             match body_with_facts.borrow_set.location_map().get(&location) {
               Some(b_data) => {
                 // println!("borrow_data for location {:#?} : {:#?}", location, b_data);
-                let b_place = b_data.borrowed_place().local_or_deref_local();
-                let a_place = b_data.assigned_place().local_or_deref_local();
-                // println!("borrowed_place: {:#?}, as local: {:#?}", b_data.borrowed_place().to_string(self.tcx, &borrow_data.body), b_place);
-                // println!("assigned place {:#?}, as local {:#?}", b_data.assigned_place().to_string(self.tcx, &borrow_data.body), a_place);
+                // For a borrow of `r.a.b`, MIR's `borrowed_place`
+                // is `r` with projections [Field(a), Field(b)].
+                // `local_or_deref_local()` returns None for any
+                // projection that isn't a single deref, which is why
+                // ref-lifetime refinement used to skip every borrow
+                // of a struct field. Use the base `.local` directly
+                // so we always get the source name; `borrow_match`
+                // matches against either the exact lender name or a
+                // path prefix terminated by `.`.
+                let b_place = Some(b_data.borrowed_place().local);
+                let a_place = Some(b_data.assigned_place().local);
                 let b_name = self.src_name_of_local(b_place, &loc_to_source_name);
                 let a_name = self.src_name_of_local(a_place, &loc_to_source_name);
 
@@ -207,15 +214,30 @@ impl <'a, 'tcx> ExprVisitor<'a, 'tcx> {
 
     // Helper function to help refine loan regions that we compute in HIR
     pub fn borrow_match(r: &RefData, b: &MIRBorrowData) -> Option<usize> {
-        if b.borrowed_place.is_some() {
-            // For now I think it's enough to just check the assignment line and borrowed place for equality
-            // Although this is by no means sound logic
-            if *b.borrowed_place.as_ref().unwrap() == r.lender.real_name() && b.region.0 == r.assigned_at {
-                return Some(b.region.1)
-            } 
-            else { 
-                return None 
-            }
+        let mir_place = b.borrowed_place.as_ref()?;
+        if b.region.0 != r.assigned_at {
+            return None;
+        }
+        let lender_name = r.lender.real_name();
+        // MIR's `borrowed_place().local_or_deref_local()` only gives
+        // back the base Local for a place — for `&r.a.b` it returns
+        // the name `r`, not `r.a.b`. Our lender name is the full
+        // dotted path (`r.a.b`). Accept a match when MIR's name is
+        // either exactly equal OR is a path prefix terminated by `.`
+        // (so `r` matches `r.a.b` but not `roar.a.b`). Without this
+        // any borrow rooted at a struct field skips MIR refinement
+        // and the lifetime stays pinned to the assignment line —
+        // which makes the dotted ref-line render with zero height
+        // when the only use of the borrower is inside a macro
+        // (where visit_expr can't reach the Path to extend it
+        // through update_rap).
+        if *mir_place == lender_name {
+            return Some(b.region.1);
+        }
+        if lender_name.starts_with(mir_place)
+            && lender_name.as_bytes().get(mir_place.len()) == Some(&b'.')
+        {
+            return Some(b.region.1);
         }
         None
     }

--- a/rustviz-plugin/tests/field_method_call.rs
+++ b/rustviz-plugin/tests/field_method_call.rs
@@ -1,0 +1,11 @@
+// Regression for #71: chaining a method call onto a struct field.
+// Should emit `push_str reads from/writes to r.s` (the
+// PassByMutableReference path).
+
+struct R { s: String }
+
+fn main() {
+    let mut r = R { s: String::from("hi") };
+    r.s.push_str("!");
+    println!("{}", r.s);
+}

--- a/rustviz-plugin/tests/field_through_ref.rs
+++ b/rustviz-plugin/tests/field_through_ref.rs
@@ -1,0 +1,11 @@
+// Regression for #73: borrowing a field through a reference.
+// `&(&r).s` should produce the same arrows as `&r.s` —
+// `Immutable borrow from r.s to p`.
+
+struct R { s: String }
+
+fn main() {
+    let r = R { s: String::from("hi") };
+    let p = &(&r).s;
+    println!("{}", p);
+}

--- a/rustviz-plugin/tests/nested_struct_borrow.rs
+++ b/rustviz-plugin/tests/nested_struct_borrow.rs
@@ -1,0 +1,11 @@
+// Regression for #72: borrowing a nested struct field.
+// Should emit `Immutable borrow from r.a.b to p`.
+
+struct A { b: String }
+struct R { a: A }
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    let p = &r.a.b;
+    println!("{}", p);
+}

--- a/rustviz-plugin/tests/nested_struct_move.rs
+++ b/rustviz-plugin/tests/nested_struct_move.rs
@@ -1,0 +1,11 @@
+// Regression for #72: moving a nested struct field by value.
+// Should emit `Move from r.a.b to x`.
+
+struct A { b: String }
+struct R { a: A }
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    let x = r.a.b;
+    println!("{}", x);
+}

--- a/rustviz-plugin/tests/nested_struct_passref.rs
+++ b/rustviz-plugin/tests/nested_struct_passref.rs
@@ -1,0 +1,13 @@
+// Regression for #72: passing the inner struct of a nested type
+// to a free function by reference. Should emit
+// `read_a reads from r.a` (the PassByStaticReference path).
+
+struct A { b: String }
+struct R { a: A }
+
+fn read_a(_x: &A) {}
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    read_a(&r.a);
+}


### PR DESCRIPTION
Fixes #72.

## What was happening
\`define_lhs\` already iterated a struct's fields and registered each as a RAP under \`<parent>.<field>\`, but it stopped one level deep — when a field's type was itself a struct (e.g. \`R { a: A { b: ... } }\`) it added \`r.a\` and walked away. \`r.a.b\` was never in \`raps\`, so any reference to it (read, borrow, move, pass-by-ref) hit a field-arm lookup that returned \`Anonymous\` (since #83's defensive fix) and the event was silently dropped.

## Fix
Refactor the per-field iteration into a new \`register_struct_members\` helper and recurse for fields whose type is itself a non-special struct ADT. Nested members keep the outermost struct's hash as their timeline \`owner\` so the renderer groups the whole tree under one struct panel, matching how flat struct members already behave today. Enums, unions, and special-owner builtins (\`String\`, \`Vec\`, ...) are deliberately excluded — only owned struct ADTs flatten.

After this, the four nested-field event shapes #72 calls out all render correctly:

| Snippet | Arrow now emitted |
|---|---|
| \`let p = &r.a.b;\` | \`Immutable borrow from r.a.b to p\` |
| \`let x = r.a.b;\` | \`Move from r.a.b to x\` |
| \`f(&r.a);\` | \`f reads from r.a\` |
| \`r.a.b\` in any tracked expression | owner-acquire and go-out-of-scope events on the \`r.a.b\` column |

## Tests
You asked for proper unit tests, not one-shot manual verification. Reused the existing corpus infrastructure (\`rustviz-plugin/tests/\` snippets + \`rustviz-lib/tests/corpus.rs\` integration test):

- New corpus snippets for #71, #72, #73 reproductions: \`nested_struct_borrow.rs\`, \`nested_struct_move.rs\`, \`nested_struct_passref.rs\`, \`field_method_call.rs\`, \`field_through_ref.rs\`. Each is a minimal Rust program that exercises one shape.
- New \`corpus_expected_arrows_present\` test in \`corpus.rs\` that extracts arrow tooltip strings from the rendered timeline and asserts the listed tooltips appear (containment check, so adding new tracked events doesn't break the test).
- Original \`corpus_expected_ok_produce_well_formed_svg\` still runs over the same snippets as a structural floor.

\`cargo test -p rustviz-lib --test corpus\` — both tests pass locally.

## Test plan
- [x] Both corpus tests pass locally
- [x] Dropdown's Rectangle, Excerpt (lifetime + ref-typed field), and Hands-on tutorial examples still render unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)