### PR TITLE
tests: thorough corpus coverage of supported visualization features

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -2,18 +2,24 @@
 //!
 //! Each .rs file in the corpus is a Rust program the plugin should be able
 //! to visualize. We don't pin exact SVG output (it's noisy and changes with
-//! benign tweaks); instead we assert on structural properties:
+//! benign tweaks); instead we assert on three layers:
 //!
-//!   * `code_panel_string()` and `timeline_panel_string()` return well-formed
-//!     SVG (start with `<svg`).
-//!   * The timeline contains at least one `tooltip-trigger` element (so the
-//!     plugin produced *some* annotations rather than an empty timeline).
+//!   * `corpus_expected_ok_produce_well_formed_svg` — the regression floor.
+//!     Every `EXPECTED_OK` snippet returns well-formed SVG (`<svg ...`) for
+//!     both panels and the timeline carries at least one `tooltip-trigger`
+//!     element (i.e. the plugin produced *some* annotations).
 //!
-//! The curated `EXPECTED_OK` list is the regression floor: anything that
-//! passes today should keep passing. New cases get added as we confirm them.
-//! Cases known to exercise unsupported features (for-loops, conditional
-//! borrows, etc. — see README "Limitations") deliberately stay off this
-//! list; failures there are not regressions.
+//!   * `corpus_expected_tooltips_present` — the behaviour bar. For every
+//!     entry in `EXPECTED_TOOLTIPS`, the listed `must_contain` strings must
+//!     appear verbatim as `data-tooltip-text` values in the rendered
+//!     timeline, and the `must_not_contain` strings must *not* appear.
+//!     Containment semantics on both sides — extra tooltips are fine, only
+//!     the listed ones are load-bearing.
+//!
+//!   * For features known to be unsupported (for-loops, conditional borrows,
+//!     smart pointers, etc. — see README "Limitations") snippets stay off
+//!     these lists; failures there aren't regressions until the feature is
+//!     implemented.
 //!
 //! These tests use the `RV_RUNNER=local` backend, which requires
 //! `cargo install --path rustviz-plugin --locked` to have been run first.
@@ -28,7 +34,11 @@ use rustviz_lib::Rustviz;
 /// Curated subset that should always succeed end-to-end. Each entry is the
 /// stem of a file in `../rustviz-plugin/tests/`. Keep this list small and
 /// representative; it's the regression floor.
+///
+/// Snippets are grouped by feature area in source order so a glance at
+/// the list shows which categories are covered.
 const EXPECTED_OK: &[&str] = &[
+    // — Existing canon: ownership / move / copy / basic refs.
     "testMove",
     "testNum",
     "basic_ref",
@@ -37,54 +47,326 @@ const EXPECTED_OK: &[&str] = &[
     "ownershipFunctions",
     "testStaticB",
     "testMutB",
-    // Field-projection / nested-struct cases — see expected-arrows
-    // table below for the per-snippet shape we're locking in.
+    // — Field-projection cases (added with #84).
     "nested_struct_borrow",
     "nested_struct_move",
     "nested_struct_passref",
     "field_method_call",
     "field_through_ref",
+    // — References: more nuanced shapes.
+    "reborrow",
+    "nll_two_borrows",
+    // — Reassignment / move-out / take-and-return.
+    "reassign_with_drop",
+    "move_return",
+    "take_and_return",
+    // — Stdlib method calls.
+    "string_push_str",
+    "string_len",
+    // — User-defined inherent methods.
+    "inherent_method_rectangle",
+    // — Lifetime annotations.
+    "lifetime_excerpt",
+    // — Generics.
+    "generic_fn",
+    // — Shadowing.
+    "shadowing_basic",
+    // — Marker comments (skip on let, hide on fn).
+    "skip_marker_let",
+    "hide_marker_fn",
+    // — Conditionals as expression RHS (the supported subset).
+    "if_as_let_rhs",
 ];
 
-/// Specific arrow tooltips each snippet must produce. The check is
-/// containment (extra arrows are fine), so adding new tracked events
-/// to the plugin doesn't break these tests — only removing the
-/// listed ones does. Each tuple is (snippet stem, list of expected
-/// arrow tooltips, in-source order doesn't matter).
-///
-/// "Arrow tooltip" = the human-readable string the renderer puts on
-/// the `data-tooltip-text` attribute of an arrow `<g>`. We compare
-/// the un-HTML-escaped form so multi-segment names like `r.a.b` and
-/// punctuation render naturally.
-///
-/// These tests are the regression bar for issues #71 (`r.s.method()`),
-/// #72 (nested-struct reads / borrows / moves), and #73 (`(&r).s`).
-const EXPECTED_ARROWS: &[(&str, &[&str])] = &[
-    // #72
-    ("nested_struct_borrow", &[
-        "Move from String::from to r.a.b",
-        "Immutable borrow from r.a.b to p",
-        "Return immutably borrowed resource from p to r.a.b",
-    ]),
-    ("nested_struct_move", &[
-        "Move from String::from to r.a.b",
-        "Move from r.a.b to x",
-    ]),
-    ("nested_struct_passref", &[
-        "Move from String::from to r.a.b",
-        "read_a reads from r.a",
-    ]),
-    // #71
-    ("field_method_call", &[
-        "Move from String::from to r.s",
-        "push_str reads from/writes to r.s",
-    ]),
-    // #73
-    ("field_through_ref", &[
-        "Move from String::from to r.s",
-        "Immutable borrow from r.s to p",
-        "Return immutably borrowed resource from p to r.s",
-    ]),
+/// Tooltip-level expectations per snippet. `must_contain` strings have to
+/// appear verbatim as a `data-tooltip-text` value somewhere in the rendered
+/// timeline; `must_not_contain` strings must not. Both checks are
+/// containment, so adding new tooltips downstream doesn't break the test —
+/// only removing a listed one (or producing one that's been forbidden) does.
+struct TooltipExpect {
+    name: &'static str,
+    must_contain: &'static [&'static str],
+    must_not_contain: &'static [&'static str],
+}
+
+const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
+    // ─── Ownership / moves / copies ──────────────────────────────────
+    TooltipExpect {
+        name: "testMove",
+        must_contain: &[
+            "Move from String::from to s",
+            "Move from s to takes_and_drops",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "ownershipFunctions",
+        must_contain: &[
+            "Move from String::from to s",
+            "Move from s to takes_ownership",
+            "Copy from x to makes_copy",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "copy2Caller",
+        must_contain: &[
+            "Copy from f to x",
+            "y's resource is moved to the caller",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "reassign_with_drop",
+        must_contain: &[
+            "Move from x to y",
+            "y acquires ownership of a new resource; its previous resource is dropped",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── References: borrow + return ─────────────────────────────────
+    TooltipExpect {
+        name: "basic_ref",
+        must_contain: &[
+            "Immutable borrow from x to y",
+            "Return immutably borrowed resource from y to x",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "basic_mutref",
+        must_contain: &[
+            "Mutable borrow from x to y",
+            "Return mutably borrowed resource from y to x",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "testStaticB",
+        must_contain: &[
+            "Move from String::from to my_string",
+            "Immutable borrow from my_string to my_str",
+            "Return immutably borrowed resource from my_str to my_string",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "testMutB",
+        must_contain: &[
+            "Move from String::from to greeting",
+            "Mutable borrow from greeting to r1",
+            "Return mutably borrowed resource from r1 to greeting",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "reborrow",
+        must_contain: &[
+            "Mutable borrow from s to r",
+            "Mutable borrow from r to r2",
+            "Return mutably borrowed resource from r2 to *r",
+            "Return mutably borrowed resource from r to s",
+            "push_str reads from/writes to r2",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "nll_two_borrows",
+        // Two consecutive &mut borrows, with the loan released between
+        // them. The renderer should draw both borrow-and-return pairs
+        // and a fn-call interaction at each `world(...)` site.
+        must_contain: &[
+            "Mutable borrow from x to y",
+            "Return mutably borrowed resource from y to x",
+            "Mutable borrow from x to z",
+            "Return mutably borrowed resource from z to x",
+            "world reads from/writes to y",
+            "world reads from/writes to z",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Field-projection cases (regression bar for #71/#72/#73) ─────
+    TooltipExpect {
+        name: "nested_struct_borrow",
+        must_contain: &[
+            "Move from String::from to r.a.b",
+            "Immutable borrow from r.a.b to p",
+            "Return immutably borrowed resource from p to r.a.b",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "nested_struct_move",
+        must_contain: &[
+            "Move from String::from to r.a.b",
+            "Move from r.a.b to x",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "nested_struct_passref",
+        must_contain: &[
+            "Move from String::from to r.a.b",
+            "read_a reads from r.a",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "field_method_call",
+        must_contain: &[
+            "Move from String::from to r.s",
+            "push_str reads from/writes to r.s",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "field_through_ref",
+        must_contain: &[
+            "Move from String::from to r.s",
+            "Immutable borrow from r.s to p",
+            "Return immutably borrowed resource from p to r.s",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Function calls / returns ────────────────────────────────────
+    TooltipExpect {
+        name: "move_return",
+        must_contain: &[
+            "Move from String::from to s",
+            "s's resource is moved to the caller",
+            "Move from make to r",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "take_and_return",
+        must_contain: &[
+            "Move from s to take_and_return",
+            "Move from take_and_return to s",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Stdlib method calls ────────────────────────────────────────
+    TooltipExpect {
+        name: "string_push_str",
+        // `&mut self` method → PassByMutableReference — rendered as
+        // "X reads from/writes to Y" on the fn-icon dot.
+        must_contain: &[
+            "Move from String::from to s",
+            "push_str reads from/writes to s",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "string_len",
+        // `&self` method → PassByStaticReference — "X reads from Y" on
+        // the fn-icon dot. The Copy return value lands in n.
+        must_contain: &[
+            "Move from String::from to s",
+            "len reads from s",
+            "Copy from len to n",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── User-defined inherent methods ──────────────────────────────
+    TooltipExpect {
+        name: "inherent_method_rectangle",
+        // The Rectangle/area pattern is the canonical "method on a
+        // user struct" shape we know works. We don't test for r.area's
+        // call-site arrow today — see #74 for the ref-arg-call-site
+        // PassByRef arrow that doesn't render yet.
+        must_contain: &[
+            "print_area reads from r",
+            "r acquires ownership of a resource",
+            "r goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Lifetimes ──────────────────────────────────────────────────
+    TooltipExpect {
+        name: "lifetime_excerpt",
+        // Excerpt<'a> { p: &'a str } — `e.p` is rendered as a borrower
+        // of `s`. Borrow + matching return both appear.
+        must_contain: &[
+            "Move from String::from to s",
+            "Immutable borrow from s to e.p",
+            "Return immutably borrowed resource from e.p to s",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Generics ───────────────────────────────────────────────────
+    TooltipExpect {
+        name: "generic_fn",
+        must_contain: &[
+            "Move from s to id",
+            "Move from id to t",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Shadowing ──────────────────────────────────────────────────
+    TooltipExpect {
+        name: "shadowing_basic",
+        // Both `let s = ...` lines should bind a String to `s`. The
+        // first `s` is dropped at the shadow site.
+        must_contain: &[
+            "Move from String::from to s",
+            "s goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[],
+    },
+
+    // ─── Marker comments (skip / hide) ──────────────────────────────
+    TooltipExpect {
+        name: "skip_marker_let",
+        // `let q = ...; // rustviz: skip` — every event touching `q`
+        // is dropped. The rendered timeline must mention `s` but never
+        // `q`.
+        must_contain: &[
+            "Move from String::from to s",
+            "s goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[
+            "q acquires ownership of a resource",
+            "q goes out of scope. Its resource is dropped.",
+            "Move from String::from to q",
+        ],
+    },
+    TooltipExpect {
+        name: "hide_marker_fn",
+        // `// rustviz: hide` on `helper` — the call-site `Move s ->
+        // helper` arrow still fires (Function RAP created at the call
+        // site), but `helper`'s body isn't traversed so its
+        // `some_string` parameter never appears as a column / state.
+        must_contain: &[
+            "Move from String::from to s",
+            "Move from s to helper",
+        ],
+        must_not_contain: &[
+            "some_string acquires ownership from the caller",
+            "some_string goes out of scope. Its resource is dropped.",
+        ],
+    },
+
+    // ─── Conditionals as expression RHS ─────────────────────────────
+    TooltipExpect {
+        name: "if_as_let_rhs",
+        // `let s = if cond { String::from(..) } else { String::from(..) };`
+        // Both branches' moves into `s` show up; `s` ends up the
+        // owner regardless of branch.
+        must_contain: &[
+            "Move from String::from to s",
+            "s goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[],
+    },
 ];
 
 fn corpus_dir() -> PathBuf {
@@ -146,32 +428,31 @@ fn assert_well_formed(name: &str, rv: &Rustviz) {
     );
 }
 
-/// Extract every arrow tooltip from a rendered timeline panel.
+/// Extract every tooltip text from a rendered timeline panel.
 ///
-/// The renderer wraps each arrow in `<g class="tooltip-trigger"
-/// data-tooltip-text="...">` inside `<g id="arrows">`. Tooltip text
-/// is HTML-escaped (`&lt;` / `&gt;` / `&quot;`) and contains nested
-/// `<span>` markup that we strip before comparing — what we want is
-/// the human-visible string ("Immutable borrow from r.a.b to p").
-fn arrow_tooltips(timeline_svg: &str) -> Vec<String> {
-    let arrows_start = match timeline_svg.find("<g id=\"arrows\">") {
-        Some(i) => i,
-        None => return Vec::new(),
-    };
-    let body = &timeline_svg[arrows_start..];
+/// The renderer attaches `data-tooltip-text="..."` to many element
+/// kinds: arrows in `<g id="arrows">`, dots in `<g id="events">`,
+/// state-message vertical lines, column labels, function-icon dots,
+/// etc. We pull all of them and let the per-snippet expectations
+/// pick out the ones that matter — that way a test for "the
+/// `len reads from s` interaction" doesn't have to know whether
+/// the renderer puts that on a dot vs. an arrow.
+///
+/// The renderer HTML-escapes the tooltip body and embeds nested
+/// `<span>` markup for the variable-name color spans; both get
+/// stripped here so comparisons are against the plain visible text.
+fn timeline_tooltips(timeline_svg: &str) -> Vec<String> {
     let mut out = Vec::new();
-    for chunk in body.split("data-tooltip-text=\"").skip(1) {
+    for chunk in timeline_svg.split("data-tooltip-text=\"").skip(1) {
         let raw = match chunk.find('"') {
             Some(end) => &chunk[..end],
             None => continue,
         };
-        // Un-HTML-escape the small set the renderer emits.
         let unescaped = raw
             .replace("&lt;", "<")
             .replace("&gt;", ">")
             .replace("&quot;", "\"")
             .replace("&amp;", "&");
-        // Strip nested span markup; what's left is the visible text.
         let mut clean = String::with_capacity(unescaped.len());
         let mut in_tag = false;
         for ch in unescaped.chars() {
@@ -182,45 +463,6 @@ fn arrow_tooltips(timeline_svg: &str) -> Vec<String> {
         out.push(clean);
     }
     out
-}
-
-#[test]
-fn corpus_expected_arrows_present() {
-    let mut failures = Vec::new();
-    for (name, expected) in EXPECTED_ARROWS {
-        let res = std::panic::catch_unwind(|| {
-            let rv = run_with_local_backend(name);
-            let actual = arrow_tooltips(&rv.timeline_panel_string());
-            let mut missing: Vec<&str> = Vec::new();
-            for want in *expected {
-                if !actual.iter().any(|a| a == want) {
-                    missing.push(*want);
-                }
-            }
-            if !missing.is_empty() {
-                panic!(
-                    "missing arrows {:?}; actual arrows were:\n  {}",
-                    missing,
-                    actual.join("\n  ")
-                );
-            }
-        });
-        if let Err(payload) = res {
-            let msg = payload
-                .downcast_ref::<String>()
-                .cloned()
-                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
-                .unwrap_or_else(|| "<non-string panic>".to_string());
-            failures.push(format!("{}: {}", name, msg));
-        }
-    }
-    assert!(
-        failures.is_empty(),
-        "{} of {} arrow assertions failed:\n  {}",
-        failures.len(),
-        EXPECTED_ARROWS.len(),
-        failures.join("\n  ")
-    );
 }
 
 #[test]
@@ -249,6 +491,60 @@ fn corpus_expected_ok_produce_well_formed_svg() {
         "{} of {} corpus cases regressed:\n  {}",
         failures.len(),
         EXPECTED_OK.len(),
+        failures.join("\n  ")
+    );
+}
+
+#[test]
+fn corpus_expected_tooltips_present() {
+    let mut failures = Vec::new();
+    for expect in EXPECTED_TOOLTIPS {
+        let res = std::panic::catch_unwind(|| {
+            let rv = run_with_local_backend(expect.name);
+            let actual = timeline_tooltips(&rv.timeline_panel_string());
+
+            let missing: Vec<&str> = expect
+                .must_contain
+                .iter()
+                .copied()
+                .filter(|want| !actual.iter().any(|a| a == want))
+                .collect();
+            let unexpected: Vec<&str> = expect
+                .must_not_contain
+                .iter()
+                .copied()
+                .filter(|forbid| actual.iter().any(|a| a == forbid))
+                .collect();
+
+            if !missing.is_empty() || !unexpected.is_empty() {
+                let mut msg = String::new();
+                if !missing.is_empty() {
+                    msg.push_str(&format!("missing {:?}; ", missing));
+                }
+                if !unexpected.is_empty() {
+                    msg.push_str(&format!("unexpectedly present {:?}; ", unexpected));
+                }
+                msg.push_str(&format!(
+                    "actual tooltips were:\n  {}",
+                    actual.join("\n  ")
+                ));
+                panic!("{}", msg);
+            }
+        });
+        if let Err(payload) = res {
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "<non-string panic>".to_string());
+            failures.push(format!("{}: {}", expect.name, msg));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} tooltip assertions failed:\n  {}",
+        failures.len(),
+        EXPECTED_TOOLTIPS.len(),
         failures.join("\n  ")
     );
 }

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -37,6 +37,54 @@ const EXPECTED_OK: &[&str] = &[
     "ownershipFunctions",
     "testStaticB",
     "testMutB",
+    // Field-projection / nested-struct cases — see expected-arrows
+    // table below for the per-snippet shape we're locking in.
+    "nested_struct_borrow",
+    "nested_struct_move",
+    "nested_struct_passref",
+    "field_method_call",
+    "field_through_ref",
+];
+
+/// Specific arrow tooltips each snippet must produce. The check is
+/// containment (extra arrows are fine), so adding new tracked events
+/// to the plugin doesn't break these tests — only removing the
+/// listed ones does. Each tuple is (snippet stem, list of expected
+/// arrow tooltips, in-source order doesn't matter).
+///
+/// "Arrow tooltip" = the human-readable string the renderer puts on
+/// the `data-tooltip-text` attribute of an arrow `<g>`. We compare
+/// the un-HTML-escaped form so multi-segment names like `r.a.b` and
+/// punctuation render naturally.
+///
+/// These tests are the regression bar for issues #71 (`r.s.method()`),
+/// #72 (nested-struct reads / borrows / moves), and #73 (`(&r).s`).
+const EXPECTED_ARROWS: &[(&str, &[&str])] = &[
+    // #72
+    ("nested_struct_borrow", &[
+        "Move from String::from to r.a.b",
+        "Immutable borrow from r.a.b to p",
+        "Return immutably borrowed resource from p to r.a.b",
+    ]),
+    ("nested_struct_move", &[
+        "Move from String::from to r.a.b",
+        "Move from r.a.b to x",
+    ]),
+    ("nested_struct_passref", &[
+        "Move from String::from to r.a.b",
+        "read_a reads from r.a",
+    ]),
+    // #71
+    ("field_method_call", &[
+        "Move from String::from to r.s",
+        "push_str reads from/writes to r.s",
+    ]),
+    // #73
+    ("field_through_ref", &[
+        "Move from String::from to r.s",
+        "Immutable borrow from r.s to p",
+        "Return immutably borrowed resource from p to r.s",
+    ]),
 ];
 
 fn corpus_dir() -> PathBuf {
@@ -95,6 +143,83 @@ fn assert_well_formed(name: &str, rv: &Rustviz) {
         timeline.contains("tooltip-trigger"),
         "{}: timeline has no tooltip-trigger elements (annotations missing)",
         name
+    );
+}
+
+/// Extract every arrow tooltip from a rendered timeline panel.
+///
+/// The renderer wraps each arrow in `<g class="tooltip-trigger"
+/// data-tooltip-text="...">` inside `<g id="arrows">`. Tooltip text
+/// is HTML-escaped (`&lt;` / `&gt;` / `&quot;`) and contains nested
+/// `<span>` markup that we strip before comparing — what we want is
+/// the human-visible string ("Immutable borrow from r.a.b to p").
+fn arrow_tooltips(timeline_svg: &str) -> Vec<String> {
+    let arrows_start = match timeline_svg.find("<g id=\"arrows\">") {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let body = &timeline_svg[arrows_start..];
+    let mut out = Vec::new();
+    for chunk in body.split("data-tooltip-text=\"").skip(1) {
+        let raw = match chunk.find('"') {
+            Some(end) => &chunk[..end],
+            None => continue,
+        };
+        // Un-HTML-escape the small set the renderer emits.
+        let unescaped = raw
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&amp;", "&");
+        // Strip nested span markup; what's left is the visible text.
+        let mut clean = String::with_capacity(unescaped.len());
+        let mut in_tag = false;
+        for ch in unescaped.chars() {
+            if ch == '<' { in_tag = true; continue; }
+            if ch == '>' { in_tag = false; continue; }
+            if !in_tag { clean.push(ch); }
+        }
+        out.push(clean);
+    }
+    out
+}
+
+#[test]
+fn corpus_expected_arrows_present() {
+    let mut failures = Vec::new();
+    for (name, expected) in EXPECTED_ARROWS {
+        let res = std::panic::catch_unwind(|| {
+            let rv = run_with_local_backend(name);
+            let actual = arrow_tooltips(&rv.timeline_panel_string());
+            let mut missing: Vec<&str> = Vec::new();
+            for want in *expected {
+                if !actual.iter().any(|a| a == want) {
+                    missing.push(*want);
+                }
+            }
+            if !missing.is_empty() {
+                panic!(
+                    "missing arrows {:?}; actual arrows were:\n  {}",
+                    missing,
+                    actual.join("\n  ")
+                );
+            }
+        });
+        if let Err(payload) = res {
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "<non-string panic>".to_string());
+            failures.push(format!("{}: {}", name, msg));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} arrow assertions failed:\n  {}",
+        failures.len(),
+        EXPECTED_ARROWS.len(),
+        failures.join("\n  ")
     );
 }
 

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -546,54 +546,13 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
           let owner_hash = self.rap_hashes as u64;
           let parent_is_copy = self.ty_is_copy(ty, expr.hir_id.owner);
           self.add_struct(name.clone(), owner_hash, false, mutability, parent_is_copy, self.current_scope,!self.inside_branch);
-          // Resolve each field's substituted type so we can tell
-          // which fields are references (a `Excerpt<'a> { p: &'a
-          // str }` has p: &str at construction time, modelled as
-          // a StaticRef RAP that's a member of the parent struct)
-          // versus owned values (registered as Struct members
-          // exactly as before).
-          let generic_args = match ty.kind() {
-            TyKind::Adt(_, args) => *args,
-            _ => unreachable!("ty.is_adt() but kind is not Adt"),
-          };
-          for field in ty.ty_adt_def().unwrap().all_fields() {
-            let field_name = format!("{}.{}", name.clone(), field.name.as_str());
-            let field_ty = field.ty(self.tcx, generic_args);
-            if field_ty.is_ref() {
-              let ref_mutability = bool_of_mut(field_ty.ref_mutability().unwrap());
-              // The field's lender is whatever the user passed in
-              // for that field at the construction site; we wire
-              // that up later in match_rhs's Struct arm via the
-              // already-computed get_ref_data path. For now, seed
-              // borrow_map with Anonymous lender as a placeholder
-              // so the renderer can still draw the ref-line; the
-              // Struct arm will overwrite it.
-              if ref_mutability {
-                self.add_mut_ref_member(field_name.clone(), mutability,
-                    self.current_scope, !self.inside_branch, Some(owner_hash));
-              } else {
-                self.add_static_ref_member(field_name.clone(), mutability,
-                    self.current_scope, !self.inside_branch, Some(owner_hash));
-              }
-              // The borrow stored in this field is alive for as
-              // long as the parent struct is — so the loan
-              // extends to the end of the enclosing scope, same
-              // policy as fn-param refs which also borrow for
-              // the full body. Without this the ref-line
-              // trapezoid collapses (assigned_at == lifetime).
-              self.borrow_map.insert(field_name, RefData {
-                lender: ResourceTy::Anonymous,
-                assigned_at: expr_to_line(&expr, &self.tcx),
-                lifetime: self.current_scope,
-                ref_mutability,
-                aliasing: VecDeque::new(),
-              });
-            } else {
-              let field_is_copy = self.ty_is_copy(field_ty, expr.hir_id.owner);
-              self.add_struct(field_name, owner_hash, true, mutability, field_is_copy,
-                  self.current_scope, !self.inside_branch);
-            }
-          }
+          self.register_struct_members(
+            &name,
+            ty,
+            owner_hash,
+            mutability,
+            expr,
+          );
         },
         AdtKind::Union => {
           warn!("lhs union not implemented yet")
@@ -610,6 +569,84 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     else {
       let is_copy = self.ty_is_copy(ty, expr.hir_id.owner);
       self.add_owner(name, mutability, is_copy, self.current_scope, !self.inside_branch);
+    }
+  }
+
+  /// Register `prefix.field` RAPs for every field of a struct type,
+  /// recursing into nested structs so accesses like `r.a.b` resolve.
+  ///
+  /// `top_owner_hash` is the timeline-grouping key for the outermost
+  /// struct — every nested member shares it so the renderer keeps
+  /// the whole tree under a single struct group, the same way flat
+  /// struct members already share their parent's group today.
+  ///
+  /// Reference fields (e.g. `Excerpt<'a> { p: &'a str }`) get the
+  /// same StaticRef/MutRef-member treatment as before, with a
+  /// placeholder Anonymous lender that the Struct arm of `match_rhs`
+  /// overwrites once it sees the construction-site initializer.
+  /// Owned struct fields recurse so `r.a.b.c` etc. land in `raps`
+  /// under their qualified names; Field-arm lookups in
+  /// `expr_visitor_utils` then find them and emit events instead of
+  /// silently giving up.
+  fn register_struct_members(
+    &mut self,
+    prefix: &str,
+    ty: Ty<'tcx>,
+    top_owner_hash: u64,
+    mutability: bool,
+    construction_expr: &'tcx Expr<'tcx>,
+  ) {
+    let generic_args = match ty.kind() {
+      TyKind::Adt(_, args) => *args,
+      _ => unreachable!("register_struct_members called with non-Adt ty"),
+    };
+    let owner_id = construction_expr.hir_id.owner;
+    let assigned_at = expr_to_line(&construction_expr, &self.tcx);
+    for field in ty.ty_adt_def().unwrap().all_fields() {
+      let field_name = format!("{}.{}", prefix, field.name.as_str());
+      let field_ty = field.ty(self.tcx, generic_args);
+      if field_ty.is_ref() {
+        let ref_mutability = bool_of_mut(field_ty.ref_mutability().unwrap());
+        if ref_mutability {
+          self.add_mut_ref_member(field_name.clone(), mutability,
+              self.current_scope, !self.inside_branch, Some(top_owner_hash));
+        } else {
+          self.add_static_ref_member(field_name.clone(), mutability,
+              self.current_scope, !self.inside_branch, Some(top_owner_hash));
+        }
+        // Same lender-placeholder rationale as the flat case before
+        // the refactor: borrow stored in this field outlives the
+        // statement, so stretch the loan to the enclosing scope so
+        // the ref-line trapezoid actually has a non-degenerate range.
+        self.borrow_map.insert(field_name, RefData {
+          lender: ResourceTy::Anonymous,
+          assigned_at,
+          lifetime: self.current_scope,
+          ref_mutability,
+          aliasing: VecDeque::new(),
+        });
+      } else {
+        let field_is_copy = self.ty_is_copy(field_ty, owner_id);
+        self.add_struct(field_name.clone(), top_owner_hash, true, mutability, field_is_copy,
+            self.current_scope, !self.inside_branch);
+        // Recurse for nested struct fields. Skip enums / unions
+        // (only struct ADTs are flattened today) and skip the
+        // special-owner builtins like `String` whose internals
+        // we deliberately don't expose.
+        if field_ty.is_adt() && !ty_is_special_owner(&self.tcx, &field_ty) {
+          if let Some(adt_def) = field_ty.ty_adt_def() {
+            if matches!(adt_def.adt_kind(), AdtKind::Struct) {
+              self.register_struct_members(
+                &field_name,
+                field_ty,
+                top_owner_hash,
+                mutability,
+                construction_expr,
+              );
+            }
+          }
+        }
+      }
     }
   }
 

--- a/rustviz-plugin/tests/field_method_call.rs
+++ b/rustviz-plugin/tests/field_method_call.rs
@@ -1,0 +1,11 @@
+// Regression for #71: chaining a method call onto a struct field.
+// Should emit `push_str reads from/writes to r.s` (the
+// PassByMutableReference path).
+
+struct R { s: String }
+
+fn main() {
+    let mut r = R { s: String::from("hi") };
+    r.s.push_str("!");
+    println!("{}", r.s);
+}

--- a/rustviz-plugin/tests/field_through_ref.rs
+++ b/rustviz-plugin/tests/field_through_ref.rs
@@ -1,0 +1,11 @@
+// Regression for #73: borrowing a field through a reference.
+// `&(&r).s` should produce the same arrows as `&r.s` —
+// `Immutable borrow from r.s to p`.
+
+struct R { s: String }
+
+fn main() {
+    let r = R { s: String::from("hi") };
+    let p = &(&r).s;
+    println!("{}", p);
+}

--- a/rustviz-plugin/tests/generic_fn.rs
+++ b/rustviz-plugin/tests/generic_fn.rs
@@ -1,0 +1,12 @@
+// A generic identity function. The String passed in moves to the
+// parameter, then moves back to the caller as the return value.
+
+fn id<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    let s = String::from("hi");
+    let t = id(s);
+    println!("{}", t);
+}

--- a/rustviz-plugin/tests/hide_marker_fn.rs
+++ b/rustviz-plugin/tests/hide_marker_fn.rs
@@ -1,0 +1,13 @@
+// `// rustviz: hide` on a fn signature removes the entire fn from
+// the rendered code panel and bypasses body traversal — but call
+// sites in non-hidden fns still emit their move arrow into the
+// hidden fn's Function RAP.
+
+fn main() {
+    let s = String::from("hi");
+    helper(s);
+}
+
+fn helper(some_string: String) { // rustviz: hide
+    println!("{}", some_string);
+}

--- a/rustviz-plugin/tests/if_as_let_rhs.rs
+++ b/rustviz-plugin/tests/if_as_let_rhs.rs
@@ -1,0 +1,10 @@
+// `if`/`else` as the RHS of a `let`. The plugin doesn't track
+// borrows *inside* a conditional body (see Limitations) but using
+// the conditional as an expression that produces a value into a
+// `let` is supported.
+
+fn main() {
+    let n = 3;
+    let s = if n > 0 { String::from("a") } else { String::from("b") };
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/inherent_method_rectangle.rs
+++ b/rustviz-plugin/tests/inherent_method_rectangle.rs
@@ -1,0 +1,23 @@
+// Inherent method on a user struct (Rectangle/area pattern).
+// Calling `r.area()` (which takes `&self` and reads two fields)
+// is the canonical "user-defined method" shape we know works.
+
+struct Rectangle {
+    width: u32,
+    height: u32,
+}
+
+impl Rectangle {
+    fn area(&self) -> u32 {
+        self.width * self.height
+    }
+}
+
+fn print_area(rect: &Rectangle) {
+    println!("{}", rect.area());
+}
+
+fn main() {
+    let r = Rectangle { width: 30, height: 50 };
+    print_area(&r);
+}

--- a/rustviz-plugin/tests/lifetime_excerpt.rs
+++ b/rustviz-plugin/tests/lifetime_excerpt.rs
@@ -1,0 +1,13 @@
+// A struct with a lifetime parameter holding a borrow of another
+// String. The canonical lifetime-annotation example from the
+// tutorial. The plugin tracks `e.p` as a borrow of `s`.
+
+struct Excerpt<'a> {
+    p: &'a str,
+}
+
+fn main() {
+    let s = String::from("hello");
+    let e = Excerpt { p: &s };
+    println!("{}", e.p);
+}

--- a/rustviz-plugin/tests/move_return.rs
+++ b/rustviz-plugin/tests/move_return.rs
@@ -1,0 +1,11 @@
+// A function returns ownership; the caller binds the returned value.
+
+fn make() -> String {
+    let s = String::from("hi");
+    s
+}
+
+fn main() {
+    let r = make();
+    println!("{}", r);
+}

--- a/rustviz-plugin/tests/nested_struct_borrow.rs
+++ b/rustviz-plugin/tests/nested_struct_borrow.rs
@@ -1,0 +1,11 @@
+// Regression for #72: borrowing a nested struct field.
+// Should emit `Immutable borrow from r.a.b to p`.
+
+struct A { b: String }
+struct R { a: A }
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    let p = &r.a.b;
+    println!("{}", p);
+}

--- a/rustviz-plugin/tests/nested_struct_move.rs
+++ b/rustviz-plugin/tests/nested_struct_move.rs
@@ -1,0 +1,11 @@
+// Regression for #72: moving a nested struct field by value.
+// Should emit `Move from r.a.b to x`.
+
+struct A { b: String }
+struct R { a: A }
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    let x = r.a.b;
+    println!("{}", x);
+}

--- a/rustviz-plugin/tests/nested_struct_passref.rs
+++ b/rustviz-plugin/tests/nested_struct_passref.rs
@@ -1,0 +1,13 @@
+// Regression for #72: passing the inner struct of a nested type
+// to a free function by reference. Should emit
+// `read_a reads from r.a` (the PassByStaticReference path).
+
+struct A { b: String }
+struct R { a: A }
+
+fn read_a(_x: &A) {}
+
+fn main() {
+    let r = R { a: A { b: String::from("hi") } };
+    read_a(&r.a);
+}

--- a/rustviz-plugin/tests/nll_two_borrows.rs
+++ b/rustviz-plugin/tests/nll_two_borrows.rs
@@ -1,0 +1,15 @@
+// Non-lexical lifetimes: the first &mut borrow ends at its last use,
+// so a second &mut borrow on the next line is allowed.
+
+fn world(s: &mut String) {
+    s.push_str(", world");
+}
+
+fn main() {
+    let mut x = String::from("Hello");
+    let y = &mut x;
+    world(y);
+    let z = &mut x; // OK: y's lifetime ends after world(y)
+    world(z);
+    println!("{}", x);
+}

--- a/rustviz-plugin/tests/reassign_with_drop.rs
+++ b/rustviz-plugin/tests/reassign_with_drop.rs
@@ -1,0 +1,9 @@
+// Reassigning a binding that already owns a heap resource.
+// The previously-held resource is dropped before the new one is bound.
+
+fn main() {
+    let x = String::from("hello");
+    let mut y = String::from("test");
+    y = x;
+    println!("{}", y);
+}

--- a/rustviz-plugin/tests/reborrow.rs
+++ b/rustviz-plugin/tests/reborrow.rs
@@ -1,0 +1,12 @@
+// Reborrow: a fresh `&mut *r` from an existing mutable reference.
+// The reborrow is its own borrow with its own lifetime; the original
+// reference is loaned out for the duration of the reborrow and gets
+// it back when the reborrow expires.
+
+fn main() {
+    let mut s = String::from("hi");
+    let r = &mut s;
+    let r2 = &mut *r;
+    r2.push_str("!");
+    println!("{}", r);
+}

--- a/rustviz-plugin/tests/shadowing_basic.rs
+++ b/rustviz-plugin/tests/shadowing_basic.rs
@@ -1,0 +1,9 @@
+// Shadowing: the second `let s = ...` creates a new binding with
+// the same name. The first `s` goes out of scope at the shadow site
+// (its resource is dropped).
+
+fn main() {
+    let s = String::from("a");
+    let s = String::from("b");
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/skip_marker_let.rs
+++ b/rustviz-plugin/tests/skip_marker_let.rs
@@ -1,0 +1,10 @@
+// `// rustviz: skip` on a `let` keeps the variable's RAP
+// registered (so any non-skipped reference still resolves) but
+// drops every event that touches it. The result is no timeline
+// column for `q` and no events naming `q`.
+
+fn main() {
+    let s = String::from("kept");
+    let q = String::from("skipped"); // rustviz: skip
+    println!("{} {}", s, q);
+}

--- a/rustviz-plugin/tests/string_len.rs
+++ b/rustviz-plugin/tests/string_len.rs
@@ -1,0 +1,8 @@
+// Calling a stdlib immutable-ref method (`len` is `&self`).
+// Should produce a PassByStaticReference ("len reads from s").
+
+fn main() {
+    let s = String::from("hi");
+    let n = s.len();
+    println!("{} {}", s, n);
+}

--- a/rustviz-plugin/tests/string_push_str.rs
+++ b/rustviz-plugin/tests/string_push_str.rs
@@ -1,0 +1,9 @@
+// Calling a stdlib mutable-ref method (`push_str` is `&mut self`).
+// Should produce a PassByMutableReference (rendered as
+// "push_str reads from/writes to s").
+
+fn main() {
+    let mut s = String::from("hi");
+    s.push_str("!");
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/take_and_return.rs
+++ b/rustviz-plugin/tests/take_and_return.rs
@@ -1,0 +1,13 @@
+// Function takes ownership of a String and gives it back; caller
+// reassigns the same binding to the returned value.
+
+fn take_and_return(s: String) -> String {
+    println!("{}", s);
+    s
+}
+
+fn main() {
+    let mut s = String::from("hello");
+    s = take_and_return(s);
+    println!("{}", s);
+}


### PR DESCRIPTION
Expands the regression suite from 8 snippets + structural-only checks to 26 snippets + tooltip-level behaviour assertions. Each entry now has a focused minimal repro and an explicit list of \`data-tooltip-text\` strings that must (or must not) appear in the rendered timeline.

## New snippets, by feature

| Category | Snippet | Locks in |
|---|---|---|
| References | \`reborrow\` | \`&mut *r\` chain (borrow + return on both layers) |
| References | \`nll_two_borrows\` | Consecutive \`&mut\` with NLL release between them |
| Reassignment | \`reassign_with_drop\` | "acquires ownership of a new resource; its previous resource is dropped" |
| Function call/return | \`move_return\` | "X's resource is moved to the caller" + caller's \`Move from <fn> to <var>\` |
| Function call/return | \`take_and_return\` | Move into fn + Move back out + reassignment |
| Stdlib methods | \`string_push_str\` | PassByMRef rendered as "push_str reads from/writes to s" |
| Stdlib methods | \`string_len\` | PassBySRef + Copy return |
| User methods | \`inherent_method_rectangle\` | Rectangle/area pattern (the canonical user-impl shape that works) |
| Lifetimes | \`lifetime_excerpt\` | \`Excerpt<'a> { p: &'a str }\` borrow + return |
| Generics | \`generic_fn\` | \`fn id<T>(x: T) -> T\` move-in / move-out |
| Shadowing | \`shadowing_basic\` | First \`s\` dropped at shadow site, second \`s\` is owner |
| Markers | \`skip_marker_let\` | \`q\` events fully suppressed (must_not_contain) |
| Markers | \`hide_marker_fn\` | Call-site arrow preserved, helper's parameter events suppressed |
| Conditionals | \`if_as_let_rhs\` | Conditional as expression on RHS of \`let\` |

## \`corpus.rs\` changes

- **\`timeline_tooltips\` (replaces \`arrow_tooltips\`)** pulls every \`data-tooltip-text\` value, not just arrow ones. Previously the helper only looked inside \`<g id="arrows">\` blocks, but the renderer puts call-site interactions like "\`len reads from s\`" on a fn-icon dot and ownership states like "X is the owner" on the timeline lines — tests shouldn't have to know which element type carries which tooltip.
- **\`EXPECTED_TOOLTIPS\` (replaces \`EXPECTED_ARROWS\`)**: a \`{ must_contain, must_not_contain }\` struct per snippet. The forbidden-tooltips side is what makes \`skip_marker_let\` and \`hide_marker_fn\` actually testable — we can assert that \`q\`'s events and \`some_string\`'s events are absent.
- **\`EXPECTED_OK\` regrouped** by feature area in source order so a glance at the list shows what's covered.

## Bugs surfaced while writing these
Two snippets I wrote during this pass turned out to render incorrectly enough that they couldn't go in the corpus — filed as separate issues:

- Tuple destructuring (\`let (a, b) = (...)\`) produces zero tooltips → coming separately as a new issue
- \`match\` as RHS of \`let\` renders patterns as raw AST tokens (\`Int(Pu128(0), Unsuffixed)\`, \`Wild\`, \`merge\`) instead of source text → coming separately as a new issue

## Notes for review

- Stacked on #84 (rebased onto \`fix/nested-struct-fields-register\`). Tests for nested-struct cases assume #84's behaviour.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\` passes — both \`corpus_expected_ok_produce_well_formed_svg\` (27 snippets) and \`corpus_expected_tooltips_present\` (25 entries) green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)