### PR TITLE
plugin: leave RustViz-inserted rows un-numbered in the gutter

### DIFF
--- a/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
@@ -30,23 +30,32 @@ pub fn render_code_panel(
         total_lines += 1;
     }
 
-    // Account for the extra arrow rows the timeline panel reserves
-    // for arrow events that share a line — without this, a snippet
-    // with 9 source lines but an arrow stack pushing the rendered
-    // count to 10+ would lose its line-number alignment when the
-    // last few rendered numbers cross to two digits.
-    let total_with_arrow_rows: usize = total_lines + l_map.values().sum::<usize>();
-    // Right-align line numbers to the widest one. With left-aligned
-    // numbers (`9  ` vs `10  `) the trailing spaces shift content
-    // by a column whenever a digit boundary is crossed; right-align
-    // them and the content column stays put across the whole file.
-    let num_width = total_with_arrow_rows.max(1).to_string().len();
+    // Right-align the gutter to the widest source line number. We
+    // intentionally don't include the arrow-stack inserts in this
+    // calculation: those rows are blank in the gutter (they exist
+    // purely to give the trapezoid arrows vertical clearance), so
+    // the largest displayed number is just the source-line count.
+    // Right alignment matters because left alignment shifts the
+    // content column whenever a digit boundary crosses (`9  ` vs
+    // `10  `).
+    let num_width = total_lines.max(1).to_string().len();
 
     /* Render the code segment of the svg to a String */
     let x = 20;
     let mut y = 90;
     let mut output = String::from("    <g id=\"code\">\n");
-    let mut line_of_code = 1;
+    // `source_line` tracks the user's source-line number — what we
+    // print in the gutter for real source rows. `visual_row`
+    // tracks the renderer's row counter — drives both the y
+    // position and the `l_map` lookup, since `l_map`'s keys are
+    // post-shift visual rows (see svg_generation.rs's `final_line_num
+    // = line_num + extra_lines`). They diverge whenever an arrow
+    // stack inserts a blank row: visual_row keeps ticking, source_line
+    // pauses. Keeping them separate is what lets us number the
+    // displayed lines 1..n_source while still indexing per-row
+    // structures by the visual row.
+    let mut source_line: usize = 1;
+    let mut visual_row: usize = 1;
     // Threaded through per-line `highlight()` calls so a `/* … */`
     // that doesn't close on its opening line keeps subsequent lines
     // styled as a comment until we see the matching `*/`.
@@ -56,37 +65,43 @@ pub fn render_code_panel(
         let mut data = BTreeMap::new();
         data.insert("X_VAL".to_string(), x.to_string());
         data.insert("Y_VAL".to_string(), y.to_string());
-        /* automatically add line numbers to code */
         let fmt_line = format!(
             "<tspan fill=\"#AAA\">{:>width$}  </tspan>{}",
-            line_of_code, line_string, width = num_width,
+            source_line, line_string, width = num_width,
         );
         data.insert("LINE".to_string(), fmt_line);
         output.push_str(&handlebars.render("code_line_template", &data).unwrap());
-        // change line spacing
         y = y + LINE_SPACE;
-        let mut extra_line_num = match l_map.get(&line_of_code) {
+        let mut extra_line_num = match l_map.get(&visual_row) {
             Some(l) => *l,
             None => 0
         };
-        /* add empty lines for arrows */
+        /* add empty arrow-clearance rows. They occupy a visual row
+           (so the trapezoid arrow has somewhere to draw) but stay
+           blank in the gutter — line numbers in the visualization
+           stay one-to-one with the editor's line numbers. */
         while extra_line_num > 0 {
             let mut data = BTreeMap::new();
             data.insert("X_VAL".to_string(), x.to_string());
             data.insert("Y_VAL".to_string(), y.to_string());
-            /* automatically add line numbers to code */
-            line_of_code = line_of_code + 1;
+            // Pad with the same width as a real number so the
+            // content column doesn't jiggle row-to-row.
             let empty_line = format!(
-                "<tspan fill=\"#AAA\">{:>width$}</tspan>",
-                line_of_code, width = num_width,
+                "<tspan fill=\"#AAA\">{:>width$}  </tspan>",
+                "", width = num_width,
             );
             data.insert("LINE".to_string(), empty_line);
             output.push_str(&handlebars.render("code_line_template", &data).unwrap());
             y = y + LINE_SPACE;
+            visual_row += 1;
             extra_line_num -= 1;
         }
-        line_of_code = line_of_code + 1;
+        source_line += 1;
+        visual_row += 1;
     }
     output.push_str("    </g>\n");
-    (output, line_of_code as i32)
+    // Returned value used to be the next line number; preserve that
+    // shape (callers want a row count for height etc.) by returning
+    // the visual row count.
+    (output, visual_row as i32)
 }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
@@ -49,16 +49,23 @@ pub fn render_code_panel(
     let x = 20;
     let mut y = 90;
     let mut output = String::from("    <g id=\"code\">\n");
-    // `source_line` tracks the user's source-line number — what we
-    // print in the gutter for real source rows. `visual_row`
-    // tracks the renderer's row counter — drives both the y
-    // position and the `l_map` lookup, since `l_map`'s keys are
-    // post-shift visual rows (see svg_generation.rs's `final_line_num
-    // = line_num + extra_lines`). They diverge whenever an arrow
-    // stack inserts a blank row: visual_row keeps ticking, source_line
-    // pauses. Keeping them separate is what lets us number the
-    // displayed lines 1..n_source while still indexing per-row
-    // structures by the visual row.
+    // Three counters move at three different rates and aren't
+    // interchangeable:
+    //
+    //  - `iter_idx`    — 1-indexed position in `annotated_lines`. The
+    //                    fn-blank pre-pass already injected synthetic
+    //                    blanks into that vector, so `synthetic_blank_rows`
+    //                    keys live in this space (they're computed
+    //                    pre-arrow-stack-shift in svg_generation.rs).
+    //  - `source_line` — what we print in the gutter; only ticks for
+    //                    real user source rows.
+    //  - `visual_row`  — the renderer's row counter; ticks per row
+    //                    including arrow-stack inserts. Drives both
+    //                    the y position and the `l_map` lookup, since
+    //                    `l_map` keys are post-arrow-stack visual rows
+    //                    (see svg_generation.rs's
+    //                    `final_line_num = line_num + extra_lines`).
+    let mut iter_idx: usize = 1;
     let mut source_line: usize = 1;
     let mut visual_row: usize = 1;
     // Threaded through per-line `highlight()` calls so a `/* … */`
@@ -67,7 +74,7 @@ pub fn render_code_panel(
     let mut in_block_comment = false;
     for line in annotated_lines {
         let line_string = syntax::highlight(line, &mut in_block_comment);
-        let is_synthetic_blank = synthetic_blank_rows.contains(&visual_row);
+        let is_synthetic_blank = synthetic_blank_rows.contains(&iter_idx);
         let mut data = BTreeMap::new();
         data.insert("X_VAL".to_string(), x.to_string());
         data.insert("Y_VAL".to_string(), y.to_string());
@@ -116,6 +123,7 @@ pub fn render_code_panel(
             source_line += 1;
         }
         visual_row += 1;
+        iter_idx += 1;
     }
     output.push_str("    </g>\n");
     // Returned value used to be the next line number; preserve that

--- a/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/code_panel.rs
@@ -3,14 +3,20 @@ extern crate handlebars;
 use crate::svg_generator::data::{ExternalEvent, LINE_SPACE};
 use crate::svg_generator::svg_frontend::syntax;
 use handlebars::Handlebars;
-use std::{cmp::max, collections::{BTreeMap, HashMap}};
+use std::{cmp::max, collections::{BTreeMap, HashMap, HashSet}};
 
 pub fn render_code_panel(
     annotated_lines: std::str::Lines,
     lines: std::str::Lines,
     max_x_space: &mut i64,
     _event_line_map: &BTreeMap<usize, Vec<ExternalEvent>>,
-    l_map: &HashMap<usize, usize>, 
+    l_map: &HashMap<usize, usize>,
+    // Visual-row positions (1-indexed in the post-fn-blank-pass
+    // sequence) where svg_generation injected a synthetic blank line
+    // before a non-first fn so the fn-label header has somewhere to
+    // sit. Rendered with a blank gutter and no source-line increment
+    // — same treatment arrow-stack inserts get below.
+    synthetic_blank_rows: &HashSet<usize>,
 ) -> (String, i32) {
     /* Template creation */
     let mut handlebars = Handlebars::new();
@@ -30,15 +36,14 @@ pub fn render_code_panel(
         total_lines += 1;
     }
 
-    // Right-align the gutter to the widest source line number. We
-    // intentionally don't include the arrow-stack inserts in this
-    // calculation: those rows are blank in the gutter (they exist
-    // purely to give the trapezoid arrows vertical clearance), so
-    // the largest displayed number is just the source-line count.
-    // Right alignment matters because left alignment shifts the
-    // content column whenever a digit boundary crosses (`9  ` vs
-    // `10  `).
-    let num_width = total_lines.max(1).to_string().len();
+    // Right-align the gutter to the widest source line number we'll
+    // actually print. Arrow-clearance and fn-blank inserts both
+    // render with a blank gutter, so the largest displayed number
+    // is the source-line count minus all the synthetic blanks. Right
+    // alignment matters because left alignment shifts the content
+    // column whenever a digit boundary crosses (`9  ` vs `10  `).
+    let displayed_lines = total_lines.saturating_sub(synthetic_blank_rows.len());
+    let num_width = displayed_lines.max(1).to_string().len();
 
     /* Render the code segment of the svg to a String */
     let x = 20;
@@ -62,13 +67,24 @@ pub fn render_code_panel(
     let mut in_block_comment = false;
     for line in annotated_lines {
         let line_string = syntax::highlight(line, &mut in_block_comment);
+        let is_synthetic_blank = synthetic_blank_rows.contains(&visual_row);
         let mut data = BTreeMap::new();
         data.insert("X_VAL".to_string(), x.to_string());
         data.insert("Y_VAL".to_string(), y.to_string());
-        let fmt_line = format!(
-            "<tspan fill=\"#AAA\">{:>width$}  </tspan>{}",
-            source_line, line_string, width = num_width,
-        );
+        // Synthetic fn-blank inserts get the same blank-gutter
+        // treatment as arrow-clearance rows; only real source rows
+        // tick `source_line`.
+        let fmt_line = if is_synthetic_blank {
+            format!(
+                "<tspan fill=\"#AAA\">{:>width$}  </tspan>{}",
+                "", line_string, width = num_width,
+            )
+        } else {
+            format!(
+                "<tspan fill=\"#AAA\">{:>width$}  </tspan>{}",
+                source_line, line_string, width = num_width,
+            )
+        };
         data.insert("LINE".to_string(), fmt_line);
         output.push_str(&handlebars.render("code_line_template", &data).unwrap());
         y = y + LINE_SPACE;
@@ -96,7 +112,9 @@ pub fn render_code_panel(
             visual_row += 1;
             extra_line_num -= 1;
         }
-        source_line += 1;
+        if !is_synthetic_blank {
+            source_line += 1;
+        }
         visual_row += 1;
     }
     output.push_str("    </g>\n");

--- a/rustviz-plugin/src/svg_generator/svg_frontend/svg_generation.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/svg_generation.rs
@@ -265,6 +265,17 @@ pub fn render_svg(
 
     let new_a_str: String;
     let new_s_str: String;
+    // Visual-row positions (1-indexed) of the synthetic blank lines
+    // we just inserted. The Kth blank lands at `needs_blank_at[K]
+    // + K` because K earlier inserts have already shifted everything
+    // after them by one. The code-panel renderer consults this to
+    // leave those rows un-numbered in the gutter — line numbers in
+    // the visualization stay 1:1 with the user's editor.
+    let synthetic_blank_rows: HashSet<usize> = needs_blank_at
+        .iter()
+        .enumerate()
+        .map(|(i, src)| src + i)
+        .collect();
     if needs_blank_at.is_empty() {
         new_a_str = annotated_src_str.to_string();
         new_s_str = source_rs_str.to_string();
@@ -494,7 +505,7 @@ pub fn render_svg(
     // data for code panel
     let mut max_x_space: i64 = 0;
     let (output, line_of_code) =
-            code_panel::render_code_panel(a_lines, s_lines, &mut max_x_space, &visualization_data.event_line_map, &line_insertion_map);
+            code_panel::render_code_panel(a_lines, s_lines, &mut max_x_space, &visualization_data.event_line_map, &line_insertion_map, &synthetic_blank_rows);
     let code_panel_string = output;
     let num_lines = line_of_code;
 


### PR DESCRIPTION
## Summary
The arrow-stack pass inserts blank rows so trapezoid-style stacked arrows have vertical clearance. Those rows carry a gutter number today, so a 10-line snippet with two arrow stacks renders with gutter numbers 1..12 — and a user looking at "line 8" in the visualization can't find it on line 8 of their editor.

## Fix
Split the row counter into two:

- \`source_line\` — the user's source-line number; printed in the gutter for real source rows. Stays 1:1 with the editor.
- \`visual_row\` — the renderer's row counter; drives the y position and the \`l_map\` lookup (whose keys are post-shift visual rows, per svg_generation's \`final_line_num = line_num + extra_lines\`).

Arrow-clearance rows tick \`visual_row\` (so the trapezoid has somewhere to draw and y stays aligned with timeline events) but leave \`source_line\` untouched and print blank padding in the gutter.

## Before / after on the default snippet

\`\`\`
Before                          After
 1  fn main() {                  1  fn main() {
 2      let mut x = 7;           2      let mut x = 7;
 ...                             ...
 7      b = &mut c;              7      b = &mut c;
 8                                       ← blank, no number
 9      println!("x {}", *a);    8      println!("x {}", *a);
10      println!("z {}", **b);   9      println!("z {}", **b);
11                                       ← blank, no number
12  }                           10  }
\`\`\`

Editor's line 8 now matches gutter line 8.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\` still passes (corpus assertions are tooltip-based, not gutter-based, so this is a regression-floor check)
- [x] Default snippet renders as shown above; Hands-on tutorial renders 11 source lines numbered 1..11 with the inserted blank for the println-z arrow stack appearing un-numbered between rows 10 and 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)