### PR TITLE
Add direnv-based per-clone isolation for parallel checkouts

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,45 @@
+# Per-clone isolation for working on RustViz from several checkouts at once.
+#
+# Without this, every clone shares ~/.cargo: setup.sh's `cargo install`
+# steps from each clone fight over ~/.cargo/bin/rustviz, and concurrent
+# playground processes collide on the docker image tag and bind port.
+#
+# direnv (https://direnv.net/) auto-loads this file when you cd into the
+# checkout and unloads it when you cd out, so any tool launched from a
+# shell inside the checkout — including `claude` — inherits the isolated
+# environment. One-time host setup:
+#
+#   brew install direnv
+#   echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc   # then restart your shell
+#
+# Then per checkout:
+#
+#   cp .envrc.example .envrc
+#   direnv allow
+#
+# The rustup toolchain (~/.rustup) is intentionally still shared — every
+# clone pins the same nightly via rust-toolchain.toml, so a per-clone
+# copy would just waste disk.
+
+# Per-clone cargo home. Houses the binaries setup.sh installs
+# (`rustviz`, `cargo-rv-plugin`, `rv-plugin-driver`) plus a private
+# registry cache, so installing from one clone doesn't shadow another.
+export CARGO_HOME="$PWD/.cargo-home"
+export PATH="$CARGO_HOME/bin:$PATH"
+
+# Uncomment the relevant lines below if you also need to run the
+# playground concurrently from multiple clones.
+
+# Skip docker (so two clones don't fight for the rustviz/rustviz-runner
+# image tag), run the plugin in-process instead. Fine for local dev;
+# never use on a public deploy — see playground/SECURITY.md.
+# export RV_RUNNER=local
+
+# Per-clone docker tag, so `docker build -t "$RV_RUNNER_IMAGE" ...` from
+# one clone doesn't clobber another's image. Pair with `setup.sh
+# --build-runner` after exporting.
+# export RV_RUNNER_IMAGE=rustviz/rustviz-runner:clone-a
+
+# Different bind address so two playgrounds can run simultaneously
+# (default is 127.0.0.1:8080).
+# export RV_BIND=127.0.0.1:8081

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@
 target/
 */target/
 
+# Per-clone direnv environment + the cargo home it points at.
+# `.envrc.example` is committed; the live `.envrc` and `.cargo-home/`
+# are local to each checkout. See README "Working from multiple
+# checkouts in parallel".
+.envrc
+.cargo-home/
+
 # Per-run fixtures the mdbook preprocessor materialises into a book's
 # tree at build time. The inner test-book under mdbook-rustviz/ is
 # the canonical worked example; its src/examples and book/ outputs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ plus the playground's React frontend. To undo it, run `./uninstall.sh`
 (see `--help` for what it touches and what it leaves alone — by
 default it spares the rustup toolchain and the cargo `target/` tree).
 
+### Working from multiple checkouts in parallel
+
+If you keep several clones around (e.g. one branch per agent or per
+issue), they share `~/.cargo` by default — so `setup.sh`'s `cargo
+install` from each one races for `~/.cargo/bin/rustviz`, and
+concurrent playground builds collide on the `rustviz/rustviz-runner`
+docker tag. To isolate them, this repo ships an
+[`.envrc.example`](.envrc.example) for [direnv](https://direnv.net/)
+that gives each checkout its own `CARGO_HOME` (and optional knobs
+for the docker tag and playground bind address):
+
+```sh
+brew install direnv
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc   # then restart your shell
+cp .envrc.example .envrc
+direnv allow
+```
+
+After that, any shell — and anything it launches, including `claude`
+— inherits a per-clone cargo home automatically when you `cd` into
+the checkout. The rustup toolchain stays shared across clones since
+they all pin the same nightly.
+
 ---
 
 ## Four ways to use RustViz


### PR DESCRIPTION
## Summary
- Adds `.envrc.example` so each checkout can opt into its own `CARGO_HOME` (and optional `RV_RUNNER_IMAGE` / `RV_BIND`), preventing parallel checkouts from racing over `~/.cargo/bin/rustviz` or the `rustviz/rustviz-runner` docker tag.
- Gitignores the live `.envrc` and the `.cargo-home/` directory it points at.
- Adds a "Working from multiple checkouts in parallel" subsection to the README explaining the one-time host setup and per-checkout `direnv allow` step.

The rustup toolchain stays shared since every clone pins the same nightly via `rust-toolchain.toml`.

## Test plan
- [ ] `brew install direnv`, hook into shell, `cp .envrc.example .envrc && direnv allow`
- [ ] Confirm `echo $CARGO_HOME` resolves to `<checkout>/.cargo-home` and that `which rustviz` after `setup.sh` points inside it
- [ ] Confirm a second checkout with its own `.envrc` gets a separate cargo home and doesn't shadow the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)