### PR TITLE
chore: drop legacy rustviz2* names from uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -57,10 +57,7 @@ run() {
 # silently so the script is idempotent — a second run is a no-op.
 # ----------------------------------------------------------------
 echo "==> cargo uninstall"
-# Include the legacy `rustviz2*` package names so an `uninstall.sh` run
-# from a freshly-pulled checkout cleans up binaries left behind by an
-# older `setup.sh` (pre-rename).
-for pkg in rustviz-cli rustviz-plugin rustviz2 rustviz2-plugin; do
+for pkg in rustviz-cli rustviz-plugin; do
     if cargo install --list 2>/dev/null | grep -qE "^${pkg} v"; then
         run cargo uninstall "$pkg"
     else


### PR DESCRIPTION
## Summary
- Removes the `rustviz2` / `rustviz2-plugin` entries from the cargo-uninstall loop in `uninstall.sh` (and the comment explaining why they were there).
- The rename landed in 1a8ea71; the legacy fallback was kept so anyone with a pre-rename install could still clean up via the new script. Enough time has passed that we can drop it.

## Test plan
- [ ] `bash -n uninstall.sh` parses cleanly
- [ ] `./uninstall.sh --dry-run` lists only `rustviz-cli` and `rustviz-plugin` in the cargo-uninstall step

🤖 Generated with [Claude Code](https://claude.com/claude-code)