### PR TITLE
plugin: render non-local ADTs as opaque owners (fixes #76)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -76,6 +76,12 @@ const EXPECTED_OK: &[&str] = &[
     "hide_marker_fn",
     // — Conditionals as expression RHS (the supported subset).
     "if_as_let_rhs",
+    // — Smart-pointer wrappers (#76): rendered as opaque single-owner
+    //   columns rather than recursing into Unique/NonNull/PhantomData
+    //   internals.
+    "box_string",
+    "rc_clone",
+    "box_dyn",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -366,6 +372,58 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "s goes out of scope. Its resource is dropped.",
         ],
         must_not_contain: &[],
+    },
+
+    // ─── Smart-pointer wrappers (#76) ───────────────────────────────
+    // Box / Rc / Box<dyn T> render as a single owning column, not as
+    // their internal struct internals. The `must_not_contain` list
+    // pins the regression: if any of these strings come back, #84's
+    // recursive struct-field walker is leaking wrapper internals
+    // into the timeline again.
+    TooltipExpect {
+        name: "box_string",
+        must_contain: &[
+            "Move from Box::new to b",
+        ],
+        must_not_contain: &[
+            "b.0, immutable",
+            "b.0.pointer, immutable",
+            "b.0.pointer.pointer, immutable",
+            "b.0._marker, immutable",
+            "b.1, immutable",
+        ],
+    },
+    TooltipExpect {
+        name: "rc_clone",
+        // `Rc::clone(&r)` is just a regular function call: `&r` is
+        // a static borrow into Rc::clone, the return value moves
+        // into r2. Shared-ownership semantics aren't visualized
+        // (per the issue's "out of scope for the panic fix" note).
+        must_contain: &[
+            "Move from Rc::new to r",
+            "Move from Rc::clone to r2",
+            "Rc::clone reads from r",
+        ],
+        must_not_contain: &[
+            "r.ptr, immutable",
+            "r.ptr.pointer, immutable",
+            "r.phantom, immutable",
+            "r.alloc, immutable",
+            "r2.ptr, immutable",
+            "r2.alloc, immutable",
+        ],
+    },
+    TooltipExpect {
+        name: "box_dyn",
+        must_contain: &[
+            "Move from Box::new to b",
+        ],
+        must_not_contain: &[
+            "b.0, immutable",
+            "b.0.pointer, immutable",
+            "b.0._marker, immutable",
+            "b.1, immutable",
+        ],
     },
 ];
 

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -540,7 +540,7 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
 
   // Add a RAP to our collection of raps for a let stmt
   pub fn define_lhs(&mut self, name: String, mutability: bool, expr: &'tcx Expr, ty: Ty <'tcx>) {
-    let is_special = ty_is_special_owner(&self.tcx, &ty);
+    let is_special = ty_is_special_owner(&ty);
     if ty.is_ref() {
       let (lender, aliasing) = self.get_ref_data(&expr);
       self.add_ref(name.clone(), 
@@ -644,7 +644,7 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
         // (only struct ADTs are flattened today) and skip the
         // special-owner builtins like `String` whose internals
         // we deliberately don't expose.
-        if field_ty.is_adt() && !ty_is_special_owner(&self.tcx, &field_ty) {
+        if field_ty.is_adt() && !ty_is_special_owner(&field_ty) {
           if let Some(adt_def) = field_ty.ty_adt_def() {
             if matches!(adt_def.adt_kind(), AdtKind::Struct) {
               self.register_struct_members(

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -119,18 +119,25 @@ pub fn is_addr(expr: &Expr) -> bool { // todo, probably a better way to do this 
   }
 }
 
-// The purpose of this function is to override the typechecking done on variables
-// when we want to consider them owners rather than structs. This is because for 99.9% of cases
-// users don't care about acessing String::len/buf members. 
-// We should work towards elimanting all struct members that are not used in the program
-// and that way we can just get rid of this hacky function.
-pub fn ty_is_special_owner<'tcx> (tcx: &TyCtxt<'tcx>, t: &Ty<'tcx>) -> bool {
-  match &*t.sort_string(*tcx) {
-    "`std::string::String`" => { true }
-    _ => {
-      false
-    }
+// Render an ADT as a single owning column (like a primitive) rather
+// than recursing into its struct fields when the type is defined
+// outside the user's crate. RustViz is a teaching tool against a
+// single-file crate — anything from `std`/`core`/`alloc` or a third-
+// party dep (`String`, `Box`, `Rc`, `Arc`, `RefCell`, `Vec`,
+// `HashMap`, ...) is by definition opaque from the user's
+// perspective, so surfacing `r.ptr.pointer.pointer` or `r.alloc`
+// columns just exposes implementation detail. Local structs the user
+// defined (`Rectangle`, `Excerpt`, etc.) keep their per-field
+// timeline columns, matching what #84 added.
+//
+// Escape hatch for "I want to expose a non-local struct's fields
+// anyway" (e.g. a teaching example that wants to point at `Vec`'s
+// `len` / `cap`) is tracked in #90.
+pub fn ty_is_special_owner<'tcx>(t: &Ty<'tcx>) -> bool {
+  if let Some(adt_def) = t.ty_adt_def() {
+    return !adt_def.did().is_local();
   }
+  false
 }
 
 // Get a string representation of a Path - usually used as a name for a RAP

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
     // add RAP corresponding to parameter type
     let line_num=span_to_line(&param.span, &self.tcx);
     let ty = self.tcx.typeck(param.hir_id.owner).pat_ty(param.pat);
-    let is_special = ty_is_special_owner(&self.tcx, &ty);
+    let is_special = ty_is_special_owner(&ty);
     match param.pat.kind {
       PatKind::Binding(binding_annotation, _ann_hirid, ident, _op_pat) =>{
         let name: String = ident.to_string();

--- a/rustviz-plugin/tests/box_dyn.rs
+++ b/rustviz-plugin/tests/box_dyn.rs
@@ -1,0 +1,10 @@
+// `Box<dyn Display>` trait object — issue #76 case 3.
+// Same opaque-owner treatment as the sized-`Box` case: one column
+// per binding, no `Unique`/`NonNull`/`PhantomData` bleed-through.
+
+use std::fmt::Display;
+
+fn main() {
+    let b: Box<dyn Display> = Box::new(String::from("hi"));
+    println!("{}", b);
+}

--- a/rustviz-plugin/tests/box_string.rs
+++ b/rustviz-plugin/tests/box_string.rs
@@ -1,0 +1,9 @@
+// `Box::new(String::from(..))` — issue #76 case 1.
+// Should render `b` as a single owning column (like a `String` would),
+// not as the `Box` ADT's recursive internals (`b.0.pointer.pointer`,
+// `b.0._marker`, `b.1`, ...).
+
+fn main() {
+    let b = Box::new(String::from("hi"));
+    println!("{}", b);
+}

--- a/rustviz-plugin/tests/rc_clone.rs
+++ b/rustviz-plugin/tests/rc_clone.rs
@@ -1,0 +1,14 @@
+// `Rc::new` + `Rc::clone(&r)` — issue #76 case 2.
+// `Rc::clone(&r)` is a regular function call: `&r` is a static borrow
+// into `Rc::clone`, the return value is moved into `r2`. The
+// shared-ownership semantics aren't currently visualized for any
+// type — the immediate goal here is "don't crash and don't expose
+// internals like `r.ptr.pointer`."
+
+use std::rc::Rc;
+
+fn main() {
+    let r = Rc::new(String::from("hi"));
+    let r2 = Rc::clone(&r);
+    println!("{} {}", r, r2);
+}


### PR DESCRIPTION
## Summary
- Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait objects (`Box<dyn T>`) no longer leak their private internals (`r.ptr.pointer`, `r.alloc`, `b.0._marker`, ...) into the timeline.
- `ty_is_special_owner` is generalized from a single-entry `String` allowlist to a **locality check**: any ADT defined outside the user's crate renders as a single opaque owning column. Local user-defined structs (`Rectangle`, `Excerpt`, ...) keep the per-field columns #84 added.
- Catches `String`, `Box`, `Rc`, `Arc`, `RefCell`, `Cell`, `Mutex`, `RwLock`, `Vec`, `HashMap`, etc. uniformly without an enumeration. Escape hatch for the "I want a non-local struct's fields visible" case is tracked in #90.

## Background
The `Internal plugin error` panic from #76 was already eliminated as a byproduct of #84's recursive struct-field registration. But the same recursion now walks into Box / Rc / Arc / RefCell internals — `Unique`, `NonNull`, `PhantomData`, `Allocator` — and surfaces them as RAP columns in the timeline. The issue's expected-visualization section asks for these to render *as a single owning column, like `String`*, which is exactly what the locality rule produces.

## Test plan
- [x] `cargo test -p rustviz-lib --test corpus` (`corpus_expected_ok_produce_well_formed_svg` + `corpus_expected_tooltips_present`, including three new snippets below)
- [x] Existing corpus regressions (`testMove`, `nested_struct_borrow`, `inherent_method_rectangle`, ...) still pass
- [x] Manual: `Box::new(String::from(..))`, `Rc::new` + `Rc::clone(&r)`, `Box<dyn Display>` each render as a single owning column with no `*.pointer` / `*.alloc` / `*._marker` bleed-through

New corpus snippets in `rustviz-plugin/tests/`, wired into `corpus.rs`:
- `box_string.rs` — issue case 1 (`Box::new(String::from(..))`)
- `rc_clone.rs` — issue case 2 (`Rc::new` + `Rc::clone(&r)`)
- `box_dyn.rs` — issue case 3 (`Box<dyn Display>`)

Each test's `must_not_contain` list enumerates the wrapper-internal column names (`b.0.pointer.pointer`, `r.alloc`, `b.0._marker`, ...) so the regression can never silently come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)