### PR TITLE
plugin: stop crashing on macro-expanded RHS, attribute Vec slicing to receiver (fixes #75)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -63,6 +63,8 @@ const EXPECTED_OK: &[&str] = &[
     // — Stdlib method calls.
     "string_push_str",
     "string_len",
+    // — Stdlib indexing / slicing (#75).
+    "vec_slice",
     // — User-defined inherent methods.
     "inherent_method_rectangle",
     // — Lifetime annotations.
@@ -260,6 +262,25 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "push_str reads from/writes to s",
         ],
         must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "vec_slice",
+        // `let v = vec![..]` desugars through a macro into a Call whose
+        // function never gets registered as a RAP. The fix in #75 emits a
+        // plain Bind ("v acquires ownership") instead of crashing. `&v[..]`
+        // attributes the borrow to `v` (Vec is now collapsed via
+        // `ty_is_special_owner`), matching how `&s` works for `s: String`.
+        must_contain: &[
+            "v acquires ownership of a resource",
+            "Immutable borrow from v to p",
+            "Return immutably borrowed resource from p to v",
+        ],
+        must_not_contain: &[
+            // Vec internals shouldn't leak into the timeline as separate
+            // columns (regression guard for the `ty_is_special_owner` arm).
+            "v.buf, immutable",
+            "v.len, immutable",
+        ],
     },
     TooltipExpect {
         name: "string_len",

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -733,6 +733,17 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
 
 // This function does the work of adding an event for let stmts
 pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
+  // Macro-expanded RHS — `let v = vec![1, 2, 3]`, `let s = format!(...)`,
+  // etc. — desugars into a `Call` whose function path was never registered
+  // as a RAP (visit_expr's from_expansion guard skipped it). Treating
+  // such an RHS like a literal — Bind from Anonymous — gives the user a
+  // clean "v acquires ownership of a resource" event without trying to
+  // name the synthetic call inside the macro.
+  if rhs.span.from_expansion() {
+    let line_num = span_to_line(&rhs.span, &self.tcx);
+    self.add_ev(line_num, Evt::Bind, lhs, ResourceTy::Anonymous, false);
+    return;
+  }
   match rhs.kind {
     ExprKind::Path(QPath::Resolved(_,p)) => {
       let line_num = span_to_line(&p.span, &self.tcx);

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -90,6 +90,11 @@ pub fn expr_to_rap_name(expr: &Expr, tcx: &TyCtxt) -> Option<String> {
     ExprKind::AddrOf(_, _, inner)
     | ExprKind::Unary(_, inner)
     | ExprKind::DropTemps(inner) => expr_to_rap_name(inner, tcx),
+    // `v[..]` / `s[i]`: attribute the slice/element to the receiver's
+    // RAP, the same way we treat `&v` directly. RustViz doesn't render
+    // a separate column per index/slice, so collapsing onto the
+    // receiver matches how fields share their parent's column.
+    ExprKind::Index(recv, _, _) => expr_to_rap_name(recv, tcx),
     _ => None,
   }
 }
@@ -121,16 +126,20 @@ pub fn is_addr(expr: &Expr) -> bool { // todo, probably a better way to do this 
 
 // The purpose of this function is to override the typechecking done on variables
 // when we want to consider them owners rather than structs. This is because for 99.9% of cases
-// users don't care about acessing String::len/buf members. 
+// users don't care about acessing String::len/buf members.
 // We should work towards elimanting all struct members that are not used in the program
 // and that way we can just get rid of this hacky function.
+//
+// Match on the ADT's def path (without generic args) so e.g. `Vec<i32>`,
+// `Vec<String>`, and `Vec<T>` all collapse to a single owner column. Using
+// `sort_string` here would embed the generic instance, requiring a separate
+// arm per element type.
 pub fn ty_is_special_owner<'tcx> (tcx: &TyCtxt<'tcx>, t: &Ty<'tcx>) -> bool {
-  match &*t.sort_string(*tcx) {
-    "`std::string::String`" => { true }
-    _ => {
-      false
-    }
-  }
+  let rustc_middle::ty::TyKind::Adt(adt_def, _) = t.kind() else { return false; };
+  matches!(
+    tcx.def_path_str(adt_def.did()).as_str(),
+    "std::string::String" | "std::vec::Vec"
+  )
 }
 
 // Get a string representation of a Path - usually used as a name for a RAP
@@ -569,6 +578,8 @@ pub fn get_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> Re
       }
     }
     ExprKind::AddrOf(_, _, expr) | ExprKind::Unary(_, expr) => get_rap(expr, tcx, raps),
+    // `v[..]` / `s[i]`: the resource is the receiver. See `expr_to_rap_name`.
+    ExprKind::Index(recv, _, _) => get_rap(recv, tcx, raps),
     ExprKind::Call(fn_expr, _) => {
       let fn_name = hirid_to_var_name(fn_expr.hir_id, tcx).unwrap();
       ResourceTy::Value(raps.get(&fn_name).unwrap().rap.to_owned())
@@ -610,6 +621,8 @@ pub fn fetch_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> 
       Some(raps.get(&name).unwrap().rap.to_owned())
     }
     ExprKind::AddrOf(_, _, expr) | ExprKind::Unary(_, expr) => fetch_rap(expr, tcx, raps),
+    // `v[..]` / `s[i]`: the resource is the receiver. See `expr_to_rap_name`.
+    ExprKind::Index(recv, _, _) => fetch_rap(recv, tcx, raps),
     ExprKind::Block(b, _) => {
       match b.expr {
         Some(expr) => { fetch_rap(expr, tcx, raps) }
@@ -661,6 +674,11 @@ pub fn find_lender(rhs: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>, bo
     }
     ExprKind::AddrOf(_, _, expr) => {
       find_lender(expr, tcx, raps, borrow_map)
+    }
+    // `&v[..]` / `&s[i..j]`: the lender is the receiver, the same way
+    // `&r.field` resolves through the Field arm.
+    ExprKind::Index(recv, _, _) => {
+      find_lender(recv, tcx, raps, borrow_map)
     }
     ExprKind::Block(b, _) => {
       match b.expr {

--- a/rustviz-plugin/tests/vec_slice.rs
+++ b/rustviz-plugin/tests/vec_slice.rs
@@ -1,0 +1,12 @@
+// Slicing a `Vec` (`&v[..]`) — the macro-expanded `vec![..]` RHS
+// used to crash match_rhs (it walked the desugared `<[_]>::into_vec(...)`
+// Call without the function being registered as a RAP), and the
+// `&v[..]` borrow used to fall back to an Anonymous lender. Now `v`
+// is a single owner column (Vec collapsed via `ty_is_special_owner`)
+// and the borrow is attributed to it.
+
+fn main() {
+    let v = vec![1, 2, 3];
+    let p = &v[..];
+    println!("{:?}", p);
+}


### PR DESCRIPTION
## Summary

Fixes #75 — `let v = vec![1, 2, 3]; let p = &v[..];` panicked with "Internal plugin error".

- **Root cause was the `vec!` macro itself, not the slicing.** `vec![..]` expands to `<[_]>::into_vec(...)`. `visit_expr`'s `from_expansion` guard correctly skips registering the synthetic call, but `match_rhs` still walked the desugared `Call` and unwrapped a missing `raps.get(&fn_name)`. Now any `from_expansion` RHS is treated as a plain `Bind` — same shape as a literal — so macro-expanded inits give a clean "v acquires ownership of a resource" event without trying to name the synthetic call. Also covers `format!`, etc.
- **`&v[..]` lost its lender attribution.** `ExprKind::Index` wasn't handled in `expr_to_rap_name` / `get_rap` / `fetch_rap` / `find_lender`, so the borrow fell back to `Anonymous`. Each helper now walks the index receiver, so `&v[..]` and `&s[i..j]` produce the "Immutable/Mutable borrow from v to p" arrow the issue asks for — the same shape as `&v` direct.
- **`Vec` was being expanded into its private struct fields** (`v.buf`, `v.buf.inner.cap.0`, etc.) and polluting the timeline. `ty_is_special_owner` now matches on the ADT's `def_path_str` (without generic args) so `Vec<T>` collapses to a single owner column for any element type — same treatment `String` already gets.

## Test plan

- [x] Original issue repro runs cleanly and produces "Immutable borrow from v to p" / "Return immutably borrowed resource from p to v" tooltips.
- [x] Mutable variant `let p = &mut v[..]` produces the mutable-borrow analog.
- [x] New corpus entry `rustviz-plugin/tests/vec_slice.rs` registered in `EXPECTED_OK` and `EXPECTED_TOOLTIPS`, with a `must_not_contain` guard for `v.buf` / `v.len` so a regression in `ty_is_special_owner` would fail the test.
- [x] All 28 corpus regression tests pass (`cargo test -p rustviz-lib --test corpus`).
- [x] `rustviz-lib` and `rustviz-plugin` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)