### PR TITLE
docs: add VL/HCC 2022 paper section to playground + rustviz.bib

### DIFF
--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -184,35 +184,6 @@ const Description: React.FC = () => (
       </a>{' '}
       with the snippet and error message.
     </p>
-    <h3>Research paper</h3>
-    <p>
-      An earlier version of RustViz used hand-written visualization
-      directives in source comments and was deployed in classroom
-      teaching at the University of Michigan. That version is described
-      in our VL/HCC 2022 paper:
-    </p>
-    <p>
-      Marcelo Almeida, Grant Cole, Ke Du, Gongming Luo, Shulin Pan,
-      Yu Pan, Kai Qiu, Vishnu Reddy, Haochen Zhang, Yingying Zhu, and
-      Cyrus Omar.{' '}
-      <a
-        href="https://web.eecs.umich.edu/~comar/rustviz-vlhcc22.pdf"
-        target="_blank"
-        rel="noreferrer"
-      >
-        RustViz: Interactively Visualizing Ownership and Borrowing
-      </a>
-      . In <em>2022 IEEE Symposium on Visual Languages and
-      Human-Centric Computing (VL/HCC)</em>, pages 1–10, 2022.{' '}
-      <a
-        href="https://github.com/rustviz/rustviz/blob/main/rustviz.bib"
-        target="_blank"
-        rel="noreferrer"
-      >
-        BibTeX
-      </a>
-      .
-    </p>
     <h3>Credits</h3>
     <p>
       RustViz is a project of the{' '}
@@ -234,6 +205,35 @@ const Description: React.FC = () => (
       (another visualization tool for Rust) by{' '}
       <a href="https://gavinleroy.com/" target="_blank" rel="noreferrer">
         Gavin Gray
+      </a>
+      .
+    </p>
+    <h3>Research paper</h3>
+    <p>
+      An earlier version of RustViz used hand-written visualization
+      directives in source comments and was deployed in classroom
+      teaching at the University of Michigan. That version is described
+      in our VL/HCC 2022 paper:
+    </p>
+    <p className="citation">
+      Marcelo Almeida, Grant Cole, Ke Du, Gongming Luo, Shulin Pan,
+      Yu Pan, Kai Qiu, Vishnu Reddy, Haochen Zhang, Yingying Zhu, and
+      Cyrus Omar.{' '}
+      <a
+        href="https://web.eecs.umich.edu/~comar/rustviz-vlhcc22.pdf"
+        target="_blank"
+        rel="noreferrer"
+      >
+        RustViz: Interactively Visualizing Ownership and Borrowing
+      </a>
+      . In <em>2022 IEEE Symposium on Visual Languages and
+      Human-Centric Computing (VL/HCC)</em>, pages 1–10, 2022.{' '}
+      <a
+        href="https://github.com/rustviz/rustviz/blob/main/rustviz.bib"
+        target="_blank"
+        rel="noreferrer"
+      >
+        BibTeX
       </a>
       .
     </p>

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -184,6 +184,35 @@ const Description: React.FC = () => (
       </a>{' '}
       with the snippet and error message.
     </p>
+    <h3>Research paper</h3>
+    <p>
+      An earlier version of RustViz used hand-written visualization
+      directives in source comments and was deployed in classroom
+      teaching at the University of Michigan. That version is described
+      in our VL/HCC 2022 paper:
+    </p>
+    <p>
+      Marcelo Almeida, Grant Cole, Ke Du, Gongming Luo, Shulin Pan,
+      Yu Pan, Kai Qiu, Vishnu Reddy, Haochen Zhang, Yingying Zhu, and
+      Cyrus Omar.{' '}
+      <a
+        href="https://web.eecs.umich.edu/~comar/rustviz-vlhcc22.pdf"
+        target="_blank"
+        rel="noreferrer"
+      >
+        RustViz: Interactively Visualizing Ownership and Borrowing
+      </a>
+      . In <em>2022 IEEE Symposium on Visual Languages and
+      Human-Centric Computing (VL/HCC)</em>, pages 1–10, 2022.{' '}
+      <a
+        href="https://github.com/rustviz/rustviz/blob/main/rustviz.bib"
+        target="_blank"
+        rel="noreferrer"
+      >
+        BibTeX
+      </a>
+      .
+    </p>
     <h3>Credits</h3>
     <p>
       RustViz is a project of the{' '}

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -176,6 +176,12 @@ code {
 .description li { margin: 3px 0; }
 .description code { font-size: 12px; }
 
+/* Indented, smaller-text academic citation under "Research paper". */
+.description p.citation {
+  font-size: 12px;
+  margin-left: 22px;
+}
+
 /* ─── Editor panel (top-right) ──────────────────────────────────── */
 
 .editor-panel {

--- a/rustviz.bib
+++ b/rustviz.bib
@@ -1,0 +1,25 @@
+@inproceedings{almeida2022rustviz,
+  author       = {Marcelo Almeida and
+                  Grant Cole and
+                  Ke Du and
+                  Gongming Luo and
+                  Shulin Pan and
+                  Yu Pan and
+                  Kai Qiu and
+                  Vishnu Reddy and
+                  Haochen Zhang and
+                  Yingying Zhu and
+                  Cyrus Omar},
+  editor       = {Paolo Bottoni and
+                  Gennaro Costagliola and
+                  Michelle Brachman and
+                  Mark Minas},
+  title        = {RustViz: Interactively Visualizing Ownership and Borrowing},
+  booktitle    = {2022 {IEEE} Symposium on Visual Languages and Human-Centric Computing,
+                  {VL/HCC} 2022, Rome, Italy, September 12-16, 2022},
+  pages        = {1--10},
+  publisher    = {{IEEE}},
+  year         = {2022},
+  url          = {https://doi.org/10.1109/VL/HCC53370.2022.9833121},
+  doi          = {10.1109/VL/HCC53370.2022.9833121}
+}


### PR DESCRIPTION
## Summary

- Adds a **Research paper** section to the playground's left-hand prose panel (`playground/frontend/src/App.tsx`), placed between Limitations and Credits. Mentions that the earlier classroom-deployed RustViz used hand-written visualization directives — the substantive distinction from the current compiler-integrated version — and gives the full VL/HCC 2022 citation with a BibTeX link.
- Adds **`rustviz.bib`** at the repo root, carrying the canonical BibTeX entry pulled from DBLP so anyone citing RustViz can fetch it directly. The playground's "BibTeX" link points to this file on `main`.

## Test plan

- [x] `npm run build` (Vite + tsc) compiles cleanly with the new section.
- [x] Built bundle contains the new strings ("Research paper", "VL/HCC 2022", "BibTeX", "RustViz: Interactively …").
- [ ] After merge, click the "BibTeX" link in the playground prose pane and confirm it lands on `rustviz.bib` rendered on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)