### PR TITLE
plugin: emit capture arrows for closures (fixes #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ not all of it. Currently unsupported (or known to misbehave):
 - Bindings or borrows inside an `if` or `match` branch body (the
   conditional itself can return a value into a `let`, but tracking
   events inside the branch isn't supported)
-- Closures — captures (whether by reference or by `move`) aren't
-  drawn as arrows, so the visualization silently omits the capture
-  event
 - Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
   objects (`Box<dyn T>`)
 - Indexing or slicing collections like `Vec` (string slices like

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -147,11 +147,6 @@ const Description: React.FC = () => (
         <code>let</code>, but tracking events inside the branch isn't supported)
       </li>
       <li>
-        Closures — captures (whether by reference or by{' '}
-        <code>move</code>) aren't drawn as arrows, so the visualization
-        silently omits the capture event
-      </li>
-      <li>
         Smart-pointer wrappers (<code>Box</code>, <code>Rc</code>,{' '}
         <code>Arc</code>, <code>RefCell</code>) and trait objects (
         <code>Box&lt;dyn T&gt;</code>)

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -336,4 +336,44 @@ fn main() {
       },
     ],
   },
+  {
+    chapter: 'Closures',
+    examples: [
+      {
+        name: "Move closure (single capture)",
+        code: `fn main() {
+    let s = String::from("hi");
+    let f = move || println!("{}", s);
+    f();
+}`,
+      },
+      {
+        name: "Move closure (multiple captures)",
+        code: `fn main() {
+    let s = String::from("hi");
+    let t = String::from("bye");
+    let f = move || println!("{} {}", s, t);
+    f();
+}`,
+      },
+      {
+        name: "Borrow closure (immutable)",
+        code: `fn main() {
+    let s = String::from("hi");
+    let f = || println!("{}", s);
+    f();
+    println!("after: {}", s);
+}`,
+      },
+      {
+        name: "Borrow closure (mutable)",
+        code: `fn main() {
+    let mut s = String::from("hi");
+    let mut f = || s.push_str("!");
+    f();
+    println!("{}", s);
+}`,
+      },
+    ],
+  },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -84,6 +84,12 @@ const EXPECTED_OK: &[&str] = &[
     "box_string",
     "rc_clone",
     "box_dyn",
+    // — Closure captures (#79): capture arrows render for both
+    //   `move` and borrow closures.
+    "closure_move_single",
+    "closure_move_multi",
+    "closure_borrow_imm",
+    "closure_borrow_mut",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -444,6 +450,50 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "b.0.pointer, immutable",
             "b.0._marker, immutable",
             "b.1, immutable",
+        ],
+    },
+
+    // ─── Closure captures (#79) ──────────────────────────────────────
+    TooltipExpect {
+        name: "closure_move_single",
+        // `move ||` with a single captured upvar → Move arrow.
+        must_contain: &[
+            "Move from String::from to s",
+            "Move from s to f",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "closure_move_multi",
+        // Each captured upvar produces its own Move arrow.
+        must_contain: &[
+            "Move from s to f",
+            "Move from t to f",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "closure_borrow_imm",
+        // Non-`move` closure that reads its upvar → static borrow.
+        must_contain: &[
+            "Move from String::from to s",
+            "Immutable borrow from s to f",
+        ],
+        must_not_contain: &[
+            // Critically: the closure should *not* be modeled as a
+            // move — `s` is still usable after `f` runs.
+            "Move from s to f",
+        ],
+    },
+    TooltipExpect {
+        name: "closure_borrow_mut",
+        // Non-`move` closure that mutates its upvar → mutable borrow.
+        must_contain: &[
+            "Move from String::from to s",
+            "Mutable borrow from s to f",
+        ],
+        must_not_contain: &[
+            "Move from s to f",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -469,9 +469,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from s to f",
             "Closure f captures: s (moved)",
             "f goes out of scope. Its captured resources are dropped.",
-            // Move closure → f's timeline says it owns a closure
-            // that owns a resource (the moved upvar).
-            "f owns a closure which owns a resource",
+            // Move closure → f's timeline reports the exact count
+            // of move-captured resources owned via capture.
+            "f owns a closure which owns 1 resource via capture",
         ],
         must_not_contain: &[
             // Generic Move-arrow label would obscure the capture.
@@ -482,6 +482,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // Generic owner state message would obscure the
             // closure-vs-resource distinction.
             "f is the owner of the resource",
+            // Wrong pluralization guard.
+            "owns 1 resources",
         ],
     },
     TooltipExpect {
@@ -495,7 +497,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from t to f",
             "Closure f captures: s (moved), t (moved)",
             "f goes out of scope. Its captured resources are dropped.",
-            "f owns a closure which owns a resource",
+            "f owns a closure which owns 2 resources via capture",
         ],
         must_not_contain: &[
             "Move from s to f",
@@ -504,6 +506,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure f captures (moves) s's resource",
             "Closure f captures (moves) t's resource",
             "f is the owner of the resource",
+            "owns 2 resource via capture",
         ],
     },
     TooltipExpect {
@@ -534,8 +537,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure f captures an immutable reference to s",
             // No move captures → no "captured resources are dropped".
             "f goes out of scope. Its captured resources are dropped.",
-            // Borrow-only closure → no upgrade to "owns a resource".
-            "f owns a closure which owns a resource",
+            // Borrow-only closure → no upgrade to "owns N resources via capture".
+            "f owns a closure which owns",
             "f is the owner of the resource",
         ],
     },
@@ -561,7 +564,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Mutable borrow from s to f",
             "Closure f captures a mutable reference to s",
             "f goes out of scope. Its captured resources are dropped.",
-            "f owns a closure which owns a resource",
+            "f owns a closure which owns",
             "f is the owner of the resource",
         ],
     },

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -468,9 +468,10 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from String::from to s",
             "Closure capture (move) from s to f",
             "Closure f captures: s (moved)",
-            "f goes out of scope. Its captured resources are dropped.",
-            // Move closure → f's timeline reports the exact count
-            // of move-captured resources owned via capture.
+            // Scope-end and timeline tooltips both report the
+            // exact count of move-captured resources, with
+            // singular grammar at N == 1.
+            "f goes out of scope. Its 1 captured resource is dropped.",
             "f owns a closure which owns 1 resource via capture",
         ],
         must_not_contain: &[
@@ -482,8 +483,12 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // Generic owner state message would obscure the
             // closure-vs-resource distinction.
             "f is the owner of the resource",
-            // Wrong pluralization guard.
+            // Wrong pluralization guards.
             "owns 1 resources",
+            "1 captured resources are dropped",
+            // The previous count-less wording would slip through
+            // a substring match if we didn't pin the new one.
+            "Its captured resources are dropped",
         ],
     },
     TooltipExpect {
@@ -496,7 +501,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from s to f",
             "Closure capture (move) from t to f",
             "Closure f captures: s (moved), t (moved)",
-            "f goes out of scope. Its captured resources are dropped.",
+            "f goes out of scope. Its 2 captured resources are dropped.",
             "f owns a closure which owns 2 resources via capture",
         ],
         must_not_contain: &[
@@ -507,6 +512,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure f captures (moves) t's resource",
             "f is the owner of the resource",
             "owns 2 resource via capture",
+            "2 captured resource is dropped",
+            "Its captured resources are dropped",
         ],
     },
     TooltipExpect {
@@ -536,6 +543,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Immutable borrow from s to f",
             "Closure f captures an immutable reference to s",
             // No move captures → no "captured resources are dropped".
+            "f goes out of scope. Its 1 captured resource is dropped.",
+            "f goes out of scope. Its 2 captured resources are dropped.",
             "f goes out of scope. Its captured resources are dropped.",
             // Borrow-only closure → no upgrade to "owns N resources via capture".
             "f owns a closure which owns",
@@ -563,6 +572,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from s to f",
             "Mutable borrow from s to f",
             "Closure f captures a mutable reference to s",
+            "f goes out of scope. Its 1 captured resource is dropped.",
+            "f goes out of scope. Its 2 captured resources are dropped.",
             "f goes out of scope. Its captured resources are dropped.",
             "f owns a closure which owns",
             "f is the owner of the resource",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -501,11 +501,13 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     TooltipExpect {
         name: "closure_borrow_imm",
         // Non-`move` closure that reads its upvar → static borrow.
+        // No move captures, so f's scope-end gets the plain owner
+        // OOS message — there are no resources to drop.
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (immutable borrow) from s to f",
             "Closure f captures: s (immutably borrowed)",
-            "f goes out of scope. Its captured resources are dropped.",
+            "f goes out of scope",
         ],
         must_not_contain: &[
             // Critically: the closure should *not* be modeled as a
@@ -514,22 +516,27 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from s to f",
             "Immutable borrow from s to f",
             "Closure f captures an immutable reference to s",
+            // No move captures → no "captured resources are dropped".
+            "f goes out of scope. Its captured resources are dropped.",
         ],
     },
     TooltipExpect {
         name: "closure_borrow_mut",
         // Non-`move` closure that mutates its upvar → mutable borrow.
+        // Same as the immutable case for scope-end: no resources
+        // are dropped at the closure binding's OOS.
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (mutable borrow) from s to f",
             "Closure f captures: s (mutably borrowed)",
-            "f goes out of scope. Its captured resources are dropped.",
+            "f goes out of scope",
         ],
         must_not_contain: &[
             "Move from s to f",
             "Closure capture (move) from s to f",
             "Mutable borrow from s to f",
             "Closure f captures a mutable reference to s",
+            "f goes out of scope. Its captured resources are dropped.",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -469,6 +469,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from s to f",
             "Closure f captures: s (moved)",
             "f goes out of scope. Its captured resources are dropped.",
+            // Move closure → f's timeline says it owns a closure
+            // that owns a resource (the moved upvar).
+            "f owns a closure which owns a resource",
         ],
         must_not_contain: &[
             // Generic Move-arrow label would obscure the capture.
@@ -476,6 +479,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // Per-capture closure-side dots are suppressed in
             // favour of the combined Bind dot.
             "Closure f captures (moves) s's resource",
+            // Generic owner state message would obscure the
+            // closure-vs-resource distinction.
+            "f is the owner of the resource",
         ],
     },
     TooltipExpect {
@@ -489,6 +495,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure capture (move) from t to f",
             "Closure f captures: s (moved), t (moved)",
             "f goes out of scope. Its captured resources are dropped.",
+            "f owns a closure which owns a resource",
         ],
         must_not_contain: &[
             "Move from s to f",
@@ -496,6 +503,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // Per-capture closure-side dots suppressed.
             "Closure f captures (moves) s's resource",
             "Closure f captures (moves) t's resource",
+            "f is the owner of the resource",
         ],
     },
     TooltipExpect {
@@ -513,6 +521,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "f's immutable borrow ends",
             "s's resource is no longer immutably borrowed",
             "f goes out of scope",
+            // Borrow-only closure → f owns the closure value but
+            // not any captured resource.
+            "f owns a closure",
         ],
         must_not_contain: &[
             // Critically: the closure should *not* be modeled as a
@@ -523,6 +534,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Closure f captures an immutable reference to s",
             // No move captures → no "captured resources are dropped".
             "f goes out of scope. Its captured resources are dropped.",
+            // Borrow-only closure → no upgrade to "owns a resource".
+            "f owns a closure which owns a resource",
+            "f is the owner of the resource",
         ],
     },
     TooltipExpect {
@@ -539,6 +553,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "f's mutable borrow ends",
             "s's resource is no longer mutably borrowed",
             "f goes out of scope",
+            "f owns a closure",
         ],
         must_not_contain: &[
             "Move from s to f",
@@ -546,6 +561,8 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Mutable borrow from s to f",
             "Closure f captures a mutable reference to s",
             "f goes out of scope. Its captured resources are dropped.",
+            "f owns a closure which owns a resource",
+            "f is the owner of the resource",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -502,11 +502,16 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         name: "closure_borrow_imm",
         // Non-`move` closure that reads its upvar → static borrow.
         // No move captures, so f's scope-end gets the plain owner
-        // OOS message — there are no resources to drop.
+        // OOS message — there are no resources to drop. The borrow
+        // returns at f's NLL last use (the call on the line after
+        // the closure literal), not at the closure's lexical scope.
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (immutable borrow) from s to f",
             "Closure f captures: s (immutably borrowed)",
+            "Return immutably borrowed resource from f to s",
+            "f's immutable borrow ends",
+            "s's resource is no longer immutably borrowed",
             "f goes out of scope",
         ],
         must_not_contain: &[
@@ -524,11 +529,15 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         name: "closure_borrow_mut",
         // Non-`move` closure that mutates its upvar → mutable borrow.
         // Same as the immutable case for scope-end: no resources
-        // are dropped at the closure binding's OOS.
+        // are dropped at the closure binding's OOS, and the
+        // borrow returns at the closure's NLL last use.
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (mutable borrow) from s to f",
             "Closure f captures: s (mutably borrowed)",
+            "Return mutably borrowed resource from f to s",
+            "f's mutable borrow ends",
+            "s's resource is no longer mutably borrowed",
             "f goes out of scope",
         ],
         must_not_contain: &[

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -454,35 +454,53 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     },
 
     // ─── Closure captures (#79) ──────────────────────────────────────
+    //
+    // Move/borrow events into a closure binding render with
+    // capture-flavoured arrow labels (`Closure capture (move)` /
+    // `… (immutable borrow)` / `… (mutable borrow)`) instead of the
+    // generic `Move` / `Immutable borrow` / `Mutable borrow`. The
+    // closure binding's scope-end also gets a "captured resources
+    // are dropped" message in place of the generic "resource is
+    // dropped" suffix.
     TooltipExpect {
         name: "closure_move_single",
-        // `move ||` with a single captured upvar → Move arrow.
         must_contain: &[
             "Move from String::from to s",
+            "Closure capture (move) from s to f",
+            "f goes out of scope. Its captured resources are dropped.",
+        ],
+        must_not_contain: &[
+            // Generic Move-arrow label would obscure the capture.
             "Move from s to f",
         ],
-        must_not_contain: &[],
     },
     TooltipExpect {
         name: "closure_move_multi",
-        // Each captured upvar produces its own Move arrow.
+        // Each captured upvar produces its own capture arrow.
         must_contain: &[
+            "Closure capture (move) from s to f",
+            "Closure capture (move) from t to f",
+            "f goes out of scope. Its captured resources are dropped.",
+        ],
+        must_not_contain: &[
             "Move from s to f",
             "Move from t to f",
         ],
-        must_not_contain: &[],
     },
     TooltipExpect {
         name: "closure_borrow_imm",
         // Non-`move` closure that reads its upvar → static borrow.
         must_contain: &[
             "Move from String::from to s",
-            "Immutable borrow from s to f",
+            "Closure capture (immutable borrow) from s to f",
+            "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
             // Critically: the closure should *not* be modeled as a
             // move — `s` is still usable after `f` runs.
             "Move from s to f",
+            "Closure capture (move) from s to f",
+            "Immutable borrow from s to f",
         ],
     },
     TooltipExpect {
@@ -490,10 +508,13 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // Non-`move` closure that mutates its upvar → mutable borrow.
         must_contain: &[
             "Move from String::from to s",
-            "Mutable borrow from s to f",
+            "Closure capture (mutable borrow) from s to f",
+            "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
             "Move from s to f",
+            "Closure capture (move) from s to f",
+            "Mutable borrow from s to f",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -467,24 +467,35 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (move) from s to f",
+            "Closure f captures: s (moved)",
             "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
             // Generic Move-arrow label would obscure the capture.
             "Move from s to f",
+            // Per-capture closure-side dots are suppressed in
+            // favour of the combined Bind dot.
+            "Closure f captures (moves) s's resource",
         ],
     },
     TooltipExpect {
         name: "closure_move_multi",
-        // Each captured upvar produces its own capture arrow.
+        // Each captured upvar produces its own capture arrow on
+        // the source side; on the closure side, a single Bind dot
+        // enumerates every capture so neither tooltip masks the
+        // other (#79 follow-up).
         must_contain: &[
             "Closure capture (move) from s to f",
             "Closure capture (move) from t to f",
+            "Closure f captures: s (moved), t (moved)",
             "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
             "Move from s to f",
             "Move from t to f",
+            // Per-capture closure-side dots suppressed.
+            "Closure f captures (moves) s's resource",
+            "Closure f captures (moves) t's resource",
         ],
     },
     TooltipExpect {
@@ -493,6 +504,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (immutable borrow) from s to f",
+            "Closure f captures: s (immutably borrowed)",
             "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
@@ -501,6 +513,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from s to f",
             "Closure capture (move) from s to f",
             "Immutable borrow from s to f",
+            "Closure f captures an immutable reference to s",
         ],
     },
     TooltipExpect {
@@ -509,12 +522,14 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "Move from String::from to s",
             "Closure capture (mutable borrow) from s to f",
+            "Closure f captures: s (mutably borrowed)",
             "f goes out of scope. Its captured resources are dropped.",
         ],
         must_not_contain: &[
             "Move from s to f",
             "Closure capture (move) from s to f",
             "Mutable borrow from s to f",
+            "Closure f captures a mutable reference to s",
         ],
     },
 ];

--- a/rustviz-plugin/README.md
+++ b/rustviz-plugin/README.md
@@ -47,9 +47,6 @@ not all of it. Currently unsupported (or known to misbehave):
 - Bindings or borrows inside an `if` or `match` branch body (the
   conditional itself can return a value into a `let`, but tracking
   events inside the branch isn't supported)
-- Closures — captures (whether by reference or by `move`) aren't
-  drawn as arrows, so the visualization silently omits the capture
-  event
 - Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
   objects (`Box<dyn T>`)
 - Indexing or slicing collections like `Vec` (string slices like

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -954,6 +954,64 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
     ExprKind::DropTemps(exp) => {
       self.match_rhs(lhs, &exp, evt);
     }
+    // `let f = move || ...` / `let f = || ...`. The closure itself
+    // is conceptually a small struct that holds the upvars it
+    // captures from the enclosing scope. Bind `f` to that struct
+    // (Anonymous source — we don't render the closure body), then
+    // emit one capture event per upvar pulled from rustc's
+    // `closure_min_captures_flattened`. Capture kind decides the
+    // event shape:
+    //   ByValue (always for `move`, sometimes for inferred captures)
+    //     → Move(upvar → f). f now owns the captured resource.
+    //   ByRef(Immutable | UniqueImmBorrow) → SBorrow(upvar → f).
+    //   ByRef(Mutable)                     → MBorrow(upvar → f).
+    //   ByUse (`use` capture clause, recent feature) → Move,
+    //     same as ByValue for our purposes.
+    //
+    // We only handle whole-variable captures here (place.projections
+    // empty); a partial-field capture like `move || x.field`
+    // carries projections we don't have a column for, so we
+    // attribute the event to the root variable's RAP. That matches
+    // what the rest of the plugin does for field accesses today.
+    ExprKind::Closure(closure) => {
+      let line_num = span_to_line(&rhs.span, &self.tcx);
+      // Bind for the closure value itself — gives `f` an "acquires
+      // ownership of a resource" dot like other Bind sites.
+      self.add_ev(line_num, Evt::Bind, lhs.clone(), ResourceTy::Anonymous, false);
+
+      let typeck = self.tcx.typeck(closure.def_id);
+      for capture in typeck.closure_min_captures_flattened(closure.def_id) {
+        let upvar_hir_id = match capture.place.base {
+          rustc_middle::hir::place::PlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
+          _ => continue,
+        };
+        // Use the registered RAP name for the upvar (covers
+        // `r.a.b`-style nested field captures via expr_to_rap_name's
+        // counterpart on the source side; for now we just take the
+        // root variable's name).
+        let upvar_name = self.tcx.hir_name(upvar_hir_id).as_str().to_owned();
+        let upvar_rap = match self.raps.get(&upvar_name) {
+          Some(rd) => rd.rap.to_owned(),
+          None => continue,
+        };
+        let from = ResourceTy::Value(upvar_rap);
+        let to = lhs.clone();
+        let evt_kind = match capture.info.capture_kind {
+          rustc_middle::ty::UpvarCapture::ByValue
+          | rustc_middle::ty::UpvarCapture::ByUse => Evt::Move,
+          rustc_middle::ty::UpvarCapture::ByRef(kind) => match kind {
+            rustc_middle::ty::BorrowKind::Mutable => Evt::MBorrow,
+            // Immutable + UniqueImmBorrow both render as a static
+            // (immutable) borrow from the user's perspective —
+            // UniqueImmBorrow is an internal closure-borrow flavor
+            // they can't write, and the visualization shouldn't
+            // distinguish it.
+            _ => Evt::SBorrow,
+          },
+        };
+        self.add_ev(line_num, evt_kind, to, from, false);
+      }
+    }
     _ => {
       warn!("unmatched rhs {:#?}", rhs);
     }

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -993,6 +993,16 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       // ownership of a resource" dot like other Bind sites.
       self.add_ev(line_num, Evt::Bind, lhs.clone(), ResourceTy::Anonymous, false);
 
+      // MIR loan facts for the enclosing fn body. Each ref capture
+      // becomes one polonius loan whose `borrowed_place` is the
+      // upvar and whose `region.1` is the NLL kill line — the line
+      // where the borrow ends, which under NLL is the closure
+      // binding's last use, not its lexical scope end. We use this
+      // below to emit a StaticDie / MutableDie at the kill line so
+      // the captured borrow visually returns to its lender on the
+      // line the user expects.
+      let mir_b_data = self.gather_borrow_data(self.bwf);
+
       let typeck = self.tcx.typeck(closure.def_id);
       for capture in typeck.closure_min_captures_flattened(closure.def_id) {
         let upvar_hir_id = match capture.place.base {
@@ -1023,7 +1033,41 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
             _ => Evt::SBorrow,
           },
         };
-        self.add_ev(line_num, evt_kind, to, from, false);
+        self.add_ev(line_num, evt_kind.clone(), to, from.clone(), false);
+
+        // For ref captures, find the matching MIR loan and emit
+        // a Die event at its kill line so the borrow returns on
+        // the closure's last use, not at the closure's lexical
+        // scope end. Move captures don't go through the loan
+        // machinery — they transfer ownership outright, and the
+        // closure's drop is what releases them.
+        let die_evt = match evt_kind {
+          Evt::SBorrow => Some(Evt::SDie),
+          Evt::MBorrow => Some(Evt::MDie),
+          _ => None,
+        };
+        if let Some(die_evt) = die_evt {
+          let kill_line = mir_b_data.iter().find_map(|b| {
+            // Match on (assignment line, upvar name): the loan
+            // for this capture is issued at the closure literal's
+            // line and borrows the upvar by name. region.1 is the
+            // NLL-refined kill line.
+            if b.region.0 == line_num
+              && b.borrowed_place.as_deref() == Some(upvar_name.as_str())
+            {
+              Some(b.region.1)
+            } else {
+              None
+            }
+          });
+          if let Some(die_line) = kill_line {
+            // add_ev maps (lhs, rhs) → StaticDie/MutableDie
+            // {from: rhs, to: lhs}. We want from=closure (f),
+            // to=upvar (s) so the renderer's return arrow goes
+            // f → s, mirroring the borrow direction.
+            self.add_ev(die_line, die_evt, from, lhs.clone(), false);
+          }
+        }
       }
     }
     _ => {

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -196,7 +196,14 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
 
   // Adds an owner RAP
   pub fn add_owner(&mut self, name: String, mutability: bool, is_copy: bool, scope: usize, is_global: bool) {
-    self.add_rap(ResourceAccessPoint::Owner(Owner{name: name, hash: self.rap_hashes as u64, is_mut: mutability, is_copy}), scope, is_global);
+    self.add_rap(ResourceAccessPoint::Owner(Owner{name: name, hash: self.rap_hashes as u64, is_mut: mutability, is_copy, is_closure: false}), scope, is_global);
+  }
+
+  // Adds an owner RAP that binds a closure literal. Routed through
+  // a separate constructor (rather than an extra arg on add_owner) so
+  // we don't churn every call site — closures are the only producer.
+  pub fn add_closure_owner(&mut self, name: String, mutability: bool, scope: usize, is_global: bool) {
+    self.add_rap(ResourceAccessPoint::Owner(Owner{name: name, hash: self.rap_hashes as u64, is_mut: mutability, is_copy: false, is_closure: true}), scope, is_global);
   }
 
   // Adds a reference RAP
@@ -576,6 +583,13 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     }
     else if ty.is_fn() {
       error!("cannot have fn as lhs of expr");
+    }
+    else if ty.is_closure() {
+      // Tag the binding as a closure so the tooltip layer can swap
+      // capture-flavoured wording for moves/borrows into `name` and
+      // for `name`'s scope-end. The `match_rhs` ExprKind::Closure
+      // arm emits the actual capture events on top of this RAP.
+      self.add_closure_owner(name, mutability, self.current_scope, !self.inside_branch);
     }
     else {
       let is_copy = self.ty_is_copy(ty, expr.hir_id.owner);

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -92,6 +92,11 @@ pub struct Owner {
     /// going out of scope reclaims storage but doesn't run any
     /// drop glue; we surface that distinction visually.
     pub is_copy: bool,
+    /// True iff this owner binds a closure literal (`let f = || ...`
+    /// or `let f = move || ...`). Routes capture-related events
+    /// (Move/StaticBorrow/MutableBorrow into `f`) and `f`'s scope-end
+    /// to closure-flavoured tooltip text.
+    pub is_closure: bool,
 }
 
 // when something is a struct member
@@ -188,6 +193,13 @@ impl ResourceTy {
           }
     }
 
+    pub fn is_closure(&self) -> bool {
+        match self {
+            ResourceTy::Value(r) | ResourceTy::Deref(r) => r.is_closure(),
+            _ => false
+        }
+    }
+
     pub fn extract_rap(&self) -> Option<&ResourceAccessPoint> {
         match self {
             ResourceTy::Anonymous | ResourceTy::Caller => None,
@@ -271,6 +283,13 @@ impl ResourceAccessPoint {
             ResourceAccessPoint::MutRef(_) => true,
             _ => false
         }
+    }
+
+    /// True iff this RAP is the binding of a closure literal — used
+    /// by the tooltip layer to swap in capture-flavoured wording for
+    /// events that flow into or out of a closure.
+    pub fn is_closure(&self) -> bool {
+        matches!(self, ResourceAccessPoint::Owner(Owner { is_closure: true, .. }))
     }
 
     /// True if this RAP is part of a struct grouping — either the
@@ -989,15 +1008,24 @@ impl Event {
             Event::Move{ to ,..} => {
                 match to {
                     ResourceTy::Caller => safe_message(hover_messages::event_dot_move_to_caller, &self.deref_name(my_name), to),
+                    _ if to.is_closure() => safe_message(hover_messages::event_dot_capture_move_to_closure, &self.deref_name(my_name), to),
                     _ => safe_message(hover_messages::event_dot_move_to, &self.deref_name(my_name), to),
                 }
-                
+
             }
             Event::StaticLend{ to ,..} => {
-                safe_message(hover_messages::event_dot_static_lend, &self.deref_name(my_name), to)
+                if to.is_closure() {
+                    safe_message(hover_messages::event_dot_capture_static_lend_to_closure, &self.deref_name(my_name), to)
+                } else {
+                    safe_message(hover_messages::event_dot_static_lend, &self.deref_name(my_name), to)
+                }
             }
             Event::MutableLend{ to ,..} => {
-                safe_message(hover_messages::event_dot_mut_lend, &self.deref_name(my_name), to)
+                if to.is_closure() {
+                    safe_message(hover_messages::event_dot_capture_mut_lend_to_closure, &self.deref_name(my_name), to)
+                } else {
+                    safe_message(hover_messages::event_dot_mut_lend, &self.deref_name(my_name), to)
+                }
             }
             Event::StaticDie{ to,.. } => {
                 safe_message(hover_messages::event_dot_static_return, &self.deref_name(my_name), to)
@@ -1006,17 +1034,35 @@ impl Event {
                 safe_message(hover_messages::event_dot_mut_return, &self.deref_name(my_name), to)
             }
             // arrow going in
-            Event::Acquire{ from ,..} => {
-                safe_message(hover_messages::event_dot_acquire, &self.deref_name(my_name), from)
+            Event::Acquire{ from, is, ..} => {
+                if is.is_closure() && from.extract_rap().is_some() {
+                    // `f` (closure) acquiring from a real source —
+                    // this is a `move`-capture, not a generic
+                    // ownership transfer. The Anonymous-from case
+                    // (the closure literal's own Bind) keeps the
+                    // generic message because there's no captured
+                    // upvar to name on the closure side yet.
+                    safe_message(hover_messages::event_dot_closure_capture_acquire, &self.deref_name(my_name), from)
+                } else {
+                    safe_message(hover_messages::event_dot_acquire, &self.deref_name(my_name), from)
+                }
             }
             Event::Copy{ from ,..} => {
                 safe_message(hover_messages::event_dot_copy_from, &self.deref_name(my_name), from)
             }
-            Event::MutableBorrow{ from ,..} => {
-                hover_messages::event_dot_mut_borrow(&self.deref_name(my_name), &from.name())
+            Event::MutableBorrow{ from, is, ..} => {
+                if is.is_closure() {
+                    hover_messages::event_dot_closure_capture_mut_borrow(&self.deref_name(my_name), &from.name())
+                } else {
+                    hover_messages::event_dot_mut_borrow(&self.deref_name(my_name), &from.name())
+                }
             }
-            Event::StaticBorrow{ from ,..} => {
-                hover_messages::event_dot_static_borrow(&self.deref_name(my_name), &from.name())
+            Event::StaticBorrow{ from, is, ..} => {
+                if is.is_closure() {
+                    hover_messages::event_dot_closure_capture_static_borrow(&self.deref_name(my_name), &from.name())
+                } else {
+                    hover_messages::event_dot_static_borrow(&self.deref_name(my_name), &from.name())
+                }
             }
             Event::StaticReacquire{ from ,..} => {
                 safe_message(hover_messages::event_dot_static_reacquire, &self.deref_name(my_name), from)
@@ -1101,23 +1147,31 @@ pub fn string_of_external_event(e: &ExternalEvent) -> String {
             String::from("Bind")
         },
         ExternalEvent::Copy{ is_partial,.. } => {
-            if *is_partial { String::from("Partial copy") } 
+            if *is_partial { String::from("Partial copy") }
             else { String::from("Copy") }
         },
-        ExternalEvent::Move{ is_partial, .. } => {
-            if *is_partial { String::from("Partial move")}
+        // Move/StaticBorrow/MutableBorrow into a closure binding are
+        // closure captures — the renderer's `from … to …` template
+        // (in render_arrow) reads e.g. "Closure capture (move)" as
+        // "Closure capture (move) from s to f", which scans more
+        // clearly than a bare "Move" arrow into a closure.
+        ExternalEvent::Move{ is_partial, to, .. } => {
+            if *is_partial { String::from("Partial move") }
+            else if to.is_closure() { String::from("Closure capture (move)") }
             else { String::from("Move") }
         },
-        ExternalEvent::StaticBorrow{ is_partial, .. } => {
+        ExternalEvent::StaticBorrow{ is_partial, to, .. } => {
             if *is_partial { String::from("Partial immutable borrow") }
+            else if to.is_closure() { String::from("Closure capture (immutable borrow)") }
             else { String::from("Immutable borrow") }
         },
         ExternalEvent::StaticDie{ .. } => {
             String::from("Return immutably borrowed resource")
         },
-        ExternalEvent::MutableBorrow{ is_partial, .. } => {
+        ExternalEvent::MutableBorrow{ is_partial, to, .. } => {
             if *is_partial { String::from("Partial Mutable borrow") }
-            else { String::from("Mutable borrow")}
+            else if to.is_closure() { String::from("Closure capture (mutable borrow)") }
+            else { String::from("Mutable borrow") }
         },
         ExternalEvent::MutableDie{ .. } => {
            String::from("Return mutably borrowed resource")

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1314,6 +1314,22 @@ impl Visualizable for VisualizationData {
                 }
             },
             
+            // Closure binding takes a mutable capture: the closure
+            // is at FullPrivilege from its Bind-Acquire, takes a
+            // mutable borrow of an upvar, and stays at
+            // FullPrivilege — the borrow is internal to the
+            // closure's value, not a state change of `f` itself.
+            // Mirror for MutableDie at the closure's NLL last use:
+            // the borrow ends but the closure binding survives,
+            // unlike an ordinary MutRef binding (which the next
+            // arm covers).
+            (State::FullPrivilege{..}, Event::MutableBorrow { is, .. })
+            | (State::FullPrivilege{..}, Event::MutableDie { is, .. })
+                if is.is_closure() =>
+            {
+                State::FullPrivilege { s: LineState::Full }
+            }
+
             // happends when a mutable reference returns, invalid otherwise
             (State::FullPrivilege{..}, Event::MutableDie{ .. }) =>
                 State::OutOfScope,

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1575,7 +1575,7 @@ impl Visualizable for VisualizationData {
         },
         ExternalEvent::MutableBorrow{from: from_ro, to: to_ro, id, ..} => {
           if to_o { vec![(line_num,  Event::MutableBorrow{from : from_ro.to_owned(), is: to_ro.clone(), id: *id})] }
-          else { vec![(line_num, Event::MutableLend{to : to_ro.to_owned(), is: from_ro.clone(), id: *id})] }          
+          else { vec![(line_num, Event::MutableLend{to : to_ro.to_owned(), is: from_ro.clone(), id: *id})] }
         },
         ExternalEvent::MutableDie{from: from_ro, to: to_ro, id} => {
           if to_o && !from_ro.is_same_underlying(&to_ro){ 
@@ -1811,7 +1811,7 @@ impl Visualizable for VisualizationData {
             ExternalEvent::StaticBorrow{from: from_ro, to: to_ro, id, ..} => {
                 maybe_append_event(self, &from_ro, Event::StaticLend{to : to_ro.to_owned(), is: from_ro.clone(), id: id}, line_number);
                 maybe_append_event(self, &to_ro.clone(), Event::StaticBorrow{from : from_ro.to_owned(), is: to_ro, id: id}, line_number);
-                
+
             },
             ExternalEvent::StaticDie{from: from_ro, to: to_ro, id} => {
               // this catches when StaticDie(s to s*) to avoid duplicate events
@@ -1823,7 +1823,7 @@ impl Visualizable for VisualizationData {
             ExternalEvent::MutableBorrow{from: from_ro, to: to_ro, id, ..} => {
                 maybe_append_event(self, &from_ro, Event::MutableLend{to : to_ro.to_owned(), is: from_ro.clone(), id: id}, line_number);
                 maybe_append_event(self, &to_ro.clone(), Event::MutableBorrow{from : from_ro.to_owned(), is: to_ro, id: id}, line_number);
-                
+
             },
             ExternalEvent::MutableDie{from: from_ro, to: to_ro, id} => {
                 // this catches when MutableDie(s to s*) to avoid duplicate events

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -50,19 +50,21 @@ pub fn event_dot_owner_go_out_out_scope(my_name: &String) -> String {
 }
 
 // Closure binding goes out of scope. The closure value is dropped,
-// which in turn drops every captured upvar (for `move` captures) or
-// ends the borrow of every captured upvar (for ref captures). The
-// distinction isn't surfaced here because either way, from the
-// captured upvar's point of view, the closure releases it.
-//
-// Includes the "captured resources are dropped" suffix inline so the
-// timeline_panel's drop-dot path doesn't append the generic
-// "Its resource is dropped." tail to a closure's scope-end.
-pub fn event_dot_closure_go_out_of_scope(my_name: &String) -> String {
+// which in turn drops each move-captured upvar — `move_capture_count`
+// is how many of those there are. Reaches the timeline only when
+// the count is at least one (borrow-only and capture-less closures
+// take the plain owner-OOS path), so the singular/plural branch
+// only needs to handle ≥1.
+pub fn event_dot_closure_go_out_of_scope(my_name: &String, move_capture_count: usize) -> String {
     let my_name_fmt = fmt_style(my_name);
+    let (noun, verb) = if move_capture_count == 1 {
+        ("resource", "is")
+    } else {
+        ("resources", "are")
+    };
     format!(
-        "{0} goes out of scope. Its captured resources are dropped.",
-        my_name_fmt
+        "{0} goes out of scope. Its {1} captured {2} {3} dropped.",
+        my_name_fmt, move_capture_count, noun, verb
     )
 }
 

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -49,6 +49,23 @@ pub fn event_dot_owner_go_out_out_scope(my_name: &String) -> String {
     )                             //was moved from the variable earlier.
 }
 
+// Closure binding goes out of scope. The closure value is dropped,
+// which in turn drops every captured upvar (for `move` captures) or
+// ends the borrow of every captured upvar (for ref captures). The
+// distinction isn't surfaced here because either way, from the
+// captured upvar's point of view, the closure releases it.
+//
+// Includes the "captured resources are dropped" suffix inline so the
+// timeline_panel's drop-dot path doesn't append the generic
+// "Its resource is dropped." tail to a closure's scope-end.
+pub fn event_dot_closure_go_out_of_scope(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!(
+        "{0} goes out of scope. Its captured resources are dropped.",
+        my_name_fmt
+    )
+}
+
 // An owned (non-ref) function parameter receives its resource from
 // whatever the caller passed. The L-shaped arrow on the param's
 // timeline visually anchors that "from outside this scope" origin;
@@ -269,6 +286,74 @@ pub fn event_dot_static_borrow(my_name: &String, _target_name: &String) -> Strin
     format!(
         "{0} immutably borrows a resource",
         my_name_fmt
+    )
+}
+
+// ─── Closure capture variants ────────────────────────────────────
+//
+// Used when the `to`/`is` of an event is a closure binding. Wording
+// emphasizes that the move/borrow is happening because the closure
+// captured the upvar, not because the user wrote an explicit `let
+// y = x` / `let r = &x`.
+
+// Source dot for a `move`-captured upvar. Mirrors event_dot_move_to.
+pub fn event_dot_capture_move_to_closure(my_name: &String, target_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let target_fmt = fmt_style(target_name);
+    format!(
+        "{0}'s resource is captured (moved) by closure {1}",
+        my_name_fmt, target_fmt
+    )
+}
+
+// Source dot for an immutably captured upvar. Mirrors event_dot_static_lend.
+pub fn event_dot_capture_static_lend_to_closure(my_name: &String, target_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let target_fmt = fmt_style(target_name);
+    format!(
+        "{0}'s resource is captured (immutably borrowed) by closure {1}",
+        my_name_fmt, target_fmt
+    )
+}
+
+// Source dot for a mutably captured upvar. Mirrors event_dot_mut_lend.
+pub fn event_dot_capture_mut_lend_to_closure(my_name: &String, target_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let target_fmt = fmt_style(target_name);
+    format!(
+        "{0}'s resource is captured (mutably borrowed) by closure {1}",
+        my_name_fmt, target_fmt
+    )
+}
+
+// Closure-side dot when a `move`-captured upvar lands on `f`'s
+// timeline. Mirrors event_dot_acquire.
+pub fn event_dot_closure_capture_acquire(my_name: &String, from_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let from_fmt = fmt_style(from_name);
+    format!(
+        "Closure {0} captures (moves) {1}'s resource",
+        my_name_fmt, from_fmt
+    )
+}
+
+// Closure-side dot for an immutable capture. Mirrors event_dot_static_borrow.
+pub fn event_dot_closure_capture_static_borrow(my_name: &String, from_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let from_fmt = fmt_style(from_name);
+    format!(
+        "Closure {0} captures an immutable reference to {1}",
+        my_name_fmt, from_fmt
+    )
+}
+
+// Closure-side dot for a mutable capture. Mirrors event_dot_mut_borrow.
+pub fn event_dot_closure_capture_mut_borrow(my_name: &String, from_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    let from_fmt = fmt_style(from_name);
+    format!(
+        "Closure {0} captures a mutable reference to {1}",
+        my_name_fmt, from_fmt
     )
 }
 

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -326,6 +326,32 @@ pub fn event_dot_capture_mut_lend_to_closure(my_name: &String, target_name: &Str
     )
 }
 
+// Combined tooltip for the closure binding's Bind-Acquire dot
+// when one or more upvars are captured at the closure literal.
+// `captures` lists (upvar_name, capture_kind_label) pairs in the
+// order they were emitted by expr_visitor's Closure arm. Used in
+// place of the per-capture closure-side dots, which would
+// otherwise stack on the same (x,y) and mask each other.
+pub fn event_dot_closure_bind_with_captures(
+    my_name: &String,
+    captures: &[(String, &'static str)],
+) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    if captures.is_empty() {
+        // Closure with no captures (e.g. `let f = || println!("hi")`).
+        return format!("Closure {0} is bound", my_name_fmt);
+    }
+    let parts: Vec<String> = captures
+        .iter()
+        .map(|(name, kind)| format!("{} ({})", fmt_style(name), kind))
+        .collect();
+    format!(
+        "Closure {0} captures: {1}",
+        my_name_fmt,
+        parts.join(", ")
+    )
+}
+
 // Closure-side dot when a `move`-captured upvar lands on `f`'s
 // timeline. Mirrors event_dot_acquire.
 pub fn event_dot_closure_capture_acquire(my_name: &String, from_name: &String) -> String {

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -647,12 +647,18 @@ pub fn state_full_privilege(my_name: &String) -> String {
 
 // Closure binding's FullPrivilege state. Two flavours so the
 // timeline tooltip distinguishes a `move ||` (closure owns the
-// captured resource — drop runs at scope-end) from a borrow-only
+// captured resources — drop runs at scope-end) from a borrow-only
 // closure (captures a reference; nothing of the resource is owned
-// by the closure value itself).
-pub fn state_closure_full_privilege_with_resource(my_name: &String) -> String {
+// by the closure value itself). The move-flavoured variant takes
+// the count of move-captured upvars so the tooltip is honest
+// about whether the closure owns one or many resources.
+pub fn state_closure_full_privilege_with_resource(my_name: &String, move_capture_count: usize) -> String {
     let my_name_fmt = fmt_style(my_name);
-    format!("{0} owns a closure which owns a resource", my_name_fmt)
+    let noun = if move_capture_count == 1 { "resource" } else { "resources" };
+    format!(
+        "{0} owns a closure which owns {1} {2} via capture",
+        my_name_fmt, move_capture_count, noun
+    )
 }
 
 pub fn state_closure_full_privilege_no_resource(my_name: &String) -> String {

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -638,11 +638,26 @@ pub fn state_resource_revoked(my_name: &String, _to_name: &String) -> String {
 pub fn state_full_privilege(my_name: &String) -> String {
     // update styling
     let my_name_fmt = fmt_style(my_name);
-    
+
     format!(
         "{0} is the owner of the resource", //not necessarily write if let was used rather than let mut
         my_name_fmt
     )
+}
+
+// Closure binding's FullPrivilege state. Two flavours so the
+// timeline tooltip distinguishes a `move ||` (closure owns the
+// captured resource — drop runs at scope-end) from a borrow-only
+// closure (captures a reference; nothing of the resource is owned
+// by the closure value itself).
+pub fn state_closure_full_privilege_with_resource(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!("{0} owns a closure which owns a resource", my_name_fmt)
+}
+
+pub fn state_closure_full_privilege_no_resource(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!("{0} owns a closure", my_name_fmt)
 }
 
 // More than one ResourceOwner has access to the underlying resource

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -621,12 +621,29 @@ fn render_dot(
     resource_hold: bool
 ) {
     for (line_number, event) in history.iter() {
+        // Closure-capture per-upvar dots on the closure's own
+        // timeline are suppressed here: the closure's Bind-Acquire
+        // dot at the same line carries a combined tooltip listing
+        // every capture (see the Anonymous-from arm below). The
+        // per-capture events stay in `history` because the arrow
+        // renderer traverses them to find the closure column for
+        // each capture arrow's endpoint.
+        let is_closure_capture_event = match event {
+            Event::Acquire { from: ResourceTy::Anonymous, .. } => false,
+            Event::Acquire { is, .. }
+            | Event::StaticBorrow { is, .. }
+            | Event::MutableBorrow { is, .. } => is.is_closure(),
+            _ => false,
+        };
+        if is_closure_capture_event {
+            continue;
+        }
         //matching the event
         match event {
             Event::RefDie { .. } => {
                 continue;
             }
-            Event::Branch { is, branch_history, ty, split_point, merge_point, .. } => { 
+            Event::Branch { is, branch_history, ty, split_point, merge_point, .. } => {
                 // first append split dot
                 let b_data = EventDotData {
                     hash: *hash as u64,
@@ -766,13 +783,73 @@ fn render_dot(
                     continue;
                 },
                 _ => {
-                    data.title = event.print_message_with_name(& mut name);
+                    // Closure Bind-Acquire: aggregate every capture
+                    // event landing at the same line into a single
+                    // tooltip listing all captured upvars, since the
+                    // per-capture target-side dots are suppressed
+                    // (they'd stack on this one and the topmost
+                    // tooltip would mask the rest).
+                    if let Event::Acquire { from: ResourceTy::Anonymous, is, .. } = event {
+                        if is.is_closure() {
+                            let captures = collect_closure_captures(visualization_data, *hash, *line_number);
+                            data.title = hover_messages::event_dot_closure_bind_with_captures(&name, &captures);
+                        } else {
+                            data.title = event.print_message_with_name(& mut name);
+                        }
+                    } else {
+                        data.title = event.print_message_with_name(& mut name);
+                    }
                 }
             }
         }
         // push to individual timelines
         append_dot(&data, output, timeline_data, registry);
     }
+}
+
+// Walk the original ExternalEvents to find every capture (Move /
+// StaticBorrow / MutableBorrow) at `line` whose target is the
+// closure identified by `closure_hash`. Returns (upvar_name,
+// kind_label) pairs in source order so the rendered list matches
+// what the user wrote in the closure literal.
+fn collect_closure_captures(
+    visualization_data: &VisualizationData,
+    closure_hash: u64,
+    line: usize,
+) -> Vec<(String, &'static str)> {
+    let mut out = Vec::new();
+    for (l, ev) in &visualization_data.external_events {
+        if *l != line {
+            continue;
+        }
+        match ev {
+            ExternalEvent::Move { from, to, .. } if matches_closure(to, closure_hash) => {
+                if let Some(name) = upvar_name(from) {
+                    out.push((name, "moved"));
+                }
+            }
+            ExternalEvent::StaticBorrow { from, to, .. } if matches_closure(to, closure_hash) => {
+                if let Some(name) = upvar_name(from) {
+                    out.push((name, "immutably borrowed"));
+                }
+            }
+            ExternalEvent::MutableBorrow { from, to, .. } if matches_closure(to, closure_hash) => {
+                if let Some(name) = upvar_name(from) {
+                    out.push((name, "mutably borrowed"));
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn matches_closure(rty: &ResourceTy, closure_hash: u64) -> bool {
+    rty.extract_rap().map_or(false, |r| *r.hash() == closure_hash)
+}
+
+fn upvar_name(rty: &ResourceTy) -> Option<String> {
+    rty.extract_rap().map(|r| r.name().to_owned())
 }
 
 // Same routing logic as `append_dot` (struct-grouped vs flat

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -703,29 +703,32 @@ fn render_dot(
                     let is_copy = ro.is_copy();
                     let is_closure = ro.is_closure();
                     if is_closure {
-                        // The closure value is dropped, which in turn
-                        // drops every captured upvar (move) or ends
-                        // the borrow (ref). For borrow-capture
-                        // closures, `resource_hold` ends up false on
-                        // `f` (no Move/Acquire of an owned resource
-                        // on `f`'s timeline), so the generic flow
-                        // would say "No resource is dropped" — wrong
-                        // for a closure, whose drop *is* what
-                        // releases the captures. Override unconditionally.
-                        let cx = timeline_data.x_val;
-                        let cy = get_y_axis_pos(*line_number);
-                        let title = hover_messages::event_dot_closure_go_out_of_scope(&name);
-                        let drop_data = DropDotData {
-                            hash: *hash as u64,
-                            dot_x: cx,
-                            dot_y: cy,
-                            title,
-                            p1x: cx - 3, p1y: cy - 1,
-                            p2x: cx + 3, p2y: cy - 1,
-                            p3x: cx,     p3y: cy + 3,
-                        };
-                        append_drop_dot(&drop_data, output, timeline_data, registry);
-                        continue;
+                        // Closure value going out of scope: only
+                        // surface "Its captured resources are
+                        // dropped" when at least one upvar was
+                        // move-captured. Borrow-only and capture-
+                        // less closures have no owned resources to
+                        // drop, just the closure struct itself —
+                        // render a plain OOS dot like a Copy type
+                        // with the standard "f goes out of scope"
+                        // message.
+                        if closure_has_move_captures(visualization_data, *hash) {
+                            let cx = timeline_data.x_val;
+                            let cy = get_y_axis_pos(*line_number);
+                            let title = hover_messages::event_dot_closure_go_out_of_scope(&name);
+                            let drop_data = DropDotData {
+                                hash: *hash as u64,
+                                dot_x: cx,
+                                dot_y: cy,
+                                title,
+                                p1x: cx - 3, p1y: cy - 1,
+                                p2x: cx + 3, p2y: cy - 1,
+                                p3x: cx,     p3y: cy + 3,
+                            };
+                            append_drop_dot(&drop_data, output, timeline_data, registry);
+                            continue;
+                        }
+                        data.title = event.print_message_with_name(&mut name);
                     } else if !resource_hold {
                         // Resource was already moved out — same copy
                         // for both Copy and non-Copy types: just note
@@ -842,6 +845,21 @@ fn collect_closure_captures(
         }
     }
     out
+}
+
+// True iff the closure identified by `closure_hash` move-captured
+// at least one upvar (across the whole event stream — captures
+// always land at the closure literal's line, but we don't require
+// callers to know that line). Borrow-only closures have nothing
+// to "drop" at scope-end beyond the closure value itself, so the
+// "captured resources are dropped" message is suppressed.
+fn closure_has_move_captures(
+    visualization_data: &VisualizationData,
+    closure_hash: u64,
+) -> bool {
+    visualization_data.external_events.iter().any(|(_, ev)| {
+        matches!(ev, ExternalEvent::Move { to, .. } if matches_closure(to, closure_hash))
+    })
 }
 
 fn matches_closure(rty: &ResourceTy, closure_hash: u64) -> bool {

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -684,7 +684,32 @@ fn render_dot(
                 Event::OwnerGoOutOfScope => {
                     let ro = &visualization_data.timelines[hash].resource_access_point;
                     let is_copy = ro.is_copy();
-                    if !resource_hold {
+                    let is_closure = ro.is_closure();
+                    if is_closure {
+                        // The closure value is dropped, which in turn
+                        // drops every captured upvar (move) or ends
+                        // the borrow (ref). For borrow-capture
+                        // closures, `resource_hold` ends up false on
+                        // `f` (no Move/Acquire of an owned resource
+                        // on `f`'s timeline), so the generic flow
+                        // would say "No resource is dropped" — wrong
+                        // for a closure, whose drop *is* what
+                        // releases the captures. Override unconditionally.
+                        let cx = timeline_data.x_val;
+                        let cy = get_y_axis_pos(*line_number);
+                        let title = hover_messages::event_dot_closure_go_out_of_scope(&name);
+                        let drop_data = DropDotData {
+                            hash: *hash as u64,
+                            dot_x: cx,
+                            dot_y: cy,
+                            title,
+                            p1x: cx - 3, p1y: cy - 1,
+                            p2x: cx + 3, p2y: cy - 1,
+                            p3x: cx,     p3y: cy + 3,
+                        };
+                        append_drop_dot(&drop_data, output, timeline_data, registry);
+                        continue;
+                    } else if !resource_hold {
                         // Resource was already moved out — same copy
                         // for both Copy and non-Copy types: just note
                         // there's nothing to drop here.

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -862,6 +862,30 @@ fn closure_has_move_captures(
     })
 }
 
+// Title for a vertical timeline segment. Routes around the generic
+// `state.print_message_with_name` for closure bindings so the
+// FullPrivilege segment reads as "f owns a closure (which owns a
+// resource)?" instead of the misleading generic "f is the owner
+// of the resource" — `f` doesn't own the upvar's resource directly,
+// it owns the closure value, and that closure may or may not in
+// turn own a captured resource.
+fn timeline_segment_title(
+    state: &State,
+    rap: &ResourceAccessPoint,
+    visualization_data: &VisualizationData,
+) -> String {
+    if rap.is_closure() {
+        if let State::FullPrivilege { .. } = state {
+            let name = rap.name().to_owned();
+            if closure_has_move_captures(visualization_data, *rap.hash()) {
+                return hover_messages::state_closure_full_privilege_with_resource(&name);
+            }
+            return hover_messages::state_closure_full_privilege_no_resource(&name);
+        }
+    }
+    state.print_message_with_name(rap.name())
+}
+
 fn matches_closure(rty: &ResourceTy, closure_hash: u64) -> bool {
     rty.extract_rap().map_or(false, |r| *r.hash() == closure_hash)
 }
@@ -1729,7 +1753,7 @@ fn render_timeline(
                         y1: get_y_axis_pos(*split_point),
                         x2: branch.t_data.x_val as f64,
                         y2: get_y_axis_pos(*split_point + 1),
-                        title: p_state.print_message_with_name(rap.name()),
+                        title: timeline_segment_title(&p_state, rap, visualization_data),
                         opacity: 1.0
                     };
 
@@ -1758,7 +1782,7 @@ fn render_timeline(
                         y1: get_y_axis_pos(*merge_point + 1),
                         x2: branch.t_data.x_val as f64,
                         y2: get_y_axis_pos(*merge_point),
-                        title: e_state.print_message_with_name(rap.name()),
+                        title: timeline_segment_title(&e_state, rap, visualization_data),
                         opacity: 1.0
                     };
 
@@ -1782,7 +1806,7 @@ fn render_timeline(
                 y1: get_y_axis_pos(*line_start),
                 x2: timeline_data.x_val as f64,
                 y2: get_y_axis_pos(*line_end),
-                title: state.print_message_with_name(rap.name()),
+                title: timeline_segment_title(state, rap, visualization_data),
                 opacity: 1.0
         };
         if *line_start != *line_end {

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -847,19 +847,27 @@ fn collect_closure_captures(
     out
 }
 
-// True iff the closure identified by `closure_hash` move-captured
-// at least one upvar (across the whole event stream — captures
-// always land at the closure literal's line, but we don't require
-// callers to know that line). Borrow-only closures have nothing
-// to "drop" at scope-end beyond the closure value itself, so the
-// "captured resources are dropped" message is suppressed.
+// Count of upvars move-captured by the closure identified by
+// `closure_hash`. Zero ⇒ borrow-only or capture-less closure;
+// distinguishes the scope-end "captured resources are dropped"
+// message and the timeline state line ("owns N resources via
+// capture") from their borrow-only fallbacks.
+fn closure_move_capture_count(
+    visualization_data: &VisualizationData,
+    closure_hash: u64,
+) -> usize {
+    visualization_data
+        .external_events
+        .iter()
+        .filter(|(_, ev)| matches!(ev, ExternalEvent::Move { to, .. } if matches_closure(to, closure_hash)))
+        .count()
+}
+
 fn closure_has_move_captures(
     visualization_data: &VisualizationData,
     closure_hash: u64,
 ) -> bool {
-    visualization_data.external_events.iter().any(|(_, ev)| {
-        matches!(ev, ExternalEvent::Move { to, .. } if matches_closure(to, closure_hash))
-    })
+    closure_move_capture_count(visualization_data, closure_hash) > 0
 }
 
 // Title for a vertical timeline segment. Routes around the generic
@@ -877,8 +885,9 @@ fn timeline_segment_title(
     if rap.is_closure() {
         if let State::FullPrivilege { .. } = state {
             let name = rap.name().to_owned();
-            if closure_has_move_captures(visualization_data, *rap.hash()) {
-                return hover_messages::state_closure_full_privilege_with_resource(&name);
+            let count = closure_move_capture_count(visualization_data, *rap.hash());
+            if count > 0 {
+                return hover_messages::state_closure_full_privilege_with_resource(&name, count);
             }
             return hover_messages::state_closure_full_privilege_no_resource(&name);
         }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -712,10 +712,11 @@ fn render_dot(
                         // render a plain OOS dot like a Copy type
                         // with the standard "f goes out of scope"
                         // message.
-                        if closure_has_move_captures(visualization_data, *hash) {
+                        let move_count = closure_move_capture_count(visualization_data, *hash);
+                        if move_count > 0 {
                             let cx = timeline_data.x_val;
                             let cy = get_y_axis_pos(*line_number);
-                            let title = hover_messages::event_dot_closure_go_out_of_scope(&name);
+                            let title = hover_messages::event_dot_closure_go_out_of_scope(&name, move_count);
                             let drop_data = DropDotData {
                                 hash: *hash as u64,
                                 dot_x: cx,

--- a/rustviz-plugin/tests/closure_borrow_imm.rs
+++ b/rustviz-plugin/tests/closure_borrow_imm.rs
@@ -1,0 +1,9 @@
+// Non-`move` closure that immutably borrows its upvar. Should emit
+// `Immutable borrow from s to f` (matching what `let r = &s;` would).
+
+fn main() {
+    let s = String::from("hi");
+    let f = || println!("{}", s);
+    f();
+    println!("after: {}", s);
+}

--- a/rustviz-plugin/tests/closure_borrow_mut.rs
+++ b/rustviz-plugin/tests/closure_borrow_mut.rs
@@ -1,0 +1,9 @@
+// Non-`move` closure that mutably borrows its upvar. Should emit
+// `Mutable borrow from s to f` (matching `let r = &mut s;`).
+
+fn main() {
+    let mut s = String::from("hi");
+    let mut f = || s.push_str("!");
+    f();
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/closure_move_multi.rs
+++ b/rustviz-plugin/tests/closure_move_multi.rs
@@ -1,0 +1,9 @@
+// `move` closure that captures two distinct upvars. Each capture
+// becomes its own Move arrow into the closure binding.
+
+fn main() {
+    let s = String::from("hi");
+    let t = String::from("bye");
+    let f = move || println!("{} {}", s, t);
+    f();
+}

--- a/rustviz-plugin/tests/closure_move_single.rs
+++ b/rustviz-plugin/tests/closure_move_single.rs
@@ -1,0 +1,9 @@
+// `move` closure with a single captured upvar. Should emit
+// `Move from s to f` at the let line so the user sees ownership
+// of `s` transferring into the closure.
+
+fn main() {
+    let s = String::from("hi");
+    let f = move || println!("{}", s);
+    f();
+}


### PR DESCRIPTION
Fixes #79.

This branch grew from "draw the missing capture arrow" into a full pass over how closures are visualized. Each commit is self-contained; the cumulative result is described below.

## Capture events

Closures used to fall through `match_rhs`'s default arm — `define_lhs` registered `f` as an Owner because the closure type isn't ref / adt / fn, and no Move/Borrow event was emitted for the captured upvars. The visualization showed `f` acquiring a resource from nowhere while `s` happily continued to look like the resource owner. Misleading for a teaching tool whose whole job is to surface ownership transfers.

Fix: use rustc's own capture analysis. `tcx.typeck(...).closure_min_captures_flattened(closure_def_id)` returns one entry per captured upvar with the capture mode already resolved (rustc decides based on `move` keyword + body usage). For each capture:

| Capture kind | Event emitted | Reads as |
|---|---|---|
| `ByValue` (always for `move`, sometimes inferred) | `Move(upvar → f)` | f now owns the captured resource; `s`'s column ends |
| `ByRef(Immutable \| UniqueImmBorrow)` | `SBorrow(upvar → f)` | same arrow as `let r = &s;` |
| `ByRef(Mutable)` | `MBorrow(upvar → f)` | same arrow as `let r = &mut s;` |
| `ByUse` (experimental `use` capture clause) | `Move` | treated as ByValue |

Whole-variable captures only — a partial-field capture like `move || x.field` carries projections we don't have a column for, so we attribute the event to the root variable's RAP (matches how field accesses already aggregate today).

## Tooltip wording

Generic Move/Borrow tooltips ("Move from s to f", "f acquires ownership of a resource") obscure that the event is happening because the closure captured the upvar. Tag the closure binding via a new `Owner.is_closure` flag set by `define_lhs` when the lhs type is a closure, and route every capture-related event through closure-flavoured wording:

- Source dot: `s's resource is captured (moved | immutably borrowed | mutably borrowed) by closure f`
- Arrow label: `Closure capture (move | immutable borrow | mutable borrow) from s to f`
- Closure-side dot at the binding: `Closure f captures: s (moved), t (moved), …` — one combined tooltip enumerating every upvar in source order, since the per-capture target-side dots are suppressed (they'd stack on the same (x,y) and the topmost would mask the rest)
- Scope-end: `f goes out of scope. Its N captured resource(s) is/are dropped.` (move closures only — borrow-only closures get the plain "f goes out of scope" with no drop suffix and no drop triangle, since releasing the closure value doesn't drop any captured resource)
- Timeline state line: `f owns a closure which owns N resource(s) via capture` for move closures, `f owns a closure` for borrow-only

Counts and pluralization are computed from the actual `ExternalEvent::Move` events targeting the closure's hash, so any number of captures renders correctly.

## NLL borrow ends

`let f = || println!("{}", s); f(); println!("{}", s);` compiles because NLL ends `f`'s borrow of `s` at `f()`, not at the closure's lexical scope. The visualization was extending the borrow to the closure's OOS line, contradicting that the println on the next line is legal.

The existing borrow-end machinery (`print_lifetimes` → `StaticDie`/`MutableDie` via `gather_borrow_data`) only walks `borrow_map`, which is keyed by reference-binding name. Closures register `f` as Owner and aren't in `borrow_map`, and we can't simply add them: a closure may capture multiple upvars by different reference flavours and `borrow_map` only tolerates one entry per borrower name.

Fix: emit Die events directly from the `ExprKind::Closure` arm. Polonius's `loan_issued_at` gives one `MIRBorrowData` per ref capture, keyed by `borrowed_place` (upvar name) and assignment line (closure literal's line). `region.1` is the NLL-refined kill line. After emitting `StaticBorrow`/`MutableBorrow` per ref capture, look up its loan and `add_ev` an `SDie`/`MDie` at `region.1`.

Two state-machine arms also needed adding: `(FullPrivilege, MutableBorrow)` had no rule (ordinary MutRefs reach MutableBorrow from OutOfScope), so closure mutable captures hit `Invalid` and the f column went blank; `(FullPrivilege, MutableDie) → OutOfScope` is right for an ordinary MutRef but wrong for a closure that survives its own borrow ending. Both gain closure-conditional no-ops that hold `FullPrivilege` across the events.

## Tests

Four new corpus snippets in `rustviz-plugin/tests/`, each with structural assertions in `corpus_expected_ok_produce_well_formed_svg` and tooltip-level assertions in `corpus_expected_tooltips_present`:

- `closure_move_single` — `let f = move || println!("{}", s);` (single move capture)
- `closure_move_multi` — two captured upvars (combined Bind dot, two arrows, plural drop count)
- `closure_borrow_imm` — `let f = || println!("{}", s);` (NLL borrow returns at `f()`)
- `closure_borrow_mut` — `let mut f = || s.push_str("!");` (NLL borrow returns at `f()`, solid timeline through capture)

Each `must_contain` asserts the closure-flavoured tooltips and `must_not_contain` asserts that the previous generic / wrong-pluralization wordings don't slip back through.

## Examples for the dropdown

A new "Closures" section in the playground's example dropdown with the four shapes, so users can click through them in the UI:

- Move closure (single capture)
- Move closure (multiple captures)
- Borrow closure (immutable)
- Borrow closure (mutable)

## Docs

Removed the "Closures — captures aren't drawn as arrows, so the visualization silently omits the capture event" line from the support matrix in three places:

- `README.md` (workspace root)
- `rustviz-plugin/README.md`
- `playground/frontend/src/App.tsx` (the in-app Description panel)

## Test plan
- [x] All four issue reproductions emit the expected capture arrows
- [x] `cargo test -p rustviz-lib --test corpus` passes (existing snippets + four new closure ones, with strengthened tooltip assertions)
- [x] Borrow-closure NLL: `s` is usable after `f()`, and the visualization shows the borrow returning at `f()` rather than at `f`'s scope end
- [x] Mutable-closure timeline column stays solid from creation to scope-end
- [x] Move-closure scope-end dot triangle + `Its N captured resource(s) is/are dropped.` tooltip
- [x] Borrow-only closure scope-end is a regular dot with `f goes out of scope` (no triangle, no drop suffix)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)