### PR TITLE
plugin: skip macro/desugar stmts in liveness helpers (fixes #78)

### DIFF
--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -239,6 +239,11 @@ pub fn get_decl_of_expr(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapDat
 
 pub fn get_decl_of_stmt(stmt: &Stmt, _tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> HashSet<ResourceAccessPoint> {
   let mut res = HashSet::new();
+  // Synthetic stmts from macro/desugar expansion (the `let args = …`
+  // emitted by `println!`, the inner Match arms of `?`, etc.) aren't
+  // registered as RAPs by visit_local, so a name lookup here would
+  // unwrap None. Mirror visit_local's skip on the read side.
+  if stmt.span.from_expansion() { return res; }
   match stmt.kind {
     StmtKind::Let(ref local) => {
       let name = match local.pat.kind {
@@ -255,6 +260,7 @@ pub fn get_decl_of_stmt(stmt: &Stmt, _tcx: &TyCtxt, raps: &HashMap<String, RapDa
 }
 
 pub fn get_live_of_stmt(stmt: &Stmt, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> HashSet<ResourceAccessPoint> {
+  if stmt.span.from_expansion() { return HashSet::new(); }
   match stmt.kind {
     StmtKind::Let(ref local) => {
       match local.init {

--- a/rustviz-plugin/tests/if_borrow_in_body.rs
+++ b/rustviz-plugin/tests/if_borrow_in_body.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let s = String::from("hi");
+    let n = 3;
+    if n > 0 {
+        println!("{}", &s);
+    }
+}

--- a/rustviz-plugin/tests/if_let_inside_body.rs
+++ b/rustviz-plugin/tests/if_let_inside_body.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let n = 3;
+    if n > 0 {
+        let s = String::from("a");
+        println!("{}", s);
+    }
+}

--- a/rustviz-plugin/tests/if_let_with_macro.rs
+++ b/rustviz-plugin/tests/if_let_with_macro.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let opt: Option<i32> = Some(3);
+    if let Some(x) = opt {
+        println!("{}", x);
+    }
+}

--- a/rustviz-plugin/tests/match_arm_with_let.rs
+++ b/rustviz-plugin/tests/match_arm_with_let.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let n = 3;
+    match n {
+        0 => {}
+        _ => {
+            let s = String::from("a");
+            println!("{}", s);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #78 — bindings or borrows inside an `if` / `match` branch body panic.

`get_decl_of_stmt` and `get_live_of_stmt` walk every stmt in a Block, including macro-synthetic `let args = …` bindings emitted by `println!` and friends. `visit_local` correctly skips those at registration time, so a downstream lookup against `raps` would unwrap None and panic. Mirror the skip on the read side so any branch body containing a macro stops crashing.

Adds four corpus tests covering both reproductions in the issue, `match`-arm equivalents, and `if let` (which desugars through the same path).

## Test plan
- [x] `cargo install --path rustviz-plugin --locked` builds clean
- [x] Full corpus passes (was 89/91 on main pre-#75 fixes; now 100/100 stacked with #77/#80 PRs)
- [ ] Reviewers can poke at the `tests/if_borrow_in_body.rs`, `tests/if_let_inside_body.rs`, `tests/match_arm_with_let.rs`, `tests/if_let_with_macro.rs` fixtures in the playground