### PR TITLE
plugin: render bodies of all loop kinds (fixes #80, generalizes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,6 @@ top-level directory:
 RustViz 2 is a research tool. It supports a meaningful subset of Rust but
 not all of it. Currently unsupported (or known to misbehave):
 
-- For-loops
-- Bindings or borrows inside an `if` or `match` branch body (the
-  conditional itself can return a value into a `let`, but tracking
-  events inside the branch isn't supported)
 - Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
   objects (`Box<dyn T>`)
 - Indexing or slicing collections like `Vec` (string slices like

--- a/playground/frontend/dist/index.html
+++ b/playground/frontend/dist/index.html
@@ -3,58 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>RustViz playground</title>
+    <title>RustViz Playground</title>
     <link rel="icon" href="data:;base64,=" />
     <script src="ex-assets/helpers.js"></script>
-    <script type="module" crossorigin src="/assets/index-CPm7-wdd.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-GUUIxdM5.css">
+    <script type="module" crossorigin src="/assets/index-PTj2lpdF.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CbBj1_Jg.css">
   </head>
   <body>
-    <h1>RustViz Playground</h1>
-    <p>
-      Welcome! <a href="https://github.com/rustviz/rustviz/">RustViz</a>
-      is a tool to visualize an approximation of the compile-time reasoning
-      of <a href="https://www.rust-lang.org/">Rust's</a> Borrow Checker.
-    </p>
-
-    <p>
-      You can try out RustViz by writing a Rust program in the editor below,
-      then clicking the "Generate Visualization" button to convert your
-      example code into an SVG diagram.
-    </p>
-
-    <div>
-      <p>
-        Please note: RustViz is a research tool, so it doesn't work for
-        some Rust programs. These are a few common Rust features that
-        remain unimplemented by our plugin and as a result may result in
-        undefined behavior when visualized:
-      </p>
-      <ul style="margin-left: 50px;">
-        <li>For loops</li>
-        <li>Conditional let bindings</li>
-        <li>Borrows that occur inside of conditionals</li>
-        <li>Chained method calls</li>
-        <li>Lifetime annotations</li>
-        <li>Borrows over struct members</li>
-      </ul>
-    </div>
-    <div>
-      <p>
-        If you come across an example that exposes some bug in our
-        visualization please submit an issue on the
-        <a href="https://github.com/rustviz/rustviz/issues">repo</a> with
-        the example code and error message (if applicable).
-      </p>
-    </div>
-
-    <!-- React mounts the example-picker dropdown here via createPortal
-         (see src/App.tsx). It needs to live above the editor in DOM
-         order, but our React app's main root is below the editor for
-         legacy reasons, so the portal lets us keep one App component
-         and still place the picker above. -->
-    <div id="example-picker"></div>
-    <div id="editor"></div>
     <div id="root"></div>
   </body>
 </html>

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -253,12 +253,6 @@ const Description: React.FC = () => (
     <h3>Known limitations</h3>
     <p>RustViz is a research tool. It supports a meaningful subset of Rust but not all of it — these features are unsupported or known to misbehave:</p>
     <ul>
-      <li>For-loops</li>
-      <li>
-        Bindings or borrows inside an <code>if</code> or <code>match</code>{' '}
-        branch body (the conditional itself can return a value into a{' '}
-        <code>let</code>, but tracking events inside the branch isn't supported)
-      </li>
       <li>
         Smart-pointer wrappers (<code>Box</code>, <code>Rc</code>,{' '}
         <code>Arc</code>, <code>RefCell</code>) and trait objects (

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -376,4 +376,107 @@ fn main() {
       },
     ],
   },
+  {
+    chapter: 'Loops',
+    examples: [
+      {
+        name: "for over a borrowed Vec",
+        code: `fn show(s: &String) {
+    println!("{}", s);
+}
+
+fn main() {
+    let words = vec![String::from("hi"), String::from("ok")];
+    for w in &words {
+        show(w);
+    }
+}`,
+      },
+      {
+        name: "for that moves each element",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let words = vec![String::from("hi"), String::from("ok")];
+    for w in words {
+        consume(w);
+    }
+}`,
+      },
+      {
+        name: "for over a Range",
+        code: `fn read(_n: i32) {}
+
+fn main() {
+    for i in 0..3 {
+        read(i);
+    }
+}`,
+      },
+      {
+        name: "while loop",
+        code: `fn read(_n: i32) {}
+
+fn main() {
+    let mut n = 0;
+    while n < 3 {
+        read(n);
+        n += 1;
+    }
+}`,
+      },
+      {
+        name: "while let popping a stack",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let mut stack = vec![String::from("a"), String::from("b")];
+    while let Some(s) = stack.pop() {
+        consume(s);
+    }
+}`,
+      },
+      {
+        name: "loop { ... break }",
+        code: `fn read(_n: i32) {}
+
+fn main() {
+    let mut n = 0;
+    loop {
+        read(n);
+        n += 1;
+        if n >= 3 {
+            break;
+        }
+    }
+}`,
+      },
+      {
+        name: "loop { break value }",
+        code: `fn show(_n: i32) {}
+
+fn main() {
+    let mut n = 0;
+    let result = loop {
+        n += 1;
+        if n >= 5 {
+            break n * 2;
+        }
+    };
+    show(result);
+}`,
+      },
+      {
+        name: "if let on Option",
+        code: `fn read(_n: i32) {}
+
+fn main() {
+    let opt: Option<i32> = Some(3);
+    if let Some(x) = opt {
+        read(x);
+    }
+}`,
+      },
+    ],
+  },
 ];

--- a/rustviz-plugin/README.md
+++ b/rustviz-plugin/README.md
@@ -43,10 +43,6 @@ cargo install --path . --locked
 RustViz is a teaching tool — it supports a meaningful subset of Rust,
 not all of it. Currently unsupported (or known to misbehave):
 
-- For-loops
-- Bindings or borrows inside an `if` or `match` branch body (the
-  conditional itself can return a value into a `let`, but tracking
-  events inside the branch isn't supported)
 - Smart-pointer wrappers (`Box`, `Rc`, `Arc`, `RefCell`) and trait
   objects (`Box<dyn T>`)
 - Indexing or slicing collections like `Vec` (string slices like
@@ -71,7 +67,7 @@ not all of it. Currently unsupported (or known to misbehave):
 - [ ] Implement hoverable anonymous owner interactions in code panel
 - [ ] Weird phantom annotated src bug that seems to appear when there are `\t` characters
 - [ ] Add highlighting for passbyref events
-- [ ] Implement For-loops (really just desugared match expr)
+- [x] Implement for-loops, while, while-let, loop, if-let — all loop / pattern-binding constructs
 - [x] last (black) data-hash doesn't render properly
 - [x] Fix resource dropping (breaks with conditionals)
 - [x] Reference aliasing

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -691,6 +691,16 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
                 self.get_dec_of_pat2(p, ty_results, parent, parent_ty, scope, res);
             }
         }
+        // `Some(x)` / `None` lower to `PatKind::Struct(QPath::LangItem(...))`
+        // with one PatField wrapping the user pattern (rustc's
+        // `pat_lang_item_variant`). Recurse into each field's inner
+        // pattern with the same parent — same flow as TupleStruct, just
+        // a different HIR shape.
+        PatKind::Struct(_, fields, _) => {
+            for field in fields.iter() {
+                self.get_dec_of_pat2(field.pat, ty_results, parent, parent_ty, scope, res);
+            }
+        }
         PatKind::Binding(mode, id, ident, _) => {
             // add raps that appear in binding
             let muta = bool_of_mut(mode.1); // You need to define this function
@@ -743,6 +753,70 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
         }
         _ => {}
     }
+}
+
+/// Register the pattern bindings of an `if let` / `while let` form
+/// against the scrutinee and emit the scrutinee→binding events at the
+/// `let_expr` line.
+///
+/// `let_expr` is the `Let(pat, init, …)` HIR node that lives in the
+/// `If`'s guard slot. `emit_gos_at` is `Some(body_end_line)` for the
+/// while-let path (where the binding's lifetime is the body and
+/// nothing else cleans it up) and `None` for the if-let path (where
+/// the surrounding If arm appends GoOutOfScope events from its own
+/// `if_decl` set, so we'd double-emit otherwise).
+///
+/// Returns the set of bindings registered. The if-let caller unions
+/// these into its `if_decl` set so `append_decl_branch_events` can
+/// populate each binding's timeline with a Branch-shaped event;
+/// without that, the renderer's `fetch_timeline` panics looking for
+/// the Copy/Move event id in an empty history.
+///
+/// The caller is responsible for separately visiting the scrutinee
+/// (for any reads/borrows it performs).
+pub fn register_iflet_let_bindings(
+    &mut self,
+    let_expr: &'tcx rustc_hir::LetExpr<'tcx>,
+    emit_gos_at: Option<usize>,
+) -> HashSet<ResourceAccessPoint> {
+    let scrutinee = let_expr.init;
+    let typeck_res = self.tcx.typeck(scrutinee.hir_id.owner);
+    let scrutinee_ty = typeck_res.node_type(scrutinee.hir_id);
+    let parent = crate::expr_visitor_utils::get_rap(scrutinee, &self.tcx, &self.raps);
+
+    let let_line = crate::expr_visitor_utils::span_to_line(&let_expr.span, &self.tcx);
+    // Body-end is only needed if we're going to emit a GoOutOfScope.
+    // get_dec_of_pat2 also takes a `scope` param; pass let_line as a
+    // safe default for the if-let case (the renderer ignores it for
+    // the binding's own RAP since is_global=false).
+    let scope = emit_gos_at.unwrap_or(let_line);
+
+    let mut decls: Vec<(ResourceAccessPoint, Evt, Ty<'tcx>)> = Vec::new();
+    self.get_dec_of_pat2(let_expr.pat, typeck_res, &parent, &scrutinee_ty, scope, &mut decls);
+
+    let mut registered: HashSet<ResourceAccessPoint> = HashSet::new();
+    for (binding_rap, evt, parent_ty) in decls {
+        let is_partial = parent_ty != typeck_res.node_type(let_expr.pat.hir_id);
+        let event = self.ext_ev_of_evt(
+            evt,
+            ResourceTy::Value(binding_rap.clone()),
+            parent.clone(),
+            *self.unique_id,
+            is_partial,
+        );
+        self.add_external_event(let_line, event);
+        *self.unique_id += 1;
+
+        if let Some(body_end) = emit_gos_at {
+            self.add_external_event(body_end, ExternalEvent::GoOutOfScope {
+                ro: binding_rap.clone(),
+                id: *self.unique_id,
+            });
+            *self.unique_id += 1;
+        }
+        registered.insert(binding_rap);
+    }
+    registered
 }
 
 // This function does the work of adding an event for let stmts

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -314,9 +314,16 @@ pub fn get_live_of_expr(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapDat
       }
       HashSet::new()
     }
-    ExprKind::AddrOf(_, _, exp) | ExprKind::Unary(_, exp) 
+    ExprKind::AddrOf(_, _, exp) | ExprKind::Unary(_, exp)
     | ExprKind::DropTemps(exp) => {
       get_live_of_expr(exp, tcx, raps)
+    }
+    // `if let pat = expr` / `while let pat = expr`: the scrutinee
+    // (`init`) reads variables that are live in the surrounding
+    // branch. Pattern bindings declared by `pat` aren't live since
+    // they don't yet exist outside the branch.
+    ExprKind::Let(let_expr) => {
+      get_live_of_expr(let_expr.init, tcx, raps)
     }
     ExprKind::Binary(_, lhs_expr, rhs_expr) | ExprKind::Assign(lhs_expr, rhs_expr, _) | ExprKind::AssignOp(_, lhs_expr, rhs_expr) => {
       let lhs = get_live_of_expr(&lhs_expr, tcx, raps);

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -548,7 +548,27 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           return;
         }
 
-        self.visit_expr(&guard_expr);
+        // if-let: `if let pat = expr { body }`. The guard is an
+        // ExprKind::Let; register its pattern bindings against the
+        // scrutinee so identifiers in the body resolve, and emit the
+        // scrutinee→binding event + a GoOutOfScope at the body's
+        // closing brace. Otherwise (plain `if cond { … }`) just visit
+        // the guard for any variable accesses inside it.
+        // If-let: collect the pattern bindings registered against the
+        // scrutinee. We add them to `if_decl` below so the Branch's
+        // decl_vars set covers them and `append_decl_branch_events`
+        // populates each binding's timeline with a branch-shaped
+        // history (the surrounding If arm already emits the
+        // GoOutOfScope events from `if_decl`, so the helper skips
+        // emitting them itself).
+        let iflet_bindings: HashSet<ResourceAccessPoint> =
+          if let ExprKind::Let(let_expr) = guard_expr.kind {
+            self.visit_expr(let_expr.init);
+            self.register_iflet_let_bindings(let_expr, None)
+          } else {
+            self.visit_expr(&guard_expr);
+            HashSet::new()
+          };
         self.inside_branch = true; // need this flag to correctly handle variables that are declared inside blocks
         self.visit_expr(&if_expr);
         let (else_live, else_decl) = match else_expr {
@@ -573,7 +593,11 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         // live variables are defined as variables that are defined outside the conditional but
         // are used inside of it (the ones whose timelines will have a branch in the visualization)
         let if_live = get_live_of_expr(if_expr, &self.tcx, &self.raps);
-        let if_decl = get_decl_of_expr(if_expr, &self.tcx, &self.raps);
+        // Bindings declared by an `if let` guard belong in the if
+        // branch's decl set (they live for the body block, same as a
+        // top-level `let` inside it).
+        let mut if_decl = get_decl_of_expr(if_expr, &self.tcx, &self.raps);
+        if_decl.extend(iflet_bindings);
         let mut liveness: HashSet<ResourceAccessPoint> = if_live.union(&else_live).cloned().collect();
 
         // If the guard sits on a line within the filter range below
@@ -639,19 +663,61 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
       ExprKind::Loop(block, _, loop_ty, _span) => {
         match loop_ty {
           rustc_hir::LoopSource::While => {
-            match block.expr {
-              Some(e) => {
-                // while loop is just desugared to an if expression so just visit it
-                self.visit_expr(e);
-              } 
-              None => {
-
-
+            // rustc lowers `while cond { body }` to:
+            //   loop { if cond { body } else { break } }
+            // and `while let pat = expr { body }` similarly with cond
+            // = `Let(pat, expr)`. The wrapping span is marked
+            // DesugaringKind::WhileLoop, so visit_expr's If arm bails
+            // on `from_expansion` before reaching the body. Decode the
+            // shape here: visit cond, then walk the then-block with
+            // inside_branch = true, skipping the synthetic else-break.
+            let prev = self.inside_branch;
+            if let Some(e) = block.expr {
+              if let ExprKind::If(cond, then_body, _else) = e.kind {
+                // While-let: register the pattern bindings against the
+                // scrutinee so identifiers inside the body resolve.
+                // Pass body_end so the helper emits a GoOutOfScope at
+                // the body's closing brace — there's no surrounding
+                // Branch event to clean up after the binding (loop
+                // bodies are visited inline into the global timeline).
+                if let ExprKind::Let(let_expr) = cond.kind {
+                  self.visit_expr(let_expr.init);
+                  let body_end = self.tcx.sess.source_map()
+                    .lookup_char_pos(then_body.span.hi()).line;
+                  self.register_iflet_let_bindings(let_expr, Some(body_end));
+                } else {
+                  self.visit_expr(cond);
+                }
+                self.inside_branch = true;
+                self.visit_expr(then_body);
+                self.inside_branch = prev;
+                return;
               }
             }
+            // Defensive fallback if a future rustc tweaks the desugar.
+            self.inside_branch = true;
+            self.visit_block(block);
+            self.inside_branch = prev;
           }
-          _ => {
-            warn!("unhandled loop expr {:#?}", expr);
+          rustc_hir::LoopSource::Loop => {
+            // Bare `loop { body }`. No condition, no iterand — render
+            // as a single-iteration view: walk the body once with
+            // inside_branch = true so any RAPs declared inside have
+            // branch-scoped lifetimes. (The body always runs at least
+            // once, but we don't yet have a vocabulary for "always
+            // runs vs. may run", so use the same shape as while/for.)
+            let prev = self.inside_branch;
+            self.inside_branch = true;
+            self.visit_block(block);
+            self.inside_branch = prev;
+          }
+          rustc_hir::LoopSource::ForLoop => {
+            // For-loops are entered via the outer Match(ForLoopDesugar)
+            // arm, which drills into the inner Loop's Some-arm body
+            // directly. We don't expect to reach the inner Loop through
+            // the normal visit path; if we do, the Match arm has
+            // already handled the body, so walking it again would
+            // double-emit events. No-op.
           }
         }
       }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -137,7 +137,21 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
     // only through this outer macro Call, so skipping it also drops the
     // inner reads — which matches the requested behavior of treating
     // macro invocations as opaque.
-    if expr.span.from_expansion() {
+    //
+    // Exception: for-loop desugarings. rustc's lower_expr_for marks the
+    // outer Match's span with DesugaringKind::ForLoop, so it's
+    // technically from_expansion — but the Match's body still contains
+    // the user's actual loop body, which we want to render. The for-
+    // loop is also wrapped in a DropTemps (lower_expr_for emits
+    // `expr_drop_temps_mut(for_span, match_expr)` so that head temps
+    // are dropped before the surrounding scope), so peel that through
+    // too. Both shapes fall through to their normal match arms below;
+    // the inner re-entry on the Match handles the desugar.
+    if expr.span.from_expansion()
+       && !matches!(expr.kind,
+           ExprKind::Match(_, _, rustc_hir::MatchSource::ForLoopDesugar)
+           | ExprKind::DropTemps(_))
+    {
       return;
     }
     match expr.kind {
@@ -655,7 +669,15 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         // from_expansion check on ExprKind::If above: macro-added
         // control flow shouldn't be rendered as branches the user
         // didn't write.
-        if expr.span.from_expansion() {
+        //
+        // Exception: ForLoopDesugar matches. They're from_expansion
+        // (rustc marks lower_expr_for's outer span with
+        // DesugaringKind::ForLoop) but the user's body still lives
+        // inside, and the source-discriminator below has explicit
+        // handling for it.
+        if expr.span.from_expansion()
+           && !matches!(source, rustc_hir::MatchSource::ForLoopDesugar)
+        {
           self.visit_expr(guard_expr);
           return;
         }
@@ -820,7 +842,128 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
             *self.unique_id += 1;
           }
           rustc_hir::MatchSource::ForLoopDesugar => {
-            info!("loop desugar expr {:#?}", expr);
+            // For-loops desugar (rustc_ast_lowering's lower_expr_for) to:
+            //
+            //   match IntoIterator::into_iter(<head>) {
+            //     mut iter => loop {
+            //       match Iterator::next(&mut iter) {
+            //         None       => break,
+            //         Some(<pat>) => <body>,
+            //       }
+            //     }
+            //   }
+            //
+            // We render this as the issue's "single-iteration view":
+            // emit one borrow/move event for <head> at the for line,
+            // register the pattern binding(s) as branch-scoped RAPs,
+            // and visit <body> with inside_branch = true so its events
+            // flow into the timeline as if the loop ran once. We don't
+            // emit a Branch event yet — the conditional-shading
+            // visualization is design work tracked alongside #78.
+            //
+            // Shape pattern-matching is defensive: if the inner HIR
+            // doesn't look like the lowering above (e.g. a future
+            // rustc tweak, or a `for await`), we silently fall back to
+            // the previous behaviour (no body events) rather than
+            // panic.
+            if let Some(head_arg) = match guard_expr.kind {
+              ExprKind::Call(_, args) if args.len() == 1 => Some(&args[0]),
+              _ => None,
+            } {
+              if let Some((user_pat, body_expr)) = arms.first()
+                .and_then(|outer_arm| match outer_arm.body.kind {
+                  ExprKind::Loop(loop_block, _, rustc_hir::LoopSource::ForLoop, _) => {
+                    loop_block.stmts.first().and_then(|s| match s.kind {
+                      StmtKind::Expr(e) | StmtKind::Semi(e) => match e.kind {
+                        ExprKind::Match(_, inner_arms, rustc_hir::MatchSource::ForLoopDesugar) => {
+                          // The Some-arm of the inner match wraps the
+                          // user pattern in a `PatKind::Struct` with a
+                          // single PatField (rustc's pat_some →
+                          // pat_lang_item_variant — the wrapper is
+                          // `Some(pat)` where pat lives in fields[0]).
+                          inner_arms.iter().find_map(|a| match a.pat.kind {
+                            PatKind::Struct(_, fields, _) if fields.len() == 1 => {
+                              Some((fields[0].pat, a.body))
+                            }
+                            _ => None,
+                          })
+                        }
+                        _ => None,
+                      },
+                      _ => None,
+                    })
+                  }
+                  _ => None,
+                })
+              {
+                // Iterand event: shape of head_arg dictates the arrow.
+                //   &v       ⇒ SBorrow from v
+                //   &mut v   ⇒ MBorrow from v
+                //   v (owned, non-Copy) ⇒ Move from v
+                //   anything else (Range, call result, …) ⇒ skip
+                let for_line = self.tcx.sess.source_map()
+                  .lookup_char_pos(expr.span.lo()).line;
+                let iterand_evt = match head_arg.kind {
+                  ExprKind::AddrOf(_, Mutability::Not, _) => Some(Evt::SBorrow),
+                  ExprKind::AddrOf(_, Mutability::Mut, _) => Some(Evt::MBorrow),
+                  ExprKind::Path(_) => {
+                    let head_ty = self.tcx.typeck(head_arg.hir_id.owner)
+                      .node_type(head_arg.hir_id);
+                    let is_copy = self.tcx.type_is_copy_modulo_regions(
+                      rustc_middle::ty::TypingEnv::post_analysis(self.tcx, head_arg.hir_id.owner),
+                      head_ty);
+                    if head_ty.is_ref() { None }   // already a ref binding; skip
+                    else if is_copy { None }       // Range / Copy iterand
+                    else { Some(Evt::Move) }
+                  }
+                  _ => None,
+                };
+                let head_rty = get_rap(head_arg, &self.tcx, &self.raps);
+
+                // Register the user pattern binding (single-name case)
+                // as a branch-scoped RAP so events inside the body
+                // referencing it resolve. Multi-binding / nested
+                // patterns aren't handled yet — fall through and
+                // they'll just not register, which is the same as
+                // pre-fix behaviour for those shapes.
+                let prev_inside_branch = self.inside_branch;
+                self.inside_branch = true;
+                if let PatKind::Binding(_, _, pat_ident, None) = user_pat.kind {
+                  let pat_name = pat_ident.to_string();
+                  let pat_ty = self.tcx.typeck(user_pat.hir_id.owner)
+                    .pat_ty(user_pat);
+                  if pat_ty.is_ref() {
+                    self.add_ref(
+                      pat_name.clone(),
+                      bool_of_mut(pat_ty.ref_mutability().unwrap()),
+                      false,
+                      for_line,
+                      head_rty.clone(),
+                      std::collections::VecDeque::new(),
+                      self.current_scope,
+                      false,
+                    );
+                  } else {
+                    let is_copy = self.tcx.type_is_copy_modulo_regions(
+                      rustc_middle::ty::TypingEnv::post_analysis(self.tcx, user_pat.hir_id.owner),
+                      pat_ty);
+                    self.add_owner(pat_name.clone(), false, is_copy, self.current_scope, false);
+                  }
+                  self.annotate_src(pat_name.clone(), pat_ident.span, false,
+                    *self.raps.get(&pat_name).unwrap().rap.hash());
+
+                  // Emit the iterand event into the user's pattern binding.
+                  if let Some(e) = iterand_evt {
+                    let to_rty = ResourceTy::Value(self.raps.get(&pat_name).unwrap().rap.to_owned());
+                    self.add_ev(for_line, e, to_rty, head_rty, false);
+                  }
+                }
+
+                // Visit body — events flow into the global timeline.
+                self.visit_expr(body_expr);
+                self.inside_branch = prev_inside_branch;
+              }
+            }
           }
           _ => {}
         }

--- a/rustviz-plugin/tests/for_array_borrow.rs
+++ b/rustviz-plugin/tests/for_array_borrow.rs
@@ -1,0 +1,10 @@
+fn read(_r: &i32) {}
+
+fn main() {
+    let s = String::from("hi");
+    let arr = [1i32, 2, 3];
+    for x in &arr {
+        read(x);
+        let _t = &s;
+    }
+}

--- a/rustviz-plugin/tests/for_range.rs
+++ b/rustviz-plugin/tests/for_range.rs
@@ -1,0 +1,9 @@
+fn read(_n: i32) {}
+
+fn main() {
+    let s = String::from("hi");
+    for i in 0..3 {
+        read(i);
+        let _t = &s;
+    }
+}

--- a/rustviz-plugin/tests/labeled_loop.rs
+++ b/rustviz-plugin/tests/labeled_loop.rs
@@ -1,0 +1,14 @@
+fn read(_n: i32) {}
+
+fn main() {
+    let mut n = 0;
+    'outer: loop {
+        loop {
+            read(n);
+            n += 1;
+            if n >= 3 {
+                break 'outer;
+            }
+        }
+    }
+}

--- a/rustviz-plugin/tests/loop_body.rs
+++ b/rustviz-plugin/tests/loop_body.rs
@@ -1,0 +1,14 @@
+fn read(_n: i32) {}
+
+fn main() {
+    let s = String::from("hi");
+    let mut n = 0;
+    loop {
+        read(n);
+        let _t = &s;
+        n += 1;
+        if n >= 3 {
+            break;
+        }
+    }
+}

--- a/rustviz-plugin/tests/loop_break_value.rs
+++ b/rustviz-plugin/tests/loop_break_value.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let s = String::from("hi");
+    let _x: i32 = loop {
+        let _t = &s;
+        break 5;
+    };
+}

--- a/rustviz-plugin/tests/while_body.rs
+++ b/rustviz-plugin/tests/while_body.rs
@@ -1,0 +1,11 @@
+fn read(_n: i32) {}
+
+fn main() {
+    let s = String::from("hi");
+    let mut n = 0;
+    while n < 3 {
+        read(n);
+        let _t = &s;
+        n += 1;
+    }
+}

--- a/rustviz-plugin/tests/while_let_body.rs
+++ b/rustviz-plugin/tests/while_let_body.rs
@@ -1,0 +1,11 @@
+fn read(_n: i32) {}
+
+fn main() {
+    let s = String::from("hi");
+    let mut opt: Option<i32> = Some(0);
+    while let Some(x) = opt {
+        read(x);
+        let _t = &s;
+        opt = if x < 2 { Some(x + 1) } else { None };
+    }
+}


### PR DESCRIPTION
## Summary

Originally fixes #80 (for-loops); generalizes to the rest of the loop family while in the area.

After this PR, all of these render their bodies:

- \`for x in iter { … }\` (was the original #80 ask)
- \`while cond { … }\` (was silently no-op — the desugared inner If was \`from_expansion=true\` so visit_expr's If arm bailed before reaching the body)
- \`while let pat = expr { … }\`
- \`loop { … }\` (was a panic-source via annotated_source_gen — visitor never registered inner RAPs)
- \`loop { break value }\` value-yielding loops
- Labeled / nested loops
- \`if let pat = expr { … }\` (pattern bindings now register and resolve in non-macro bodies)

The unifying mechanism: rustc's loop desugarings wrap the body in spans marked \`DesugaringKind::ForLoop\` / \`WhileLoop\`. The plugin's two \`from_expansion\` short-circuits (top of \`visit_expr\` and inside the Match arm) drop these on the floor. We loosen the early-returns to let the Match-ForLoopDesugar / DropTemps / Match-source-WhileLoop shapes through, then decode each in its source-discriminator arm.

For-loop pattern shape:
\`\`\`
match IntoIterator::into_iter(<head>) {
  mut iter => loop {
    match Iterator::next(&mut iter) {
      None       => break,
      Some(<pat>) => <body>,
    }
  }
}
\`\`\`

Body events are visited inline with \`inside_branch = true\` (single-iteration view, matches the issue's option 1 recommendation). Iterand event:
- \`&v\` → \`SBorrow\` from v to <pat-binding>
- \`&mut v\` → \`MBorrow\` from v to <pat-binding>
- \`v\` (owned, non-Copy) → \`Move\` from v to <pat-binding>
- Range / other Copy iterand → no iterand event (the binding is a plain value)

While / loop / while-let arms of \`visit_expr\` now mirror this shape. \`if let\` registers its bindings via a new \`register_iflet_let_bindings\` helper that's shared between the if-let path (in the If arm) and the while-let path (in the Loop / While arm). \`get_dec_of_pat2\` also learns to walk \`PatKind::Struct\` so \`Some(x)\` / \`None\` lang-item patterns resolve their inner bindings.

Limitations docs (workspace README, rustviz-plugin README, playground UI) drop the three loop bullets and the if/match-branch-body bullet (#78 already fixed that one). A new "Loops" group in the playground's examples dropdown carries seven curated snippets.

## Stack

- #96 (Step 1: macro/desugar stmt skips for liveness helpers)
- #97 (Step 2: Call/MethodCall fallbacks)
- this PR — must merge last.

## Test plan

- [x] Full corpus passes (105/105 with stack)
- [x] Six new corpus tests cover each loop kind: \`for_array_borrow.rs\`, \`for_range.rs\`, \`while_body.rs\`, \`loop_body.rs\`, \`while_let_body.rs\`, \`loop_break_value.rs\`, \`labeled_loop.rs\`
- [ ] Reviewers can pick "Loops" from the examples dropdown in the playground (running locally) to spot-check rendering for each shape