### PR TITLE
plugin: descend through macro expansion to user subexprs (fixes #74)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -90,6 +90,12 @@ const EXPECTED_OK: &[&str] = &[
     "closure_move_multi",
     "closure_borrow_imm",
     "closure_borrow_mut",
+    // — Ref-arg call sites inside `println!` (#74): the visitor now
+    //   descends through synthetic macro scaffolding to user-spanned
+    //   subexpressions, so an inline `r.method()` / `f(&r)` inside a
+    //   formatter macro emits its call-site arrow.
+    "method_call_in_println",
+    "freefn_call_in_println",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -310,11 +316,13 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     TooltipExpect {
         name: "inherent_method_rectangle",
         // The Rectangle/area pattern is the canonical "method on a
-        // user struct" shape we know works. We don't test for r.area's
-        // call-site arrow today — see #74 for the ref-arg-call-site
-        // PassByRef arrow that doesn't render yet.
+        // user struct" shape. After #74's macro-descent fix the
+        // inline `rect.area()` inside `print_area`'s `println!` body
+        // now emits its own call-site arrow alongside the outer
+        // `print_area(&r)` arrow.
         must_contain: &[
             "print_area reads from r",
+            "area reads from rect",
             "r acquires ownership of a resource",
             "r goes out of scope. Its resource is dropped.",
         ],
@@ -578,6 +586,27 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "f owns a closure which owns",
             "f is the owner of the resource",
         ],
+    },
+
+    // ─── Ref-arg call sites inside `println!` (#74) ─────────────────
+    // The inline `r.method()` / `f(&r)` inside `println!("{}", …)`
+    // emits its call-site arrow once the visitor descends through
+    // synthetic macro scaffolding. Before #74's fix, the outer
+    // synthetic block's expansion span discarded the entire arg
+    // subtree before the MethodCall / Call arms could fire.
+    TooltipExpect {
+        name: "method_call_in_println",
+        must_contain: &[
+            "get reads from r",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "freefn_call_in_println",
+        must_contain: &[
+            "get reads from r",
+        ],
+        must_not_contain: &[],
     },
 ];
 

--- a/rustviz-plugin/README.md
+++ b/rustviz-plugin/README.md
@@ -53,10 +53,6 @@ not all of it. Currently unsupported (or known to misbehave):
   (`r.field.method()`), nested field access (`r.a.b`), and field
   access through a reference (`(&r).field`). Plain `r.field` and
   `&r.field` work.
-- Inherent methods (`impl S { fn ... }`) are fragile — the
-  Rectangle/area pattern (`fn area(&self) -> u32 { self.width *
-  self.height }`) works, but minor variants (e.g. a one-field
-  `fn get(&self) -> i32 { self.n }`) crash.
 
 ### To fix / implement
 

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -15,6 +15,76 @@ use rustc_middle::ty::adjustment::*;
 use std::collections::{HashSet, VecDeque};
 
 
+impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
+  /// Walk through synthetic macro-expansion scaffolding to find any
+  /// user-written subexpressions and dispatch them back through
+  /// `visit_expr`. Called from the `from_expansion` guard at the top
+  /// of `visit_expr` (see comment there for why).
+  ///
+  /// We only descend through "transparent container" shapes — Block,
+  /// Call, MethodCall, AddrOf, Unary, DropTemps, Array, Tup. These
+  /// are the wrappers the formatter macros (`println!`,
+  /// `format_args!`, etc.) build around their args and that always
+  /// just hold subexpressions verbatim, so reaching the user's
+  /// subexpression is a straight recursive walk. Synthetic
+  /// control-flow shapes (If / Match / Loop / Closure) are
+  /// deliberately *not* descended through: those are how
+  /// `assert!(cond)`, `?`, and similar macros desugar, and treating
+  /// the synthesized panic-arm or capture-closure body as user code
+  /// would surface spurious events. The existing
+  /// from_expansion-guarded handlers in those arms cover what's
+  /// actually needed (e.g. visit just the assert's guard).
+  fn descend_through_expansion(&mut self, expr: &'tcx Expr<'tcx>) {
+    if !expr.span.from_expansion() {
+      // Re-enter normal dispatch — the user wrote this subexpression.
+      self.visit_expr(expr);
+      return;
+    }
+    match expr.kind {
+      ExprKind::Block(b, _) => {
+        for s in b.stmts {
+          match s.kind {
+            StmtKind::Let(l) => {
+              if let Some(init) = l.init {
+                self.descend_through_expansion(init);
+              }
+            }
+            StmtKind::Expr(e) | StmtKind::Semi(e) => {
+              self.descend_through_expansion(e);
+            }
+            StmtKind::Item(_) => {}
+          }
+        }
+        if let Some(e) = b.expr {
+          self.descend_through_expansion(e);
+        }
+      }
+      ExprKind::Call(_, args) => {
+        for a in args {
+          self.descend_through_expansion(a);
+        }
+      }
+      ExprKind::MethodCall(_, recv, args, _) => {
+        self.descend_through_expansion(recv);
+        for a in args {
+          self.descend_through_expansion(a);
+        }
+      }
+      ExprKind::AddrOf(_, _, inner)
+      | ExprKind::Unary(_, inner)
+      | ExprKind::DropTemps(inner) => {
+        self.descend_through_expansion(inner);
+      }
+      ExprKind::Array(items) | ExprKind::Tup(items) => {
+        for i in items {
+          self.descend_through_expansion(i);
+        }
+      }
+      _ => {}
+    }
+  }
+}
+
 impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
   // A fn body
   fn visit_body(&mut self, body: &rustc_hir::Body<'tcx>) -> Self::Result {
@@ -128,31 +198,44 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
   }
 
   fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
-    // Skip everything synthesized by macro expansion. The user's source
-    // doesn't show e.g. `format_argument::new_display(&s)` from inside
-    // `println!("{}", s)` — surfacing those calls in the timeline (a
-    // spurious `args` column, a "reads from s" arrow into a synthetic
-    // formatter) is more confusing than informative. References to user
-    // variables that happen to live inside a macro argument are reached
-    // only through this outer macro Call, so skipping it also drops the
-    // inner reads — which matches the requested behavior of treating
-    // macro invocations as opaque.
+    // Two complementary behaviours for synthesized HIR nodes (those
+    // whose span originates from a macro / desugar expansion):
     //
-    // Exception: for-loop desugarings. rustc's lower_expr_for marks the
-    // outer Match's span with DesugaringKind::ForLoop, so it's
-    // technically from_expansion — but the Match's body still contains
-    // the user's actual loop body, which we want to render. The for-
-    // loop is also wrapped in a DropTemps (lower_expr_for emits
-    // `expr_drop_temps_mut(for_span, match_expr)` so that head temps
-    // are dropped before the surrounding scope), so peel that through
-    // too. Both shapes fall through to their normal match arms below;
-    // the inner re-entry on the Match handles the desugar.
-    if expr.span.from_expansion()
-       && !matches!(expr.kind,
-           ExprKind::Match(_, _, rustc_hir::MatchSource::ForLoopDesugar)
-           | ExprKind::DropTemps(_))
-    {
-      return;
+    //   1. Most synthetic shapes (`Block` / `Call` / `MethodCall` /
+    //      `AddrOf` / `Unary` / `DropTemps` / `Array` / `Tup`) are
+    //      transparent wrappers — the user's actual code lives at the
+    //      bottom. Modern `println!` / `format_args!` expand to a
+    //      tree like
+    //         { ::std::io::_print({ Arguments::new_v1(&[], &[Argument::new_display(&user_expr)]) }); }
+    //      and the historical blanket return discarded the lot,
+    //      meaning an inline `r.method()` inside a `println!` (issue
+    //      #74) never reached the MethodCall arm. `descend_through_expansion`
+    //      walks those wrappers until it hits a user-spanned
+    //      descendant and re-dispatches that node through `visit_expr`
+    //      so the normal arm logic runs on it. Synthetic control-flow
+    //      shapes (If / Match / Loop / Closure) are deliberately *not*
+    //      descended through: those are how `assert!`, `?`, etc.
+    //      desugar, and the existing arms have explicit
+    //      `from_expansion` handling.
+    //
+    //   2. For-loop desugarings need to fall through to their normal
+    //      arm dispatch. rustc's `lower_expr_for` marks the outer
+    //      Match's span with `DesugaringKind::ForLoop` and wraps it
+    //      in a `DropTemps` (so head temps drop before the surrounding
+    //      scope — both spans are `from_expansion=true`). The Match
+    //      arm's source-discriminator below has explicit
+    //      `ForLoopDesugar` handling that extracts head/pattern/body;
+    //      we exempt those two shapes from descend so that handling
+    //      runs.
+    if expr.span.from_expansion() {
+      if !matches!(expr.kind,
+          ExprKind::Match(_, _, rustc_hir::MatchSource::ForLoopDesugar)
+          | ExprKind::DropTemps(_))
+      {
+        self.descend_through_expansion(expr);
+        return;
+      }
+      // Fall through to the normal Match / DropTemps arm below.
     }
     match expr.kind {
       // fn call <expr>[<expr>]

--- a/rustviz-plugin/tests/freefn_call_in_println.rs
+++ b/rustviz-plugin/tests/freefn_call_in_println.rs
@@ -1,0 +1,16 @@
+// Free-fn ref-arg call inside `println!("{}", …)` — companion to
+// `method_call_in_println.rs`. `get(&r)` is the same shape as the
+// method-call case from issue #74 (a ref-arg call), only via a free
+// function. Pre-fix the visitor's macro-skip dropped this too; the
+// fix's descend-through-expansion walks the synthetic scaffolding
+// until it reaches the user's `get(&r)` Call and the regular Call
+// arm emits the `get reads from r` arrow.
+
+struct R { n: i32 }
+
+fn get(r: &R) -> i32 { r.n }
+
+fn main() {
+    let r = R { n: 5 };
+    println!("{}", get(&r));
+}

--- a/rustviz-plugin/tests/method_call_in_println.rs
+++ b/rustviz-plugin/tests/method_call_in_println.rs
@@ -1,0 +1,20 @@
+// Inline ref-arg call inside `println!("{}", …)` — issue #74.
+// The user's `r.get()` is a `&self` method call (ref-arg call site).
+// Pre-fix, modern `println!` expanded to a synthetic block whose
+// outer span is from-expansion, so the visitor's macro-skip dropped
+// the entire arg subtree and the `get reads from r` arrow never
+// fired. After the fix, the visitor descends through synthetic
+// scaffolding until it reaches user-spanned subexpressions, so the
+// `MethodCall` arm runs and emits the call-site arrow as if the
+// method had been written at statement position.
+
+struct R { n: i32 }
+
+impl R {
+    fn get(&self) -> i32 { self.n }
+}
+
+fn main() {
+    let r = R { n: 5 };
+    println!("{}", r.get());
+}


### PR DESCRIPTION
## Summary
- The panic side of #74 was already fixed by #83. The remaining work — the call-site `r → method` PassByStaticReference arrow that doesn't render for ref-arg calls written inline inside a formatter macro — is what this PR addresses.
- Root cause: modern `println!` expands to a `{ _print({ Arguments::new_v1(&[Argument::new_display(&user_expr)]) }); }` tree where every wrapper carries the macro's expansion span. `visit_expr`'s historical `from_expansion` early-return discarded the whole subtree on the outer Block, so the user's `r.method()` / `f(&r)` never reached the MethodCall / Call arm and never emitted the call-site arrow. The pre-existing `println!` special-case in the Call arm was written for an older outer-Call shape and the modern Block-wrapped shape never reaches it.
- Fix: replace the blanket early-return with a `descend_through_expansion` helper that walks through transparent synthetic wrappers (Block / Call / MethodCall / AddrOf / Unary / DropTemps / Array / Tup) until it hits a user-spanned subexpression, then dispatches it back through `visit_expr`. Synthetic control-flow shapes (If / Match / Loop / Closure) are intentionally not descended through — those are how `assert!`, `?`, etc. desugar and treating their synthesized arms as user code would surface spurious events.

## Effect
- `println!("{}", r.area())` → now emits `area reads from r`
- `println!("{}", get(&r))`  → now emits `get reads from r`
- `println!("{} {}", r1.f(), r2.f())` → emits both call-site arrows
- `inherent_method_rectangle` snippet now also emits `area reads from rect` from `print_area`'s `println!`, on top of the outer `print_area reads from r` it already emitted.

## Test plan
- [x] `cargo test -p rustviz-lib --test corpus` — `corpus_expected_ok_produce_well_formed_svg` + `corpus_expected_tooltips_present` both pass, including:
  - new `method_call_in_println` snippet (issue's exact `R::get` repro)
  - new `freefn_call_in_println` snippet (free-fn ref-arg companion)
  - tightened `inherent_method_rectangle` requiring the new `area reads from rect` arrow
- [x] All existing corpus regressions (`testMove`, `string_len`, `nested_struct_borrow`, `box_string`, `rc_clone`, …) still pass — no spurious tooltips on snippets that don't use macro-wrapped ref-arg calls.
- [x] Manual: `assert!(cond)` doesn't surface synthetic panic-arm events (control-flow shapes excluded from descent on purpose).

## Out of scope
- Method calls inside `assert!` and other control-flow-shaped macros aren't visited — same as today. A follow-up could extend descent into If/Match guards specifically, but the existing arm-local from_expansion handlers cover the immediate need without introducing the synthetic-arm risk.
- The pre-existing `println!` special-case in the Call arm is now effectively unreachable on modern macro shapes; left in place for now since touching it is out of scope and it's a no-op rather than wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)