### PR TITLE
playground: re-attach tooltip listeners after example switch

### DIFF
--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -371,6 +371,17 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 
+  // Re-attach hover/tooltip listeners whenever the SVG content
+  // changes. Without this, switching examples while the cursor sits
+  // over the viz panel leaves the new SVG nodes without listeners
+  // (the wrapper div's onMouseEnter doesn't refire), and tooltips
+  // silently stop working until the user moves the cursor out and
+  // back in. helpers() is idempotent — it tags triggers with a
+  // .listener class to skip already-bound nodes.
+  useEffect(() => {
+    helpers('ex2');
+  }, [code_svg, timeline_svg]);
+
   const handleExampleSelect = (code: string) => {
     if (!editor) return;
     editor.setCurrentCode(code);
@@ -439,7 +450,6 @@ const App: React.FC = () => {
                   className="ex2 tl_panel"
                   style={{ width: 'auto' }}
                   dangerouslySetInnerHTML={{ __html: timeline_svg ?? '' }}
-                  onMouseEnter={() => helpers('ex2')}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- `helpers('ex2')` was wired only to the timeline panel's `onMouseEnter`. Picking a new example from the dropdown swaps the SVG via `dangerouslySetInnerHTML`, but if the cursor was already over the viz panel, no fresh `mouseenter` fires on the unchanged wrapper — so the new SVG nodes never get hover listeners and tooltips silently stop appearing.
- Moved the call into a `useEffect` keyed on `[code_svg, timeline_svg]`, so listeners are re-attached after each render that produces new SVG content. `helpers()` is already idempotent (`displayTooltip` tags triggers with a `.listener` class to skip already-bound nodes), so unconditional re-invocation is safe.
- Dropped the now-redundant `onMouseEnter` on the wrapper div.

## How it manifested
Tooltips would disappear on the first dropdown switch and stay broken until the user defocused and refocused the window (which happens to drag the cursor off the panel and back on, refiring `mouseenter`).

## Test plan
- [ ] Load the playground, hover over the timeline arrows in the seed snippet — tooltips appear.
- [ ] Without moving the cursor out of the viz panel, pick another example from the dropdown.
- [ ] Hover over the new arrows — tooltips appear immediately (no defocus/refocus needed).
- [ ] Repeat across several examples in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)