### PR TITLE
playground: add "Other ways to use RustViz" section + Rust-team disclaimer

### DIFF
--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -179,6 +179,22 @@ const Description: React.FC = () => (
       </a>{' '}
       with the snippet and error message.
     </p>
+    <h3>Other ways to use RustViz</h3>
+    <p>
+      Besides this playground, RustViz ships as an mdBook preprocessor
+      (for embedding visualizations in a book, like our{' '}
+      <a href="https://rustviz.github.io/tutorial/" target="_blank" rel="noreferrer">
+        visual Rust tutorial
+      </a>
+      ), a <code>rustviz</code>{' '}
+      command-line tool (one-shot rendering of a <code>.rs</code> file
+      to SVG or self-contained HTML), and a Rust library for
+      programmatic use. Setup and usage for all of them are in the{' '}
+      <a href="https://github.com/rustviz/rustviz" target="_blank" rel="noreferrer">
+        GitHub repo
+      </a>
+      .
+    </p>
     <h3>Credits</h3>
     <p>
       RustViz is a project of the{' '}
@@ -201,7 +217,8 @@ const Description: React.FC = () => (
       <a href="https://gavinleroy.com/" target="_blank" rel="noreferrer">
         Gavin Gray
       </a>
-      .
+      . RustViz is an independent academic project and has no formal
+      affiliation with the Rust project or the Rust Foundation.
     </p>
     <h3>Research paper</h3>
     <p>

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -180,16 +180,23 @@ const Description: React.FC = () => (
       with the snippet and error message.
     </p>
     <h3>Other ways to use RustViz</h3>
+    <p>Besides this playground, RustViz ships as:</p>
+    <ul>
+      <li>
+        an mdBook preprocessor — for embedding visualizations in a
+        book, like our{' '}
+        <a href="https://rustviz.github.io/tutorial/" target="_blank" rel="noreferrer">
+          visual Rust tutorial
+        </a>
+      </li>
+      <li>
+        a <code>rustviz</code> command-line tool — one-shot rendering
+        of a <code>.rs</code> file to SVG or self-contained HTML
+      </li>
+      <li>a Rust library — for programmatic use</li>
+    </ul>
     <p>
-      Besides this playground, RustViz ships as an mdBook preprocessor
-      (for embedding visualizations in a book, like our{' '}
-      <a href="https://rustviz.github.io/tutorial/" target="_blank" rel="noreferrer">
-        visual Rust tutorial
-      </a>
-      ), a <code>rustviz</code>{' '}
-      command-line tool (one-shot rendering of a <code>.rs</code> file
-      to SVG or self-contained HTML), and a Rust library for
-      programmatic use. Setup and usage for all of them are in the{' '}
+      Setup and usage for all of them are in the{' '}
       <a href="https://github.com/rustviz/rustviz" target="_blank" rel="noreferrer">
         GitHub repo
       </a>


### PR DESCRIPTION
## Summary

Two small additions to the playground prose pane:

- New **"Other ways to use RustViz"** section between Limitations and Credits. Names the mdBook preprocessor (with a link to <https://rustviz.github.io/tutorial/> as the canonical example), the `rustviz` CLI, and the Rust library, with a single GitHub link for setup/usage details.
- One-line **disclaimer** appended to the Credits section: "RustViz is an independent academic project and has no formal affiliation with the Rust project or the Rust Foundation."

## Test plan

- [x] Verified locally at http://localhost:3001/ via Vite HMR — both sections render where expected.
- [ ] After merge, confirm the same on https://rustviz.github.io/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)