### PR TITLE
playground: user-created examples with implicit fork on edit

### DIFF
--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -597,7 +597,17 @@ const App: React.FC = () => {
         {/* Top row: prose on the left, code editor on the right. */}
         <Panel defaultSize={40} minSize={15}>
           <PanelGroup direction="horizontal" autoSaveId="rustviz-top-horizontal">
-            <Panel defaultSize={35} minSize={15} className="panel description-panel">
+            {/* Collapsible so users running pure code demos can drag
+                the handle to the left edge and snap the prose pane
+                away. minSize is the snap threshold — below 15% the
+                panel collapses to 0; the resize handle stays visible
+                at the edge so the user can drag it back to expand. */}
+            <Panel
+              defaultSize={35}
+              minSize={15}
+              collapsible
+              className="panel description-panel"
+            >
               <Description />
             </Panel>
             <PanelResizeHandle className="resize-handle resize-handle-vertical" />

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -560,7 +560,35 @@ const App: React.FC = () => {
     );
   };
 
+  // Delete the currently-selected user example. Confirms first
+  // because the action is destructive and there's no undo (the
+  // example's code is overwritten in localStorage). After deletion,
+  // fall back to the example that was at the same index (or just
+  // before, if we deleted the last one); if no user examples are
+  // left, fall back to the default preloaded example.
+  const handleDelete = () => {
+    if (selection.kind !== 'user') return;
+    const idx = userExamples.findIndex(e => e.id === selection.id);
+    if (idx < 0) return;
+    const current = userExamples[idx];
+    if (!window.confirm(`Delete "${current.name}"? This can't be undone.`)) return;
+    const next = userExamples.filter(e => e.id !== current.id);
+    let fallback: Selection;
+    if (next.length > 0) {
+      const fallbackIdx = Math.min(idx, next.length - 1);
+      fallback = { kind: 'user', id: next[fallbackIdx].id };
+    } else {
+      fallback = DEFAULT_SELECTION;
+    }
+    setUserExamples(next);
+    setSelection(fallback);
+    if (!editor) return;
+    editor.setCurrentCode(codeForSelection(fallback, next));
+    handleClick();
+  };
+
   const canRename = selection.kind === 'user';
+  const canDelete = selection.kind === 'user';
 
   return (
     <div className="app-shell">
@@ -604,6 +632,22 @@ const App: React.FC = () => {
                       same way the `+` glyph above does — no SVG fill
                       / stroke inheritance to debug. */}
                   ✎
+                </button>
+                <button
+                  className="cm-button toolbar-icon-button"
+                  onClick={handleDelete}
+                  disabled={!canDelete}
+                  title={
+                    canDelete
+                      ? 'Delete this example'
+                      : 'Delete only works on examples you created'
+                  }
+                  aria-label="Delete this example"
+                >
+                  {/* U+2715 MULTIPLICATION X — monochrome, consistent
+                      with the + and ✎ glyphs. Reads as "remove this
+                      item" alongside the existing rename/add controls. */}
+                  ✕
                 </button>
                 <button
                   className="cm-button generate-button"

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -589,7 +589,7 @@ const App: React.FC = () => {
                   +
                 </button>
                 <button
-                  className="cm-button"
+                  className="cm-button toolbar-icon-button"
                   onClick={handleRename}
                   disabled={!canRename}
                   title={
@@ -597,8 +597,28 @@ const App: React.FC = () => {
                       ? 'Rename this example'
                       : 'Rename only works on examples you created'
                   }
+                  aria-label="Rename this example"
                 >
-                  Rename
+                  {/* Pencil icon (Lucide-style, inlined). `currentColor`
+                      inherits the button's white text color and the
+                      :disabled rule on .cm-button dims it the same way
+                      it dims text. */}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                    style={{ display: 'block' }}
+                  >
+                    <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+                    <path d="m15 5 4 4" />
+                  </svg>
                 </button>
                 <button
                   className="cm-button generate-button"

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -599,27 +599,11 @@ const App: React.FC = () => {
                   }
                   aria-label="Rename this example"
                 >
-                  {/* Pencil icon (Lucide-style, inlined). `currentColor`
-                      stroke + explicit `fill="none"` on each path —
-                      the SVG-level `fill` doesn't reliably inherit to
-                      children in React's renderer, so without per-path
-                      fill the closed pencil-body path renders as a
-                      filled rectangle. */}
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                    style={{ display: 'block' }}
-                  >
-                    <path fill="none" d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-                    <path fill="none" d="m15 5 4 4" />
-                  </svg>
+                  {/* Unicode "lower right pencil" (U+270E) renders in
+                      the inherited text color across platforms, the
+                      same way the `+` glyph above does — no SVG fill
+                      / stroke inheritance to debug. */}
+                  ✎
                 </button>
                 <button
                   className="cm-button generate-button"

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -7,6 +7,22 @@ import axios from 'axios';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import ErrorCard from './ErrorCard';
 import { exampleGroups } from './examples';
+import {
+  codeForSelection,
+  DEFAULT_SELECTION,
+  forkedName,
+  loadSelection,
+  loadUserExamples,
+  newId,
+  nextNewExampleName,
+  NEW_EXAMPLE_TEMPLATE,
+  optionValueToSelection,
+  saveSelection,
+  saveUserExamples,
+  selectionToOptionValue,
+  type Selection,
+  type UserExample,
+} from './userExamples';
 
 // API origin. Empty (relative URL) for the default same-origin Fly deploy;
 // set to https://rustviz-playground.fly.dev for the GitHub Pages build via
@@ -16,26 +32,37 @@ const API_BASE: string = import.meta.env.VITE_API_BASE ?? '';
 
 declare function helpers(param: string): void;
 
-// Seed the editor with the first dropdown example (Motivation →
-// "Hands-on tutorial") so first-time visitors land on a snippet that
-// actually exercises ownership, borrowing, and the
-// `// rustviz: skip` / `// rustviz: hide` markers — instead of an
-// abstract `let mut x = 7; let mut a = &mut x; …` chain that doesn't
-// motivate anything. Single source of truth lives in examples.ts.
-const defaultExample: string = exampleGroups[0].examples[0].code;
-
 // Thin wrapper around CodeMirror's EditorView so the React layer can
 // hold a single `Editor` instance across renders without re-creating
 // the underlying view (which would lose cursor position, undo
 // history, etc.). Owns its own DOM insertion via the constructor's
 // `parent` arg.
+//
+// `onUserChange` fires after every user-driven document change (typing,
+// paste, delete) but is suppressed during programmatic `setCurrentCode`
+// — the dropdown loading a different example shouldn't look like the
+// user editing the current one (which would trigger an implicit fork).
 class Editor {
   private view: EditorView;
+  // True for the duration of one programmatic `setCurrentCode` call.
+  // CodeMirror dispatches transactions synchronously, so we set, dispatch,
+  // and clear within the same call frame — the change listener fires
+  // in between and sees the flag set.
+  private programmatic = false;
 
-  public constructor(editorContainer: HTMLElement, code: string = defaultExample) {
+  public constructor(
+    editorContainer: HTMLElement,
+    code: string,
+    onUserChange: (code: string) => void,
+  ) {
+    const updateListener = EditorView.updateListener.of(update => {
+      if (!update.docChanged) return;
+      if (this.programmatic) return;
+      onUserChange(update.state.doc.toString());
+    });
     const initial_state = EditorState.create({
       doc: code,
-      extensions: extensions,
+      extensions: [...extensions, updateListener],
     });
     this.view = new EditorView({ state: initial_state, parent: editorContainer });
   }
@@ -44,12 +71,20 @@ class Editor {
     return this.view.state.doc.toString();
   }
 
-  // Replace the entire editor contents in one transaction. Used by the
-  // example-picker dropdown when the user selects a preloaded snippet.
+  // Replace the entire editor contents in one transaction. The
+  // `programmatic` flag prevents the change listener from interpreting
+  // this as user input (which would otherwise look like the user editing
+  // a preloaded example, triggering an unwanted implicit fork).
   public setCurrentCode(code: string): void {
-    this.view.dispatch({
-      changes: { from: 0, to: this.view.state.doc.length, insert: code },
-    });
+    if (code === this.view.state.doc.toString()) return;
+    this.programmatic = true;
+    try {
+      this.view.dispatch({
+        changes: { from: 0, to: this.view.state.doc.length, insert: code },
+      });
+    } finally {
+      this.programmatic = false;
+    }
   }
 
   public destroy(): void {
@@ -260,7 +295,9 @@ const Description: React.FC = () => (
 );
 
 type ExamplePickerProps = {
-  onSelect: (code: string) => void;
+  selection: Selection;
+  userExamples: UserExample[];
+  onSelect: (sel: Selection) => void;
 };
 
 // The picker stays interactive even while a /submit-code request is
@@ -268,28 +305,42 @@ type ExamplePickerProps = {
 // request (see inflightRef in App) and starts a new one — the user
 // can change their mind and the wrong response can never overwrite
 // the right one.
-const ExamplePicker: React.FC<ExamplePickerProps> = ({ onSelect }) => {
+//
+// Two source groups: the persisted `userExamples` at the top (only
+// rendered when non-empty) and the curated `exampleGroups` below.
+// Option values are encoded via `selectionToOptionValue` so the
+// onChange handler can round-trip a Selection without juggling
+// string parsing inline.
+const ExamplePicker: React.FC<ExamplePickerProps> = ({ selection, userExamples, onSelect }) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    if (!value) return;
-    // value encodes "<chapterIndex>:<exampleIndex>" so we don't have
-    // to escape the example name into the option's value attribute.
-    const [chapterIdx, exampleIdx] = value.split(':').map(Number);
-    onSelect(exampleGroups[chapterIdx].examples[exampleIdx].code);
+    const sel = optionValueToSelection(e.target.value);
+    if (sel) onSelect(sel);
   };
 
   return (
     <div className="example-picker">
       <label htmlFor="example-select">Example:</label>
-      {/* Default to "0:0" — Motivation → "Hands-on tutorial" — to
-          match the editor's seed snippet (defaultExample). React's
-          `defaultValue` only sets initial state; it doesn't fire
-          onChange, so we don't double-load the same code. */}
-      <select id="example-select" defaultValue="0:0" onChange={handleChange}>
+      <select
+        id="example-select"
+        value={selectionToOptionValue(selection)}
+        onChange={handleChange}
+      >
+        {userExamples.length > 0 && (
+          <optgroup label="Your examples">
+            {userExamples.map(ex => (
+              <option key={ex.id} value={selectionToOptionValue({ kind: 'user', id: ex.id })}>
+                {ex.name}
+              </option>
+            ))}
+          </optgroup>
+        )}
         {exampleGroups.map((group, gIdx) => (
           <optgroup key={group.chapter} label={group.chapter}>
             {group.examples.map((ex, eIdx) => (
-              <option key={ex.name} value={`${gIdx}:${eIdx}`}>
+              <option
+                key={ex.name}
+                value={selectionToOptionValue({ kind: 'preloaded', chapter: gIdx, index: eIdx })}
+              >
                 {ex.name}
               </option>
             ))}
@@ -308,6 +359,62 @@ const App: React.FC = () => {
   const [code_svg, setCodeSvg] = useState<string | null>(null);
   const [timeline_svg, setTimelineSvg] = useState<string | null>(null);
 
+  // Persisted user examples + the current selection. Both hydrated
+  // from localStorage on first render (useState initializer runs once)
+  // and saved back on every change via the effects below.
+  const [userExamples, setUserExamples] = useState<UserExample[]>(() => loadUserExamples());
+  const [selection, setSelection] = useState<Selection>(() =>
+    loadSelection(loadUserExamples()),
+  );
+
+  // Refs mirror the latest state so the editor's change listener — a
+  // stable closure captured at editor-mount time — can read current
+  // values when deciding whether to fork or update in-place. Without
+  // these refs the listener would see the initial state forever.
+  const selectionRef = useRef(selection);
+  const userExamplesRef = useRef(userExamples);
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
+  useEffect(() => {
+    userExamplesRef.current = userExamples;
+  }, [userExamples]);
+
+  // Persist on every change. localStorage writes are cheap; no need
+  // to debounce.
+  useEffect(() => {
+    saveUserExamples(userExamples);
+  }, [userExamples]);
+  useEffect(() => {
+    saveSelection(selection);
+  }, [selection]);
+
+  // Editor change listener. Two cases:
+  //   * `selection.kind === 'user'`  →  update the existing user
+  //     example's stored code in place (auto-save).
+  //   * `selection.kind === 'preloaded'`  →  implicit fork. Create a
+  //     new user example named "<original> (copy)", populated with
+  //     the just-edited code, and switch the selection to it. The
+  //     user's edit cursor stays where it is — we don't touch the
+  //     editor view itself.
+  const handleEditorChange = (code: string) => {
+    const sel = selectionRef.current;
+    const examples = userExamplesRef.current;
+    if (sel.kind === 'user') {
+      const next = examples.map(e => (e.id === sel.id ? { ...e, code } : e));
+      setUserExamples(next);
+      return;
+    }
+    const preloadedName = exampleGroups[sel.chapter].examples[sel.index].name;
+    const forked: UserExample = {
+      id: newId(),
+      name: forkedName(preloadedName, examples),
+      code,
+    };
+    setUserExamples([...examples, forked]);
+    setSelection({ kind: 'user', id: forked.id });
+  };
+
   // The CodeMirror editor needs a real DOM node to attach to. Create
   // it once when the host div mounts; tear it down on unmount so
   // React 18 StrictMode's dev-mode double-invocation of this effect
@@ -315,12 +422,19 @@ const App: React.FC = () => {
   const editorHostRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (!editorHostRef.current) return;
-    const newEditor = new Editor(editorHostRef.current);
+    // Read directly from the initial state values (computed in the
+    // useState initializer above). The ESLint deps rule wants
+    // selection/userExamples here, but adding them would re-mount the
+    // editor on every example switch and lose history. The change
+    // listener below uses refs to read the live values instead.
+    const initialCode = codeForSelection(selection, userExamples);
+    const newEditor = new Editor(editorHostRef.current, initialCode, handleEditorChange);
     setEditor(newEditor);
     return () => {
       newEditor.destroy();
       setEditor(null);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Tracks the AbortController of the in-flight /submit-code request,
@@ -401,14 +515,52 @@ const App: React.FC = () => {
     helpers('ex2');
   }, [code_svg, timeline_svg]);
 
-  const handleExampleSelect = (code: string) => {
+  // Switch to a different example (preloaded or user-created).
+  // Setting selection + pushing the new code into the editor are both
+  // programmatic — neither should trigger the implicit-fork path.
+  const handleExampleSelect = (sel: Selection) => {
+    setSelection(sel);
     if (!editor) return;
-    editor.setCurrentCode(code);
+    editor.setCurrentCode(codeForSelection(sel, userExamples));
     // Auto-fire the visualization. CodeMirror's dispatch is
     // synchronous so getCurrentCode() inside handleClick() will see
     // the just-set code on the next line.
     handleClick();
   };
+
+  // `+` button: create a fresh user example with the next "New
+  // example N" name and seed it with an empty fn main() template.
+  const handleNewExample = () => {
+    const created: UserExample = {
+      id: newId(),
+      name: nextNewExampleName(userExamples),
+      code: NEW_EXAMPLE_TEMPLATE,
+    };
+    setUserExamples([...userExamples, created]);
+    setSelection({ kind: 'user', id: created.id });
+    if (!editor) return;
+    editor.setCurrentCode(NEW_EXAMPLE_TEMPLATE);
+    handleClick();
+  };
+
+  // Rename the currently-selected user example. No-op (and disabled
+  // in the toolbar) for preloaded examples — those are read-only.
+  // Empty / whitespace-only names are rejected; duplicates aren't
+  // forbidden because the underlying id stays unique.
+  const handleRename = () => {
+    if (selection.kind !== 'user') return;
+    const current = userExamples.find(e => e.id === selection.id);
+    if (!current) return;
+    const input = window.prompt('Rename example:', current.name);
+    if (input === null) return;
+    const trimmed = input.trim();
+    if (!trimmed || trimmed === current.name) return;
+    setUserExamples(
+      userExamples.map(e => (e.id === current.id ? { ...e, name: trimmed } : e)),
+    );
+  };
+
+  const canRename = selection.kind === 'user';
 
   return (
     <div className="app-shell">
@@ -423,7 +575,31 @@ const App: React.FC = () => {
             <PanelResizeHandle className="resize-handle resize-handle-vertical" />
             <Panel defaultSize={65} minSize={25} className="panel editor-panel">
               <div className="editor-toolbar">
-                <ExamplePicker onSelect={handleExampleSelect} />
+                <ExamplePicker
+                  selection={selection}
+                  userExamples={userExamples}
+                  onSelect={handleExampleSelect}
+                />
+                <button
+                  className="cm-button toolbar-icon-button"
+                  onClick={handleNewExample}
+                  title="Create a new example (saved in this browser)"
+                  aria-label="Create a new example"
+                >
+                  +
+                </button>
+                <button
+                  className="cm-button"
+                  onClick={handleRename}
+                  disabled={!canRename}
+                  title={
+                    canRename
+                      ? 'Rename this example'
+                      : 'Rename only works on examples you created'
+                  }
+                >
+                  Rename
+                </button>
                 <button
                   className="cm-button generate-button"
                   onClick={handleClick}

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -600,15 +600,16 @@ const App: React.FC = () => {
                   aria-label="Rename this example"
                 >
                   {/* Pencil icon (Lucide-style, inlined). `currentColor`
-                      inherits the button's white text color and the
-                      :disabled rule on .cm-button dims it the same way
-                      it dims text. */}
+                      stroke + explicit `fill="none"` on each path —
+                      the SVG-level `fill` doesn't reliably inherit to
+                      children in React's renderer, so without per-path
+                      fill the closed pencil-body path renders as a
+                      filled rectangle. */}
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="14"
                     height="14"
                     viewBox="0 0 24 24"
-                    fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
                     strokeLinecap="round"
@@ -616,8 +617,8 @@ const App: React.FC = () => {
                     aria-hidden="true"
                     style={{ display: 'block' }}
                   >
-                    <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-                    <path d="m15 5 4 4" />
+                    <path fill="none" d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+                    <path fill="none" d="m15 5 4 4" />
                   </svg>
                 </button>
                 <button

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -159,7 +159,6 @@ code {
   overflow: auto;
   flex: 1;
   min-height: 0;
-  max-width: 80ch;
   line-height: 1.55;
 }
 

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -191,7 +191,10 @@ code {
 .editor-toolbar {
   display: flex;
   align-items: center;
-  gap: 16px;
+  /* Tight gap so the dropdown + icon buttons read as one cluster on
+     the left. The Generate button gets `margin-left: auto` (below) to
+     push itself to the right edge regardless of this gap. */
+  gap: 6px;
   padding: 10px 16px;
   background: #f6f6f6;
   border-bottom: 1px solid var(--border);

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -242,6 +242,19 @@ code {
   min-width: 180px;
 }
 
+/* Compact toolbar buttons that sit between the example dropdown and
+   the right-aligned Generate button. The `+` icon button is square;
+   the Rename button is wider but stays the same height. */
+.toolbar-icon-button {
+  padding: 4px 10px;
+  font-size: 16px;
+  line-height: 1;
+}
+.editor-toolbar .cm-button:not(.generate-button):not(.toolbar-icon-button) {
+  padding: 4px 10px;
+  font-size: 13px;
+}
+
 .editor-host {
   flex: 1;
   min-height: 0;

--- a/playground/frontend/src/index.css
+++ b/playground/frontend/src/index.css
@@ -246,11 +246,23 @@ code {
 
 /* Compact toolbar buttons that sit between the example dropdown and
    the right-aligned Generate button. The `+` icon button is square;
-   the Rename button is wider but stays the same height. */
+   the Rename button is wider but stays the same height.
+   Gray-on-fg styling deliberately demotes them next to the orange
+   Generate button — these are example-list management, not the
+   primary action. */
 .toolbar-icon-button {
   padding: 4px 10px;
   font-size: 16px;
   line-height: 1;
+  background: var(--border);
+  color: var(--fg);
+}
+.toolbar-icon-button:hover:not(:disabled) {
+  background: var(--border-strong);
+}
+.toolbar-icon-button:disabled {
+  background: var(--border);
+  color: var(--fg-muted);
 }
 .editor-toolbar .cm-button:not(.generate-button):not(.toolbar-icon-button) {
   padding: 4px 10px;

--- a/playground/frontend/src/userExamples.ts
+++ b/playground/frontend/src/userExamples.ts
@@ -1,0 +1,195 @@
+// localStorage-backed user-created example snippets, plus the
+// selection model that lets the toolbar dropdown reference either a
+// curated example from `examples.ts` or one of these.
+//
+// Two pieces live here so App.tsx stays focused on UI wiring:
+//   * `UserExample` + storage helpers — the persisted shape and
+//     read/write functions, defensive against a corrupt/foreign
+//     localStorage payload.
+//   * Naming helpers — `nextNewExampleName` for the `+` button and
+//     `forkedName` for the implicit fork on first edit. Both pick a
+//     name that doesn't collide with any existing user example so the
+//     dropdown is unambiguous.
+
+import { exampleGroups } from './examples';
+
+const STORAGE_KEY = 'rustviz.playground.userExamples';
+const SELECTED_KEY = 'rustviz.playground.selected';
+
+export type UserExample = {
+  /** Stable id so renames don't break selection refs. */
+  id: string;
+  /** Label shown in the dropdown and editable via the rename button. */
+  name: string;
+  /** Source as last seen in the editor. Updated on every keystroke. */
+  code: string;
+};
+
+/**
+ * What's currently loaded in the editor. `preloaded` references the
+ * static `exampleGroups` by indices; `user` references a row of the
+ * persisted `UserExample[]` by id.
+ */
+export type Selection =
+  | { kind: 'preloaded'; chapter: number; index: number }
+  | { kind: 'user'; id: string };
+
+export const DEFAULT_SELECTION: Selection = {
+  kind: 'preloaded',
+  chapter: 0,
+  index: 0,
+};
+
+/** Code template seeded into the editor by the `+` button. */
+export const NEW_EXAMPLE_TEMPLATE = `fn main() {
+
+}
+`;
+
+export function loadUserExamples(): UserExample[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Filter shape defensively — a future schema change or hand-edited
+    // localStorage shouldn't blow up the app.
+    return parsed.filter(
+      (e): e is UserExample =>
+        typeof (e as UserExample)?.id === 'string' &&
+        typeof (e as UserExample)?.name === 'string' &&
+        typeof (e as UserExample)?.code === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function saveUserExamples(examples: UserExample[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(examples));
+  } catch {
+    // Quota exceeded / storage unavailable. Silently degrade — the
+    // user's edits stay in the editor for this session, just not across
+    // refreshes. We could surface a warning, but losing one example to
+    // a quota cap shouldn't pop a modal.
+  }
+}
+
+/**
+ * Read the persisted selection and validate it's still pointing at
+ * something that exists. A stale reference (preloaded index out of
+ * range after we trim the curated list, or user id whose example was
+ * cleared from localStorage) falls back to the default.
+ */
+export function loadSelection(userExamples: UserExample[]): Selection {
+  try {
+    const raw = localStorage.getItem(SELECTED_KEY);
+    if (!raw) return DEFAULT_SELECTION;
+    const parsed = JSON.parse(raw) as Selection;
+    if (
+      parsed?.kind === 'preloaded' &&
+      typeof parsed.chapter === 'number' &&
+      typeof parsed.index === 'number'
+    ) {
+      const grp = exampleGroups[parsed.chapter];
+      if (grp && grp.examples[parsed.index]) return parsed;
+    }
+    if (parsed?.kind === 'user' && typeof parsed.id === 'string') {
+      if (userExamples.some(e => e.id === parsed.id)) return parsed;
+    }
+  } catch {
+    // fall through
+  }
+  return DEFAULT_SELECTION;
+}
+
+export function saveSelection(sel: Selection) {
+  try {
+    localStorage.setItem(SELECTED_KEY, JSON.stringify(sel));
+  } catch {
+    // see saveUserExamples
+  }
+}
+
+/**
+ * Resolve the code that belongs to a selection. Caller passes the
+ * current `userExamples` so we don't re-read storage on every lookup.
+ * Falls back to the default preloaded example if a user example was
+ * deleted out from under the selection (defensive — the UI normally
+ * keeps these consistent).
+ */
+export function codeForSelection(sel: Selection, userExamples: UserExample[]): string {
+  if (sel.kind === 'user') {
+    const found = userExamples.find(e => e.id === sel.id);
+    if (found) return found.code;
+    // Stale selection — use the default preloaded.
+    return exampleGroups[0].examples[0].code;
+  }
+  return exampleGroups[sel.chapter].examples[sel.index].code;
+}
+
+/** Browser-supplied UUIDs when available; random base36 otherwise. */
+export function newId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+/**
+ * Pick the next "New example N" label that doesn't collide with any
+ * existing user-example name. Walks the existing names and finds the
+ * highest N already in use, then returns N+1.
+ */
+export function nextNewExampleName(examples: UserExample[]): string {
+  let max = 0;
+  for (const e of examples) {
+    const m = /^New example (\d+)$/.exec(e.name);
+    if (m) {
+      const n = parseInt(m[1], 10);
+      if (n > max) max = n;
+    }
+  }
+  return `New example ${max + 1}`;
+}
+
+/**
+ * Pick a name for an implicit fork of `base` (the original preloaded
+ * example's name). Tries `<base> (copy)` first, then `<base> (copy 2)`,
+ * etc., until it finds one not already in `examples`.
+ */
+export function forkedName(base: string, examples: UserExample[]): string {
+  const taken = new Set(examples.map(e => e.name));
+  const first = `${base} (copy)`;
+  if (!taken.has(first)) return first;
+  for (let i = 2; ; i++) {
+    const candidate = `${base} (copy ${i})`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Encode a Selection into the dropdown's `<option value="...">`
+ * string and back. Encoding is `kind:rest`:
+ *   * `preloaded:<chapterIdx>:<exampleIdx>`
+ *   * `user:<id>`
+ * Strings only — keeps option values opaque to React.
+ */
+export function selectionToOptionValue(sel: Selection): string {
+  if (sel.kind === 'user') return `user:${sel.id}`;
+  return `preloaded:${sel.chapter}:${sel.index}`;
+}
+
+export function optionValueToSelection(value: string): Selection | null {
+  if (value.startsWith('user:')) {
+    return { kind: 'user', id: value.slice('user:'.length) };
+  }
+  if (value.startsWith('preloaded:')) {
+    const [chapter, index] = value.slice('preloaded:'.length).split(':').map(Number);
+    if (!Number.isNaN(chapter) && !Number.isNaN(index)) {
+      return { kind: 'preloaded', chapter, index };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes the long-standing UX where editing a preloaded example left the dropdown still pointing at it. Replaces that with a proper user-example model persisted in browser localStorage.

**Behaviour changes:**
- Dropdown gets a new **"Your examples"** optgroup at the top, populated from a per-browser persisted list.
- `+` button creates a fresh user example seeded with an empty \`fn main()\` template, named **"New example N"** with N auto-incrementing past any existing such names.
- The **first edit** on a preloaded example implicitly forks it into a new user example named **"<original> (copy)"** (or "(copy 2)" etc. to dodge collisions). Subsequent keystrokes auto-save into that user example.
- **Rename** button (enabled only on user examples) prompts for a new name. Empty or unchanged inputs are no-ops; duplicate names are allowed because the underlying id stays unique.

## Implementation

- New `playground/frontend/src/userExamples.ts` owns the persisted shape (\`UserExample\`), the \`Selection\` discriminated union, name-generation helpers, and the option-value codec the dropdown round-trips selections through.
- \`Editor\` class grows an \`onUserChange\` callback (wired through a CodeMirror \`updateListener.of(...)\` extension). A \`programmatic\` flag suppresses the callback during dropdown loads / \`+\` clicks so those don't look like user edits.
- App keeps \`userExamples\` and \`selection\` in state — hydrated from localStorage on first render, persisted on change — plus refs for the change listener, which captures a stable closure at editor-mount time and needs ref-based access to read the live selection.

## Test plan

- [x] \`npm run build\` (tsc + vite) compiles cleanly.
- [x] Verified locally at http://localhost:3001/ via Vite HMR while developing.
- [ ] Manual smoke after merge:
  - [ ] Pick "Hands-on tutorial" → type a character → "Hands-on tutorial (copy)" appears under Your examples and is selected; original is unchanged.
  - [ ] Click \`+\` → "New example 1" with empty \`fn main()\` template; click again → "New example 2".
  - [ ] Rename one of them; refresh; rename persists.
  - [ ] Edit a user example; refresh; edit persists.
  - [ ] Pick a preloaded example after a fork; the fork stays in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)