### PR TITLE
playground: rename internal crate from "test-crate" to "user-code"

### DIFF
--- a/playground/runner/rv-runner.sh
+++ b/playground/runner/rv-runner.sh
@@ -11,10 +11,13 @@
 set -euo pipefail
 
 cd /work
-rm -rf test-crate
+rm -rf user-code
 
-cargo new --lib --quiet test-crate
-cd test-crate
+# Crate name surfaces in rustc/cargo error messages ("could not compile
+# `user-code`"), so use a name that reads as "this is the user's code"
+# rather than a leaked internal placeholder.
+cargo new --lib --quiet user-code
+cd user-code
 
 # Pin the toolchain that rustviz-plugin was built against; without this the
 # nested cargo invocation can pick up an unrelated default.

--- a/rustviz-lib/src/lib.rs
+++ b/rustviz-lib/src/lib.rs
@@ -293,8 +293,12 @@ fn run_docker(code_str: &str) -> Result<Vec<u8>, Box<dyn Error>> {
 fn run_local(code_str: &str) -> Result<Vec<u8>, Box<dyn Error>> {
     let tempdir = tempdir()?;
     let root = tempdir.path();
+    // Crate name surfaces in rustc/cargo error messages
+    // ("could not compile `user-code`"), so use a name that reads as
+    // "this is the user's code" rather than a leaked internal
+    // placeholder.
     let status = Command::new("cargo")
-        .args(["new", "--lib", "test-crate"])
+        .args(["new", "--lib", "user-code"])
         .current_dir(root)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -305,7 +309,7 @@ fn run_local(code_str: &str) -> Result<Vec<u8>, Box<dyn Error>> {
         )));
     }
 
-    let cwd = root.join("test-crate");
+    let cwd = root.join("user-code");
     fs::write(cwd.join("rust-toolchain.toml"), TOOLCHAIN)?;
     fs::write(cwd.join("src").join("lib.rs"), code_str)?;
 


### PR DESCRIPTION
## Summary

When the plugin fails on a user snippet, rustc / cargo error messages include the package name verbatim — e.g.

\`\`\`
error: could not compile \`test-crate\` (lib) due to 1 previous error
\`\`\`

That \`test-crate\` is a leaked internal placeholder; it reads like a half-finished test fixture rather than "your code didn't compile". Renaming to \`user-code\` makes the same message land as

\`\`\`
error: could not compile \`user-code\` (lib) due to 1 previous error
\`\`\`

— which scans as "this is the user's code" with no further explanation needed.

Two locations:
- \`rustviz-lib/src/lib.rs\` — the local backend's tempdir bootstrap (used by the CLI, the mdBook preprocessor, and the in-process playground path).
- \`playground/runner/rv-runner.sh\` — the docker runner's entrypoint script (used by the sandboxed playground deployment).

## Test plan

- [x] \`cargo test -p rustviz-lib --test corpus -- corpus_expected_ok_produce_well_formed_svg\` passes (the regression floor — exercises run_local with the new name).
- [ ] After merge: hit the live playground with a snippet that fails to compile and confirm the error message reads "could not compile \`user-code\`".

🤖 Generated with [Claude Code](https://claude.com/claude-code)