### PR TITLE
plugin: attribute macro-expanded RHS bind to the user's let line

### DIFF
--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -754,7 +754,16 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
   // clean "v acquires ownership of a resource" event without trying to
   // name the synthetic call inside the macro.
   if rhs.span.from_expansion() {
-    let line_num = span_to_line(&rhs.span, &self.tcx);
+    // Walk the macro expansion chain back to the user's source span.
+    // Without this, `rhs.span` for `let v = vec![…]` points into the
+    // macro's own source file (e.g. `liballoc/macros.rs`), so the
+    // Bind event is attributed to a line that doesn't exist in the
+    // user's snippet — `compute_states` then sees the Acquire event
+    // ordered *after* the binding's GoOutOfScope at end-of-fn, and
+    // the rendered timeline column has no visible state segment or
+    // drop. `source_callsite` resolves to the user's `let` line.
+    let user_span = rhs.span.source_callsite();
+    let line_num = span_to_line(&user_span, &self.tcx);
     self.add_ev(line_num, Evt::Bind, lhs, ResourceTy::Anonymous, false);
     return;
   }

--- a/rustviz-plugin/tests/macro_rhs_acquire_line.rs
+++ b/rustviz-plugin/tests/macro_rhs_acquire_line.rs
@@ -1,0 +1,9 @@
+// Regression for: macro-expanded RHS bindings (`vec![]`, `format!`,
+// etc.) attributed their Bind/Acquire event to the macro's own
+// source line rather than the user's `let` line. The Acquire then
+// landed *after* the binding's GoOutOfScope event in time order and
+// the rendered timeline column had no visible state segment / drop.
+fn main() {
+    let words = vec![1, 2, 3];
+    let _ = words;
+}


### PR DESCRIPTION
## Summary

Fixes a column-rendering bug surfaced while reviewing the for-loop examples in #98 — independently visible without any loop or branch.

\`let v = vec![1, 2, 3];\` (and any macro-expanded RHS that hits #93's from_expansion shortcut in \`match_rhs\`) was emitting its Bind/Acquire event with the line of \`rhs.span\`. For a macro-expanded RHS that span lives in the macro's own source file — e.g. \`liballoc/macros.rs\` line ~50 for \`vec!\` — not the user's snippet. The Bind landed on a line **outside the user's source range**, and \`compute_states\` (which walks events in line order) ended up with:

\`\`\`
1..50: OutOfScope          (no rendering)
50..50: FullPrivilege       (zero-width segment, no rendering)
\`\`\`

Net effect on the rendered timeline column: label only, no stripe, no acquire dot, no drop — even for trivial code with no loop / branch / closure involved. The \`for over a borrowed Vec\` example in the playground's Loops dropdown was the user-visible repro: \`words\` had a label but no rendered "alive" stripe and no GoOutOfScope marker.

## Fix

Walk the macro expansion chain back to the user span via \`Span::source_callsite()\` before computing the line number:

\`\`\`rust
let user_span = rhs.span.source_callsite();
let line_num = span_to_line(&user_span, &self.tcx);
\`\`\`

State sequence for \`let v = vec![1,2,3];\` becomes:

\`\`\`
1..2: OutOfScope
2..3: FullPrivilege          (hollow stripe)
3..3: OutOfScope
\`\`\`

so the column renders correctly: acquire dot, hollow stripe, drop dot.

## Test plan

- [x] Full corpus (103/103 on \`main\`) passes with the fix
- [x] New \`tests/macro_rhs_acquire_line.rs\` fixture exercises the bare \`let v = vec![…]\` case
- [x] Manual verification via the playground: \`for over a borrowed Vec\` example now shows the \`words\` column's stripe + drop the user expected