### PR TITLE
plugin: annotate while-let patterns + drop "ownership" wording for Copy types

### DIFF
--- a/rustviz-plugin/src/annotated_source_gen.rs
+++ b/rustviz-plugin/src/annotated_source_gen.rs
@@ -50,13 +50,35 @@ pub fn annotate_src(&mut self, name: String, s: Span, is_func: bool, hash: u64) 
 }
 
 pub fn annotate_expr(& mut self, expr: &'tcx Expr) {
-  // Mirror the visitor's macro-expansion skip: macro-generated nodes
-  // refer to synthetic items (e.g. `core::panicking::panic`) that the
-  // visitor never registers in `self.raps`, so attempting to annotate
-  // them here unwraps None on the RAP lookup. The user's source code
-  // doesn't include these names anyway, so there's nothing to
-  // highlight in the rendered code panel.
+  // Most macro/desugar-generated subtrees should be skipped — they
+  // refer to synthetic items the visitor never registered. But a few
+  // specific desugar shapes wrap *user-written* code in synthetic
+  // spans, and we want to keep annotating into them:
+  //
+  //   while cond { body }                 →  loop { if cond { body } else { break } }
+  //   while let pat = expr { body }       →  loop { if let pat = expr { body } else { break } }
+  //   for pat in iter { body }            →  match into_iter(iter) { mut iter =>
+  //                                            loop { match next(&mut iter) {
+  //                                              None => break, Some(pat) => body } } }
+  //
+  // The wrapping `If` / `Match` / `Loop` carry the DesugaringKind
+  // span (so `from_expansion()` returns true), but the user's `pat`,
+  // scrutinee, and `body` are themselves user-written. Without this
+  // descent, `s` in `while let Some(s) = stack.pop() { … }` and
+  // `stack`/`pop` on the same line never get annotated.
   if expr.span.from_expansion() {
+    if let ExprKind::If(guard, then_body, _else) = expr.kind {
+      // The else arm of a while/if-let desugar is the synthetic
+      // `break` — skip it. The guard is either a `Let(pat, init)`
+      // (let-form) or a plain condition (regular `while`).
+      if let ExprKind::Let(let_expr) = guard.kind {
+        self.annotate_pat(let_expr.pat);
+        self.annotate_expr(let_expr.init);
+      } else {
+        self.annotate_expr(guard);
+      }
+      self.annotate_expr(then_body);
+    }
     return;
   }
   match expr.kind {
@@ -203,6 +225,14 @@ pub fn annotate_expr(& mut self, expr: &'tcx Expr) {
         Some(e) => self.annotate_expr(&e),
         None => {}
       }
+    }
+    // `if let pat = expr { … }` user-written. The Let node sits in
+    // the If's guard slot; its `pat` carries pattern bindings the
+    // user wrote (e.g. the `s` in `if let Some(s) = opt`) and `init`
+    // is the scrutinee.
+    ExprKind::Let(let_expr) => {
+      self.annotate_pat(let_expr.pat);
+      self.annotate_expr(let_expr.init);
     }
     ExprKind::Loop(block, _, _loop_ty, _span) => {
       for stmt in block.stmts.iter() {

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -292,6 +292,14 @@ impl ResourceAccessPoint {
         matches!(self, ResourceAccessPoint::Owner(Owner { is_closure: true, .. }))
     }
 
+    /// True iff this RAP is an owner of a Copy type (i32 etc.). The
+    /// "ownership" framing in tooltip text doesn't fit primitives —
+    /// they're values, not heap resources — so this lets the tooltip
+    /// dispatcher pick non-ownership wording where appropriate.
+    pub fn is_copy_owner(&self) -> bool {
+        matches!(self, ResourceAccessPoint::Owner(Owner { is_copy: true, .. }))
+    }
+
     /// True if this RAP is part of a struct grouping — either the
     /// struct itself or any of its fields (Struct fields and
     /// ref-typed fields modelled as MutRef/StaticRef with
@@ -1043,6 +1051,14 @@ impl Event {
                     // generic message because there's no captured
                     // upvar to name on the closure side yet.
                     safe_message(hover_messages::event_dot_closure_capture_acquire, &self.deref_name(my_name), from)
+                } else if matches!(from, ResourceTy::Anonymous)
+                    && matches!(is.extract_rap(), Some(rap) if rap.is_copy_owner()) {
+                    // i32 / bool / other primitive being assigned a
+                    // literal or arithmetic value (`let n = 5;` or
+                    // `n += 1;`). "Acquires ownership" is the wrong
+                    // mental model for Copy types — there's no heap
+                    // resource to own.
+                    safe_message(hover_messages::event_dot_acquire_copyable, &self.deref_name(my_name), from)
                 } else {
                     safe_message(hover_messages::event_dot_acquire, &self.deref_name(my_name), from)
                 }

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -244,9 +244,24 @@ pub fn event_dot_mut_return(my_name: &String, _target_name: &String) -> String {
 pub fn event_dot_acquire(my_name: &String, _target_name: &String) -> String {
     // update styling
     let my_name_fmt = fmt_style(my_name);
-    
+
     format!(
         "{0} acquires ownership of a resource",
+        my_name_fmt
+    )
+}
+
+// Same Acquire event shape, but the destination column holds a Copy
+// type (i32, bool, etc. — no heap, no ownership semantics) and the
+// source is Anonymous (a literal, an arithmetic expression, or a
+// macro-internal expansion). Avoids the misleading "ownership"
+// language for primitives. Used for both fresh `let n = 5;` bindings
+// and reassignments like `n += 1;`.
+pub fn event_dot_acquire_copyable(my_name: &String, _target_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+
+    format!(
+        "{0} is bound to a value",
         my_name_fmt
     )
 }
@@ -643,6 +658,19 @@ pub fn state_full_privilege(my_name: &String) -> String {
 
     format!(
         "{0} is the owner of the resource", //not necessarily write if let was used rather than let mut
+        my_name_fmt
+    )
+}
+
+// FullPrivilege but the owner is a Copy type (i32 etc.), so the
+// "owner of the resource" framing doesn't fit — primitives are
+// values, not heap-backed resources. Used for the timeline-stripe
+// tooltip and the vertical lifeline.
+pub fn state_full_privilege_copyable(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+
+    format!(
+        "{0} holds a value",
         my_name_fmt
     )
 }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -893,6 +893,15 @@ fn timeline_segment_title(
             return hover_messages::state_closure_full_privilege_no_resource(&name);
         }
     }
+    // Copy-typed owners (i32 etc.) — "the owner of the resource"
+    // language doesn't fit primitives; route to the value-flavoured
+    // wording so the lifeline tooltip stays consistent with the
+    // event-dot tooltip on the same column.
+    if rap.is_copy_owner() {
+        if let State::FullPrivilege { .. } = state {
+            return hover_messages::state_full_privilege_copyable(rap.name());
+        }
+    }
     state.print_message_with_name(rap.name())
 }
 

--- a/rustviz-plugin/tests/copy_owner_tooltip.rs
+++ b/rustviz-plugin/tests/copy_owner_tooltip.rs
@@ -1,0 +1,15 @@
+// Regression for: tooltips for Copy-typed owners (i32 etc.) used the
+// "ownership" framing ("n acquires ownership of a resource", "n is
+// the owner of the resource") even though primitives don't have
+// heap-resource semantics. The user spotted this on `n += 1` inside
+// a while loop. Now the dot tooltip reads "n is bound to a value"
+// and the lifeline tooltip reads "n holds a value".
+fn read(_n: i32) {}
+
+fn main() {
+    let mut n = 0;
+    while n < 3 {
+        read(n);
+        n += 1;
+    }
+}

--- a/rustviz-plugin/tests/while_let_pattern_annotation.rs
+++ b/rustviz-plugin/tests/while_let_pattern_annotation.rs
@@ -1,0 +1,13 @@
+// Regression for: pattern bindings inside `while let` / `if let`
+// guards weren't annotated in the code panel because the
+// surrounding desugared If carries `DesugaringKind::WhileLoop` /
+// CondTemporary and `annotate_expr` bailed on `from_expansion`
+// before reaching the user-written pat / scrutinee / body.
+fn consume(_s: String) {}
+
+fn main() {
+    let mut stack = vec![String::from("a"), String::from("b")];
+    while let Some(s) = stack.pop() {
+        consume(s);
+    }
+}


### PR DESCRIPTION
## Summary

Two small UX issues surfaced reviewing the new playground "Loops" examples.

### 1. `s` in `Some(s)` wasn't colored in the code panel

In `while let popping a stack`:

\`\`\`rust
while let Some(s) = stack.pop() {
    consume(s);
}
\`\`\`

Neither the pattern binding `s` nor the scrutinee `stack`/`pop` were `data-hash`-annotated, so hovering didn't highlight their columns. Root cause: rustc lowers `while let pat = expr { body }` to `loop { if let pat = expr { body } else { break } }` and marks the wrapping `If` with `DesugaringKind::WhileLoop`. `annotate_expr`'s blanket `from_expansion` early-return discarded the entire `If` — so user-written `pat`, `init`, and `body` never reached the walker.

**Fix**: when the from_expansion expr is an `If`, descend through it. Let-form guards are split into `(pat, init)` (annotate the pattern, recurse into the scrutinee). The else-arm is skipped since it's the synthetic `break`. Also added the missing `ExprKind::Let` arm so the non-from_expansion if-let / while-let path is consistent.

### 2. `n += 1` said "n acquires ownership of a resource"

In `while loop`:

\`\`\`rust
let mut n = 0;
while n < 3 {
    read(n);
    n += 1;
}
\`\`\`

The event-dot tooltip on `n += 1` read **"n acquires ownership of a resource"** and the lifeline tooltip read **"n is the owner of the resource"**. Both are misleading wording for a Copy primitive — there's no heap resource to own.

**Fix**: when an Acquire event lands on a Copy-typed owner from an Anonymous source (the shape of `let n = 5;`, `n += 1;`, and any Lit/Binary/Unary RHS), the dot tooltip now reads **"n is bound to a value"** and the FullPrivilege lifeline tooltip reads **"n holds a value"**. Non-Copy Anonymous binds (e.g. `let v = vec![…];`) keep the existing "acquires ownership" wording — `Vec` really is taking ownership.

Plumbing: new `ResourceAccessPoint::is_copy_owner()` helper on the existing `Owner { is_copy }` field; new `event_dot_acquire_copyable` and `state_full_privilege_copyable` hover messages; one branch in the Event::Acquire dispatch and one in `timeline_segment_title`.

## Test plan

- [x] Full corpus passes (110/110)
- [x] New fixtures: `tests/while_let_pattern_annotation.rs` (Issue 1) and `tests/copy_owner_tooltip.rs` (Issue 2)
- [x] Manual verification via the playground:
  - `while let popping a stack` → `Some(s)` and `stack.pop()` now color-highlight on hover
  - `while loop` → `n += 1` dot reads "n is bound to a value"; lifeline reads "n holds a value"
  - `while let popping a stack` (uses non-Copy String) still reads "s acquires ownership of a resource" — correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)