### PR TITLE
plugin: descend into assert! / if-cond scrutinee for call-site events

### DIFF
--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -21,19 +21,23 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
   /// `visit_expr`. Called from the `from_expansion` guard at the top
   /// of `visit_expr` (see comment there for why).
   ///
-  /// We only descend through "transparent container" shapes — Block,
-  /// Call, MethodCall, AddrOf, Unary, DropTemps, Array, Tup. These
-  /// are the wrappers the formatter macros (`println!`,
-  /// `format_args!`, etc.) build around their args and that always
-  /// just hold subexpressions verbatim, so reaching the user's
-  /// subexpression is a straight recursive walk. Synthetic
-  /// control-flow shapes (If / Match / Loop / Closure) are
-  /// deliberately *not* descended through: those are how
-  /// `assert!(cond)`, `?`, and similar macros desugar, and treating
-  /// the synthesized panic-arm or capture-closure body as user code
-  /// would surface spurious events. The existing
-  /// from_expansion-guarded handlers in those arms cover what's
-  /// actually needed (e.g. visit just the assert's guard).
+  /// Descended through:
+  /// - "transparent container" shapes (Block, Call, MethodCall,
+  ///   AddrOf, Unary, DropTemps, Array, Tup) — these are the wrappers
+  ///   `println!` / `format_args!` build around their args.
+  /// - the *condition* of synthetic If / Match — `assert!(cond)`
+  ///   lowers to a `match cond { true => {}, _ => panic!(…) }` whose
+  ///   scrutinee is the user's `cond`, including any function calls
+  ///   inside it. Without descending the scrutinee we'd miss the
+  ///   call-site PassByRef events for `assert!(f(&x))` shapes (the
+  ///   user-visible symptom: no `f` icon on the timeline at the
+  ///   assert line).
+  ///
+  /// Not descended through: arm bodies, loop bodies, closure bodies.
+  /// Those are where macro internals (the synthetic panic arm of
+  /// assert!, the closure of `?`'s ControlFlow continuation, etc.)
+  /// live, and surfacing their events would pollute the diagram with
+  /// branches the user didn't write.
   fn descend_through_expansion(&mut self, expr: &'tcx Expr<'tcx>) {
     if !expr.span.from_expansion() {
       // Re-enter normal dispatch — the user wrote this subexpression.
@@ -79,6 +83,23 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
         for i in items {
           self.descend_through_expansion(i);
         }
+      }
+      // `assert!(cond)` and `assert_eq!(...)` desugar to a `Match`
+      // whose scrutinee is the user-written cond and whose arms are
+      // synthesized panic / no-op branches. Descend into the
+      // scrutinee so calls like `compare_strings(r1, r2)` inside the
+      // assert get their normal Call-arm handling (PassByStaticRef
+      // events, function-dot icon on the timeline). Skip the arms —
+      // their bodies are synthetic panics we don't want to surface
+      // as user events.
+      ExprKind::Match(scrutinee, _, _) => {
+        self.descend_through_expansion(scrutinee);
+      }
+      // Symmetric for `if cond { … } else { … }` desugarings (older
+      // assert! shapes, `?`'s ControlFlow check, etc.). Walk the
+      // guard; skip the arms.
+      ExprKind::If(guard, _, _) => {
+        self.descend_through_expansion(guard);
       }
       _ => {}
     }

--- a/rustviz-plugin/tests/assert_call_dot.rs
+++ b/rustviz-plugin/tests/assert_call_dot.rs
@@ -1,0 +1,19 @@
+// Regression for: a function call inside `assert!(…)` didn't surface
+// its PassByStaticReference event, so the timeline showed the
+// borrow's lifetime ending but no `f` icon at the call site —
+// inconsistent with an equivalent free-fn call in the same example.
+//
+// `assert!(cond)` lowers to `match cond { true => {}, _ => panic!(…) }`.
+// `descend_through_expansion` skipped the whole Match (to avoid the
+// synthetic panic-arm), but that also dropped the user-written
+// scrutinee. Now it descends into the scrutinee while still skipping
+// the arms.
+fn pred(_a: &i32, _b: &i32) -> bool { true }
+
+fn main() {
+    let n = 1;
+    let m = 2;
+    let r1 = &n;
+    let r2 = &m;
+    assert!(pred(r1, r2));
+}


### PR DESCRIPTION
## Summary

In the playground "Hands-on tutorial" example, the call inside `assert!(compare_strings(r1, r2))` rendered the borrow lifetimes ending on the assert line but no \`f\` icon at the call site and no "compare_strings reads from r1 / r2" PassByStaticReference event. Inconsistent with the unwrapped \`clear_string(r3)\` right below it which renders both fine.

## Cause

\`assert!(cond)\` lowers to \`match cond { true => {}, _ => panic!(…) }\`. The user's \`compare_strings(r1, r2)\` lives in the scrutinee. \`descend_through_expansion\` (the helper added for #74 / #99 to fish call-site events out of \`println!\`'s expansion) intentionally skipped \`Match\` / \`If\` so the synthesized panic-arm body wouldn't pollute the user timeline with branches they didn't write — but that also discarded the user-written scrutinee. The Call arm of \`visit_expr\` therefore never ran on \`compare_strings\`.

## Fix

In \`descend_through_expansion\`, walk the \`Match\` scrutinee and the \`If\` guard. Still skip the arms / bodies / loop bodies / closures — those are where the synthetic panics live. So:

- \`assert!(f(&x))\` — descent walks the scrutinee \`f(&x)\` → user-spanned subtree → re-enter \`visit_expr\` → Call arm emits the PassByStaticReference event and the \`f\` icon. ✓
- \`assert!(cond)\` (no payload call) — descent walks \`cond\` (a Path on a user variable) → re-enter \`visit_expr\` → Path arm runs as before. ✓
- The synthetic \`true => {}, _ => panic!(…)\` arms — still skipped. ✓

## Test plan

- [x] Full corpus: same 2 pre-existing failures (\`basic_for3\`, \`returningOwnership\` — tuple destructuring not supported, on \`main\`); no new regressions
- [x] New \`tests/assert_call_dot.rs\` fixture exercises the assert-with-call shape
- [x] Playground "Hands-on tutorial" now renders the \`f\` icon for \`compare_strings\` on both r1 and r2 timelines