### PR TITLE
Join-state messaging at conditional merge points (fixes #87, #108)

### DIFF
--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -381,9 +381,20 @@ fn main() {
     examples: [
       {
         name: "if as let RHS",
+        // Branches written on their own lines on purpose. The
+        // timeline panel positions per-branch dots by source line,
+        // so the single-line form `if … { … } else { … }` collapses
+        // both branches onto one row and renders as a bowtie /
+        // X-shape rather than the intended pair of branches. Until
+        // the renderer grows synthetic offsets for same-line
+        // branches, the canonical examples stay multi-line.
         code: `fn main() {
     let n = 3;
-    let s = if n > 0 { String::from("a") } else { String::from("b") };
+    let s = if n > 0 {
+        String::from("a")
+    } else {
+        String::from("b")
+    };
     println!("{}", s);
 }`,
       },

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -377,6 +377,138 @@ fn main() {
     ],
   },
   {
+    chapter: 'Conditionals',
+    examples: [
+      {
+        name: "if as let RHS",
+        code: `fn main() {
+    let n = 3;
+    let s = if n > 0 { String::from("a") } else { String::from("b") };
+    println!("{}", s);
+}`,
+      },
+      {
+        name: "if without else",
+        code: `fn main() {
+    let s = String::from("hi");
+    if s.len() > 0 {
+        println!("non-empty: {}", s);
+    }
+    println!("{}", s);
+}`,
+      },
+      {
+        name: "if/else with disjoint variables",
+        code: `fn main() {
+    let cond = true;
+    let a = String::from("a");
+    let b = String::from("b");
+    if cond {
+        println!("{}", a);
+    } else {
+        println!("{}", b);
+    }
+}`,
+      },
+      {
+        name: "if/else: same var moved on one side",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true;
+    if cond {
+        consume(s);
+    } else {
+        println!("kept: {}", s);
+    }
+}`,
+      },
+      {
+        name: "match as let RHS",
+        code: `fn main() {
+    let n = 3;
+    let s = match n {
+        0 => String::from("zero"),
+        _ => String::from("other"),
+    };
+    println!("{}", s);
+}`,
+      },
+      {
+        name: "if let Some",
+        code: `fn main() {
+    let opt: Option<String> = Some(String::from("x"));
+    if let Some(x) = opt {
+        println!("got {}", x);
+    }
+}`,
+      },
+      {
+        name: "match with a borrow in one arm",
+        code: `fn main() {
+    let s = String::from("hello");
+    let n = 1;
+    match n {
+        0 => println!("zero"),
+        _ => println!("borrowed: {}", s),
+    }
+    println!("after: {}", s);
+}`,
+      },
+      {
+        name: "if/else: move on one side, borrow on other",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true;
+    if cond {
+        consume(s);
+    } else {
+        println!("borrow: {}", s);
+    }
+}`,
+      },
+      {
+        name: "rebind on both sides (\"bound here\" join)",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let mut s = String::from("orig");
+    let cond = true;
+    if cond {
+        consume(s);
+        s = String::from("new");
+    } else {
+        consume(s);
+        s = String::from("alt");
+    }
+    println!("{}", s);
+}`,
+      },
+      {
+        name: "nested if (move propagates outward)",
+        code: `fn consume(_s: String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let c1 = true;
+    let c2 = false;
+    if c1 {
+        if c2 {
+            consume(s);
+        } else {
+            println!("kept inner: {}", s);
+        }
+    } else {
+        consume(s);
+    }
+}`,
+      },
+    ],
+  },
+  {
     chapter: 'Loops',
     examples: [
       {

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -705,12 +705,19 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     },
     TooltipExpect {
         name: "if_no_else",
-        // Plain `if cond { body }` (no else). No "Else" branch label
-        // gets synthesized; only "If" appears.
-        must_contain: &["If"],
+        // Plain `if cond { body }` with `s` moved inside the body.
+        // The Branch is single-branch — only "If" appears, no
+        // synthesized "Else" — and the merge dot tooltip says `s`
+        // may have been moved (the implicit-untouched else means
+        // BoundHere can't fire).
+        must_contain: &[
+            "If",
+            "s may have been moved (consumed in at least one branch above)",
+        ],
         must_not_contain: &[
             "Else",
             "merge",
+            "is bound here from one of the branches above",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -101,6 +101,15 @@ const EXPECTED_OK: &[&str] = &[
     //   variant takes the same path against an array literal RHS.
     "tuple_destructure",
     "slice_destructure",
+    // — Conditionals (#87, #108): match-as-rhs renders move arrows
+    //   per arm; arm labels show source-form (`0`, `_`); merge dot
+    //   carries a join-state tooltip; nested conditionals propagate;
+    //   no-else `if` doesn't synthesize an "Else" label.
+    "match_as_let_rhs",
+    "if_else_move_join",
+    "if_else_rebind_join",
+    "nested_if_move_join",
+    "if_no_else",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -640,6 +649,69 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "get reads from r",
         ],
         must_not_contain: &[],
+    },
+
+    // ─── Conditionals (#87, #108) ────────────────────────────────────
+    TooltipExpect {
+        name: "match_as_let_rhs",
+        // `let s = match n { 0 => ..., _ => ... };`. Pre-fix: zero
+        // Move arrows (match_rhs had no Match arm), and arm labels
+        // came out as `Int(Pu128(0), Unsuffixed)` / `Wild`. We pin
+        // both the move-arrow recursion and the source-form arm
+        // labels here.
+        must_contain: &[
+            "Move from String::from to s",
+        ],
+        must_not_contain: &[
+            "Int(Pu128(0), Unsuffixed)",
+            "Bool(",
+            "Wild",
+        ],
+    },
+    TooltipExpect {
+        name: "if_else_move_join",
+        // Variable `s` consumed in if branch, only borrowed in else
+        // branch. Merge dot says `s` may have been moved (Rust treats
+        // it as moved regardless of which branch ran).
+        must_contain: &[
+            "Move from s to consume",
+            "s may have been moved (consumed in at least one branch above)",
+        ],
+        must_not_contain: &["merge"],
+    },
+    TooltipExpect {
+        name: "if_else_rebind_join",
+        // Both branches consume `s` and reassign it from a fresh
+        // String::from. After the conditional `s` owns a freshly-bound
+        // resource regardless of branch.
+        must_contain: &[
+            "s is bound here from one of the branches above",
+        ],
+        must_not_contain: &[
+            "merge",
+            "may have been moved",
+        ],
+    },
+    TooltipExpect {
+        name: "nested_if_move_join",
+        // Inner if: consume on one inner branch, borrow on the other
+        // → inner merge is "may have been moved". Outer if's else
+        // also consumes `s` → outer merge propagates the move.
+        // Two merge tooltips, both reading "may have been moved".
+        must_contain: &[
+            "s may have been moved (consumed in at least one branch above)",
+        ],
+        must_not_contain: &["merge"],
+    },
+    TooltipExpect {
+        name: "if_no_else",
+        // Plain `if cond { body }` (no else). No "Else" branch label
+        // gets synthesized; only "If" appears.
+        must_contain: &["If"],
+        must_not_contain: &[
+            "Else",
+            "merge",
+        ],
     },
 ];
 

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -685,7 +685,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // String::from. After the conditional `s` owns a freshly-bound
         // resource regardless of branch.
         must_contain: &[
-            "s is bound here from one of the branches above",
+            "s acquired ownership of a resource (in all branches above)",
         ],
         must_not_contain: &[
             "merge",
@@ -706,18 +706,18 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     TooltipExpect {
         name: "if_no_else",
         // Plain `if cond { body }` with `s` moved inside the body.
-        // The Branch is single-branch — only "If" appears, no
-        // synthesized "Else" — and the merge dot tooltip says `s`
-        // may have been moved (the implicit-untouched else means
-        // BoundHere can't fire).
+        // The merge dot says `s` may have been moved — the implicit-
+        // untouched else means BoundHere can't fire. No "If" / "Else"
+        // tooltips: those bookend dots got dropped because they were
+        // a teaching distraction (see render_dot's Branch arm).
         must_contain: &[
-            "If",
             "s may have been moved (consumed in at least one branch above)",
         ],
         must_not_contain: &[
+            "If",
             "Else",
             "merge",
-            "is bound here from one of the branches above",
+            "acquired ownership of a resource (in all branches above)",
         ],
     },
 ];

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -1049,14 +1049,26 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
         None => {}
       }
     },
-    // TODO: implement conditional let bindings:
-    // let x = if {} else {};
-    // let x = match z {};
+    // `let x = if cond { e1 } else { e2 };` — recurse into each
+    // branch's trailing expression so the move/copy/bind arrow lands
+    // on the LHS once per branch. The branches themselves rendered
+    // their inner side-effects when visit_expr walked them earlier;
+    // this arm is purely about pairing the branch result with `lhs`.
     ExprKind::If(_, if_block, else_block) => {
       self.match_rhs(lhs.clone(), &if_block, evt.clone());
       match else_block {
         Some(e) => self.match_rhs(lhs, &e, evt),
         None => {}
+      }
+    }
+    // `let x = match scrutinee { … };` — same shape as If above.
+    // Each arm's body becomes the value bound to `lhs` on the path
+    // through that arm. Pre-fix this fell through silently and a
+    // match-as-rhs binding got zero move/copy arrows, even though
+    // the equivalent if/else form rendered fine (issue #87).
+    ExprKind::Match(_, arms, _) => {
+      for arm in arms.iter() {
+        self.match_rhs(lhs.clone(), arm.body, evt.clone());
       }
     }
     ExprKind::DropTemps(exp) => {

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -874,9 +874,24 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       // returned early on `from_expansion`; (2) a desugaring whose
       // fn_expr is `QPath::LangItem` that hirid_to_var_name can't
       // name. Same rationale as the Path / Field arms in get_rap.
-      let from = hirid_to_var_name(fn_expr.hir_id, &self.tcx)
-        .and_then(|n| self.raps.get(&n).map(|rd| rd.rap.to_owned()))
-        .map_or(ResourceTy::Anonymous, ResourceTy::Value);
+      //
+      // When match_rhs runs *before* visit_expr has reached this
+      // call site (the let-as-rhs reordering for If/Match init in
+      // process_let_binding), the fn name has a resolvable identity
+      // but isn't in `self.raps` yet. Register it on the fly so the
+      // Move/Copy arrow has a labeled source instead of falling back
+      // to Anonymous.
+      let from = match hirid_to_var_name(fn_expr.hir_id, &self.tcx) {
+        Some(n) => {
+          if !self.raps.contains_key(&n) {
+            self.add_fn(n.clone());
+          }
+          self.raps.get(&n)
+            .map(|rd| ResourceTy::Value(rd.rap.to_owned()))
+            .unwrap_or(ResourceTy::Anonymous)
+        }
+        None => ResourceTy::Anonymous,
+      };
       self.add_ev(line_num, evt, lhs, from, false);
     },
     

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -2,7 +2,7 @@
 use std::{cmp::max, collections::{BTreeMap, HashMap, HashSet, VecDeque}, ops::Bound};
 use log::warn;
 use rustc_hir::Mutability;
-use crate::svg_generator::data::{ExternalEvent, ResourceAccessPoint, ResourceTy};
+use crate::svg_generator::data::{ExternalEvent, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy};
 use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_span::Span;
 use rustc_hir::{Expr, ExprKind, Path, def::Res, Pat, PatKind, QPath, HirId, StmtKind, Stmt, Block, UnOp};
@@ -493,6 +493,44 @@ pub fn get_live_of_expr(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapDat
       HashSet::new()
     }
   }
+}
+
+/// Walk a per-branch event list and accumulate the resource-owning
+/// variables it touches. Used to build a Branch event's `live_vars`
+/// from the events that actually landed inside the branches —
+/// rather than from `get_live_of_expr`, which over-includes variables
+/// only read by the conditional's guard expression and produces a
+/// branched (and visually noisy) timeline for them. Function RAPs
+/// are filtered out: they're call sites, not per-branch lifecycles.
+/// Nested Branch events propagate their inner live_vars upward —
+/// anything live in an inner branch is also live in the outer.
+pub fn collect_event_live_vars(
+    events: &[(usize, ExternalEvent)],
+    out: &mut HashSet<ResourceAccessPoint>,
+) {
+    for (_, ev) in events {
+        match ev {
+            ExternalEvent::Branch { live_vars, .. } => {
+                out.extend(live_vars.iter().cloned());
+            }
+            // Synthesized cleanup events (added after filtering) and
+            // param-init events don't introduce live vars on their
+            // own; the param case is handled at fn-entry, not in a
+            // conditional's liveness set.
+            ExternalEvent::GoOutOfScope { .. }
+            | ExternalEvent::InitRefParam { .. } => {}
+            _ => {
+                let (from, to) = ResourceAccessPoint_extract(ev);
+                for rty in [from, to] {
+                    if let ResourceTy::Value(rap) = rty {
+                        if !rap.is_fn() {
+                            out.insert(rap.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Used for filtering events from the main event container

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -176,19 +176,23 @@ pub fn get_name_of_pat(pat: &Pat, tcx: &TyCtxt) -> String {
     PatKind::Expr(rustc_hir::PatExpr { kind: rustc_hir::PatExprKind::Path(QPath::Resolved(_, p)), .. }) => {
       string_of_path(&p, tcx)
     }
-    // Literal-pattern arms like `true =>` / `0 =>` show up in
-    // macro-expanded code we have no source-text view of (chiefly
-    // `assert!(cond)`, which expands to a match with `true` and `_`
-    // arms). Render the literal's Debug form as the arm label rather
-    // than panicking; the value is used purely as a label, not for
-    // semantic analysis, so a "Bool(true)" / "Int(0, …)" label is
-    // sufficient. Avoids needing to import rustc_ast for a typed
-    // match on LitKind.
+    // Literal-pattern arms (`true =>`, `0 =>`). Prefer the source
+    // form via span_to_snippet so the user sees `0` / `true` instead
+    // of the debug-printed AST (`Int(Pu128(0), Unsuffixed)` /
+    // `Bool(true)`). Fall back to the debug print when the pattern
+    // came from macro expansion (no source-text view) — chiefly
+    // `assert!(cond)`, which lowers to `match cond { true => {}, _ =>
+    // panic!() }` with synthetic arms.
     PatKind::Expr(rustc_hir::PatExpr { kind: rustc_hir::PatExprKind::Lit { lit, .. }, .. }) => {
-      format!("{:?}", lit.node)
+      if pat.span.from_expansion() {
+        format!("{:?}", lit.node)
+      } else {
+        tcx.sess.source_map().span_to_snippet(pat.span)
+          .unwrap_or_else(|_| format!("{:?}", lit.node))
+      }
     }
     PatKind::Wild => {
-      String::from("Wild")
+      String::from("_")
     }
     PatKind::Tuple(pat_list, _) => {
       let mut res = String::from("(");
@@ -203,7 +207,16 @@ pub fn get_name_of_pat(pat: &Pat, tcx: &TyCtxt) -> String {
       }
       res
     }
-    _ => panic!("unexpected pat kind {:#?}", pat)
+    // Anything else — slice patterns, struct patterns, or-patterns,
+    // ranges, refs/box/deref, etc. We're rendering this purely as a
+    // human-readable arm label, so the source span is the right
+    // fallback. If span_to_snippet fails (synthetic spans on macro-
+    // expanded patterns we haven't classified above), drop a generic
+    // placeholder rather than panic.
+    _ => {
+      tcx.sess.source_map().span_to_snippet(pat.span)
+        .unwrap_or_else(|_| String::from("<pat>"))
+    }
   }
 }
 
@@ -221,6 +234,60 @@ pub fn num_derefs(expr: &Expr) -> usize{
 // LIVENESS + DECLARATION FUNCTIONS
 // Functions used for getting variables that are live inside of blocks
 // As well as variables that are declared inside of blocks
+
+/// Walk every `PatKind::Binding` reachable inside `pat` and accumulate
+/// the corresponding RAPs into `out`. Mirror of `bind_walk` in
+/// visitor.rs — used by `get_decl_of_stmt` so that destructuring let
+/// patterns inside a conditional body register every binding they
+/// introduce, not just simple `let x = …;` shapes. Skips bindings
+/// that haven't been registered yet (e.g. names skipped by
+/// `visit_local`'s from_expansion guard).
+fn collect_pat_bindings(
+  pat: &Pat,
+  raps: &HashMap<String, RapData>,
+  out: &mut HashSet<ResourceAccessPoint>,
+) {
+  match pat.kind {
+    PatKind::Binding(_, _, ident, sub_pat) => {
+      if let Some(rd) = raps.get(&ident.to_string()) {
+        out.insert(rd.rap.to_owned());
+      }
+      if let Some(sp) = sub_pat {
+        collect_pat_bindings(sp, raps, out);
+      }
+    }
+    PatKind::Tuple(pats, _) | PatKind::TupleStruct(_, pats, _) => {
+      for p in pats { collect_pat_bindings(p, raps, out); }
+    }
+    PatKind::Struct(_, fields, _) => {
+      for f in fields { collect_pat_bindings(f.pat, raps, out); }
+    }
+    PatKind::Or(pats) => {
+      // Or-pattern alts bind the same names; walking one alt is enough.
+      if let Some(first) = pats.first() {
+        collect_pat_bindings(first, raps, out);
+      }
+    }
+    PatKind::Ref(inner, _)
+    | PatKind::Box(inner)
+    | PatKind::Deref(inner)
+    | PatKind::Guard(inner, _) => {
+      collect_pat_bindings(inner, raps, out);
+    }
+    PatKind::Slice(before, mid, after) => {
+      for p in before { collect_pat_bindings(p, raps, out); }
+      if let Some(p) = mid { collect_pat_bindings(p, raps, out); }
+      for p in after { collect_pat_bindings(p, raps, out); }
+    }
+    // No bindings inside these.
+    PatKind::Wild
+    | PatKind::Never
+    | PatKind::Missing
+    | PatKind::Err(_)
+    | PatKind::Expr(_)
+    | PatKind::Range(..) => {}
+  }
+}
 
 pub fn get_decl_of_block(block: &Block, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> HashSet<ResourceAccessPoint>{
   let mut res:HashSet<ResourceAccessPoint> = HashSet::new();
@@ -246,13 +313,7 @@ pub fn get_decl_of_stmt(stmt: &Stmt, _tcx: &TyCtxt, raps: &HashMap<String, RapDa
   if stmt.span.from_expansion() { return res; }
   match stmt.kind {
     StmtKind::Let(ref local) => {
-      let name = match local.pat.kind {
-        PatKind::Binding(_, _, ident, _) => {
-          ident.to_string()
-        }
-        _ => panic!("unexpected let binding pattern")
-      };
-      res.insert(raps.get(&name).unwrap().rap.to_owned());
+      collect_pat_bindings(&local.pat, raps, &mut res);
     }
     _ => {}
   }

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1462,12 +1462,6 @@ impl Visualizable for VisualizationData {
     branch_start: usize,
     branch_end: usize,
     mut previous_state: State) -> State{
-        // an empty branch - rendered as the same as previous state
-        if history.is_empty() {
-            states.push((branch_start, branch_end, branch_state_converter(&previous_state)));
-            return previous_state;
-        }
-
         // Clamp valid_range to [branch_start, branch_end]. With the
         // convergence-one-line-earlier work, callers now pass
         // branch_end = merge_point - 1 so the branch column ends
@@ -1478,6 +1472,29 @@ impl Visualizable for VisualizationData {
         let (begin, end) = valid_range;
         let begin = begin.clamp(branch_start, branch_end);
         let end = end.clamp(branch_start, branch_end);
+
+        // Empty branches still render: dashed leading segment from
+        // branch_start to begin (the OTHER branch's territory),
+        // solid segment from begin to end (this branch's body
+        // span — even with no per-line events the body range is
+        // active here, so we want it solid), and a dashed trailing
+        // segment from end to branch_end if any. Pre-fix, an empty
+        // branch dropped to a single Gray segment over the entire
+        // column, which made e.g. `else { println!(...) }` look
+        // entirely dashed even though else is the active path on
+        // its own body lines.
+        if history.is_empty() {
+            if begin > branch_start {
+                states.push((branch_start, begin, branch_state_converter(&previous_state)));
+            }
+            if begin < end {
+                states.push((begin, end, previous_state.clone()));
+            }
+            if end < branch_end {
+                states.push((end, branch_end, branch_state_converter(&previous_state)));
+            }
+            return previous_state;
+        }
 
         // Render opaque line if branch does not begin at split point
         if begin != branch_start {

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1443,10 +1443,10 @@ impl Visualizable for VisualizationData {
         }
     }
 
-    fn compute_branch_states(&self, 
-    history: & mut Vec<(usize, Event)>, 
-    states: & mut Vec<(usize, usize, State)>, 
-    hash: &u64, 
+    fn compute_branch_states(&self,
+    history: & mut Vec<(usize, Event)>,
+    states: & mut Vec<(usize, usize, State)>,
+    hash: &u64,
     valid_range: (usize, usize),
     branch_start: usize,
     branch_end: usize,
@@ -1457,7 +1457,17 @@ impl Visualizable for VisualizationData {
             return previous_state;
         }
 
+        // Clamp valid_range to [branch_start, branch_end]. With the
+        // convergence-one-line-earlier work, callers now pass
+        // branch_end = merge_point - 1 so the branch column ends
+        // where the convergence diagonal starts. The body span used
+        // to derive valid_range still reaches `merge_point` (the
+        // closing brace), which would push reversed-range states
+        // (e.g. (7, 6, Gray)) without this clamp.
         let (begin, end) = valid_range;
+        let begin = begin.clamp(branch_start, branch_end);
+        let end = end.clamp(branch_start, branch_end);
+
         // Render opaque line if branch does not begin at split point
         if begin != branch_start {
             states.push((branch_start, begin, branch_state_converter(&previous_state)));
@@ -1473,12 +1483,17 @@ impl Visualizable for VisualizationData {
                     let mut ending_states: Vec<State> = Vec::new();
                     for (i, branch) in branch_history.iter_mut().enumerate() {
                         ending_states.push(self.compute_branch_states(
-                            & mut branch.e_data, 
-                            & mut branch.states, 
-                            hash, 
-                            ty.get_start_end(i), 
+                            & mut branch.e_data,
+                            & mut branch.states,
+                            hash,
+                            ty.get_start_end(i),
                             *split_point + 1,
-                            *merge_point,
+                            // Branch column ends one line above the
+                            // join dot — the convergence diagonal
+                            // bridges that last row. saturating_sub
+                            // guards against the (in practice
+                            // unreachable) merge_point = 0 case.
+                            merge_point.saturating_sub(1),
                             previous_state.clone()));
                     }
 
@@ -1517,12 +1532,17 @@ impl Visualizable for VisualizationData {
                     let mut ending_states: Vec<State> = Vec::new();
                     for (i, branch) in branch_history.iter_mut().enumerate() {
                         ending_states.push(self.compute_branch_states(
-                            & mut branch.e_data, 
-                            & mut branch.states, 
-                            hash, 
-                            ty.get_start_end(i), 
+                            & mut branch.e_data,
+                            & mut branch.states,
+                            hash,
+                            ty.get_start_end(i),
                             *split_point + 1,
-                            *merge_point,
+                            // Branch column ends one line above the
+                            // join dot — the convergence diagonal
+                            // bridges that last row. saturating_sub
+                            // guards against the (in practice
+                            // unreachable) merge_point = 0 case.
+                            merge_point.saturating_sub(1),
                             previous_state.clone()));
                     }
 

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -855,11 +855,22 @@ impl PartialEq for State {
 impl Eq for State {}
 
 
+/// Convert a state to its "passive" branch flavour — what the
+/// rendering layer turns into a dashed, half-opacity vertical so
+/// readers can tell which arm is the active one on a given row.
+///
+/// `OutOfScope` is converted to `FullPrivilege { Gray }` instead of
+/// staying `OutOfScope` so let-as-rhs bindings (where the variable
+/// doesn't exist before the conditional) still get a visible
+/// passive column on their inactive branch — without this, the
+/// pre-event segment of every let-as-rhs branch rendered as
+/// nothing at all.
 pub fn branch_state_converter(s: &State) -> State {
     match s {
         State::FullPrivilege { .. } => State::FullPrivilege { s: LineState::Gray },
         State::PartialPrivilege { .. } => State::PartialPrivilege { s: LineState::Gray },
-        _ => s.clone() 
+        State::OutOfScope => State::FullPrivilege { s: LineState::Gray },
+        _ => s.clone()
     }
 }
 
@@ -1499,7 +1510,12 @@ impl Visualizable for VisualizationData {
 
                     ending_states.sort(); // partial order of the ending states
                     previous_state = convert_back(&ending_states.first().unwrap());
-                    previous_line = *merge_point + 1; // timeline starts one line after the curly brace
+                    // Resume the parent timeline at `merge_point`,
+                    // not `merge_point + 1`. The join dot sits at
+                    // `merge_point` (see render_dot's Branch arm);
+                    // resuming a row later leaves a visible gap
+                    // between the join and the post-merge state.
+                    previous_line = *merge_point;
                 }
                 _ => {
                     previous_state = self.calc_state(&previous_state, e, *l, hash);
@@ -1548,7 +1564,12 @@ impl Visualizable for VisualizationData {
 
                     ending_states.sort(); // partial order of the ending states
                     previous_state = convert_back(&ending_states.first().unwrap());
-                    previous_line = *merge_point + 1; // timeline starts one line after the curly brace
+                    // Resume the parent timeline at `merge_point`,
+                    // not `merge_point + 1`. The join dot sits at
+                    // `merge_point` (see render_dot's Branch arm);
+                    // resuming a row later leaves a visible gap
+                    // between the join and the post-merge state.
+                    previous_line = *merge_point;
 
                 }
                 _ => {

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -730,9 +730,43 @@ pub fn state_invalid(my_name: &String) -> String {
 pub fn structure(my_name: &String) -> String {
     // update styling
     let my_name_fmt = fmt_style(my_name);
-    
+
     format!(
         "the components in the box belong to struct {0}",
+        my_name_fmt
+    )
+}
+
+// ── Conditional join-point messages ────────────────────────────────
+//
+// Tooltip on the per-variable merge dot at the bottom of an `if` /
+// `match` / `if let`. Says what happened to the variable across the
+// branches, so the reader doesn't have to scan each branch's history
+// to figure out whether the resource is still owned. Wording follows
+// Rust's actual rule: "moved in any branch above" → unusable here,
+// no matter how many branches actually moved it. Resource ownership
+// at the join is binary (owned vs. not), and the messaging tracks
+// that, not the raw count.
+
+/// Variable was moved (consumed without being rebound) in at least
+/// one branch above. After the conditional Rust treats it as
+/// possibly-moved → can't be used.
+pub fn event_dot_branch_merge_moved(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!(
+        "{0} may have been moved (consumed in at least one branch above)",
+        my_name_fmt
+    )
+}
+
+/// Every branch above contributed a value that ends up in this
+/// variable (the `let s = if … { … } else { … };` shape, plus the
+/// match-as-rhs analog). After the conditional the variable owns a
+/// freshly bound resource regardless of which branch ran.
+pub fn event_dot_branch_merge_bound(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!(
+        "{0} is bound here from one of the branches above",
         my_name_fmt
     )
 }

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -766,7 +766,7 @@ pub fn event_dot_branch_merge_moved(my_name: &String) -> String {
 pub fn event_dot_branch_merge_bound(my_name: &String) -> String {
     let my_name_fmt = fmt_style(my_name);
     format!(
-        "{0} is bound here from one of the branches above",
+        "{0} acquired ownership of a resource (in all branches above)",
         my_name_fmt
     )
 }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/templates.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/templates.rs
@@ -192,6 +192,15 @@ pub static CSS_TEMPLATE: &'static str =
     .tooltip-trigger:hover{
         filter: url(#glow);
     }
+
+    /* When the cursor is anywhere inside a branch column,
+       glow every element grouped under .branch-group.
+       Single-element hover otherwise only highlighted one of
+       the two parallel sides at a time, with no feedback on
+       the transparent gap between them. */
+    .branch-group:hover .tooltip-trigger {
+        filter: url(#glow);
+    }
     
     /* hash based styling */
     [data-hash=\"0\"] {

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1880,6 +1880,201 @@ fn append_line(
     }
 }
 
+// Style classifier for branch column segments: returns Some(true)
+// for "dashed" (Gray) states, Some(false) for "solid" (Full) states,
+// and None for states that render as nothing (OOS, ResourceMoved,
+// etc.). Used to slice a branch's `states` into per-style runs that
+// each become one polyline.
+fn segment_style(state: &State) -> Option<bool> {
+    match state {
+        State::FullPrivilege { s: LineState::Gray }
+        | State::PartialPrivilege { s: LineState::Gray } => Some(true),
+        State::FullPrivilege { s: LineState::Full }
+        | State::PartialPrivilege { s: LineState::Full } => Some(false),
+        _ => None,
+    }
+}
+
+/// Render every branch (and any nested branches) reachable through
+/// `history`. Each branch's column-plus-convergence is emitted as
+/// `<polyline>` elements: one per side of the strip, broken at
+/// style boundaries (solid ↔ dashed). Adjacent polylines share
+/// endpoints exactly so a dashed leading edge meets the column's
+/// dashed leading run with no gap, the column's solid body meets
+/// the trailing solid wedge with no gap, etc.
+///
+/// Replaces the previous "split_line + body + merge_line" trio of
+/// independently-rendered strip elements, where the strip-via-
+/// perpendicular orientation of the diagonals didn't line up with
+/// the column's horizontal-perpendicular sides at the corners.
+fn render_branches(
+    hash: &u64,
+    rap: &ResourceAccessPoint,
+    history: &Vec<(usize, Event)>,
+    parent_states: &Vec<(usize, usize, State)>,
+    output: &mut BTreeMap<i64, (TimelinePanelData, TimelinePanelData)>,
+    visualization_data: &VisualizationData,
+    timeline_data: &TimelineColumnData,
+) {
+    if rap.is_fn() { return; }
+    for (_, ev) in history {
+        if let Event::Branch { branch_history, split_point, merge_point, .. } = ev {
+            // Find the parent state segment that *covers* the
+            // split point. Range-containment (rather than exact
+            // end-line match) handles the let-as-rhs case where
+            // the parent's pre-branch and during-branch OOS
+            // segments get merged by clean_states.
+            let begin_state = parent_states.iter()
+                .find(|item| item.0 <= *split_point && *split_point <= item.1)
+                .cloned()
+                .unwrap_or((0, 0, State::OutOfScope));
+            // Let-as-rhs (variable doesn't exist before the
+            // conditional, parent state is OOS): synthesize a
+            // FullPrivilege::Full leading state so the active
+            // arm's leading diagonal has something to render. The
+            // passive-arm dasharray override below handles the
+            // alternates.
+            let p_state = match begin_state.2 {
+                State::OutOfScope => State::FullPrivilege { s: LineState::Full },
+                ref s => convert_back(s),
+            };
+            let p_title = timeline_segment_title(&p_state, rap, visualization_data);
+
+            // Half the hollow column's strip width — matches
+            // `compute_hollow_line_data`'s w=3.5 / 2 on a vertical
+            // line, so the polyline endpoints share coordinates
+            // with the column body's two parallel `<line>`s.
+            let half_w: f64 = 1.75;
+            let parent_x = timeline_data.x_val as f64;
+
+            for (i, branch) in branch_history.iter().enumerate() {
+                let branch_x = branch.t_data.x_val as f64;
+                let e_state = branch.states.last().map(|s| s.2.clone()).unwrap_or(State::OutOfScope);
+                let e_title = timeline_segment_title(&e_state, rap, visualization_data);
+
+                // Leading edge style: passive arms (i != 0) and
+                // empty branches dash; the leading active arm
+                // renders solid.
+                let leading_dashed = branch.e_data.is_empty() || i != 0;
+                // Trailing edge style: tracks the branch's
+                // ending state (Gray → dashed, anything else →
+                // solid). Lets `else { println!(s) }` (active arm
+                // with no surfaced events but Owner end-state)
+                // converge solid into the join dot.
+                let trailing_dashed = matches!(
+                    e_state,
+                    State::FullPrivilege { s: LineState::Gray }
+                    | State::PartialPrivilege { s: LineState::Gray }
+                );
+
+                // Body groups: contiguous-style runs of state
+                // segments. Zero-length and unrenderable states
+                // (OOS, ResourceMoved, ...) drop out so the
+                // surrounding polylines connect through the gap.
+                let mut groups: Vec<(bool, usize, usize, String)> = Vec::new();
+                for seg in &branch.states {
+                    if seg.0 == seg.1 { continue; }
+                    if let Some(dashed) = segment_style(&seg.2) {
+                        let title = timeline_segment_title(&seg.2, rap, visualization_data);
+                        if let Some(last) = groups.last_mut() {
+                            if last.0 == dashed && last.2 == seg.0 {
+                                last.2 = seg.1;
+                                continue;
+                            }
+                        }
+                        groups.push((dashed, seg.0, seg.1, title));
+                    }
+                }
+
+                // For each side of the strip emit polylines:
+                // walk pieces (leading | body groups | trailing)
+                // in source order and merge consecutive same-
+                // style pieces into single `<polyline>`s. Where
+                // styles change, two abutting polylines share a
+                // common endpoint and meet seamlessly.
+                for offset in [-half_w, half_w] {
+                    let mut pieces: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
+
+                    pieces.push((
+                        leading_dashed,
+                        vec![
+                            (parent_x, get_y_axis_pos(*split_point) as f64),
+                            (branch_x + offset, get_y_axis_pos(*split_point + 1) as f64),
+                        ],
+                        p_title.clone(),
+                    ));
+
+                    for (dashed, top, bot, title) in &groups {
+                        pieces.push((
+                            *dashed,
+                            vec![
+                                (branch_x + offset, get_y_axis_pos(*top) as f64),
+                                (branch_x + offset, get_y_axis_pos(*bot) as f64),
+                            ],
+                            title.clone(),
+                        ));
+                    }
+
+                    pieces.push((
+                        trailing_dashed,
+                        vec![
+                            (branch_x + offset, get_y_axis_pos(merge_point.saturating_sub(1)) as f64),
+                            (parent_x, get_y_axis_pos(*merge_point) as f64),
+                        ],
+                        e_title.clone(),
+                    ));
+
+                    let mut polylines: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
+                    for (dashed, pts, title) in pieces {
+                        let merged = polylines.last().map(|l| l.0 == dashed).unwrap_or(false);
+                        if merged {
+                            let last = polylines.last_mut().unwrap();
+                            for (i, p) in pts.into_iter().enumerate() {
+                                if i == 0 && last.1.last() == Some(&p) {
+                                    continue;
+                                }
+                                last.1.push(p);
+                            }
+                        } else {
+                            polylines.push((dashed, pts, title));
+                        }
+                    }
+
+                    for (dashed, pts, title) in polylines {
+                        let pts_str = pts.iter()
+                            .map(|p| format!("{},{}", p.0, p.1))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let dasharray = if dashed { "4 4" } else { "none" };
+                        let svg = format!(
+                            "        <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
+                            hash, pts_str, title, dasharray,
+                        );
+                        output.entry(-1).or_insert_with(|| (
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                        )).0.timelines.push_str(&svg);
+                    }
+                }
+
+                // Recurse for any branches nested inside this
+                // branch's body. The nested call uses this
+                // branch's own state list as `parent_states` so
+                // its begin_state lookup hits the right segment.
+                render_branches(
+                    hash,
+                    rap,
+                    &branch.e_data,
+                    &branch.states,
+                    output,
+                    visualization_data,
+                    &branch.t_data,
+                );
+            }
+        }
+    }
+}
+
 // render timeline given a hash
 fn render_timeline(
     hash: &u64,
@@ -1892,117 +2087,13 @@ fn render_timeline(
     registry: &Handlebars
 ) {
     if rap.is_fn() { return; } // functions have no timelines
-    for (_, ev) in history {
-        match ev {
-            Event::Branch { branch_history, split_point, merge_point, ..} => {
-                // Find the state segment that *covers* the split point.
-                // Looking for `.1 == split_point` was a foothold from
-                // the days before let-as-rhs could put a Branch in
-                // live_vars: when the LHS variable doesn't exist
-                // before the conditional, the pre-branch state and
-                // the during-branch placeholder are both OutOfScope
-                // and clean_states merges them, so the boundary at
-                // split_point disappears. Range-containment finds the
-                // right segment in either case.
-                let begin_state = states.iter()
-                    .find(|item| item.0 <= *split_point && *split_point <= item.1)
-                    .unwrap_or_else(|| panic!("no state segment covers split_point {}", split_point))
-                    .clone();
-                // For let-as-rhs bindings the parent state is
-                // OutOfScope before the conditional — the variable
-                // doesn't exist yet. `create_owner_line_string`
-                // returns "" for OutOfScope, so the leading split
-                // diagonals from the fork dot down to each branch
-                // column would silently vanish, leaving the fork dot
-                // floating above disconnected branches. Treat the
-                // OOS-prior case as if the variable were
-                // FullPrivilege::Full at the split: the *active*
-                // branch's diagonal renders as the regular owner
-                // line (solid for mut, hollow for immut), and the
-                // passive-branch dasharray below dashes the rest.
-                let p_state = match begin_state.2 {
-                    State::OutOfScope => State::FullPrivilege { s: LineState::Full },
-                    ref s => convert_back(s),
-                };
-                for (i, branch) in branch_history.iter().enumerate() {
-                    let mut split_line_data = VerticalLineData {
-                        line_class: String::new(),
-                        hash: *hash,
-                        x1: timeline_data.x_val as f64,
-                        y1: get_y_axis_pos(*split_point),
-                        x2: branch.t_data.x_val as f64,
-                        y2: get_y_axis_pos(*split_point + 1),
-                        title: timeline_segment_title(&p_state, rap, visualization_data),
-                        opacity: 1.0,
-                        dasharray: "none".to_owned(),
-                    };
-
-                    // The first branch (i = 0, conventionally the
-                    // if-arm or the first match-arm) renders solid
-                    // — it's the "leading" path the user reads
-                    // first. Subsequent branches dash + fade their
-                    // leading split diagonal so it's clear they're
-                    // the alternate paths. Empty branches always
-                    // dash + fade. Pre-set dasharray here so a
-                    // non-Gray state (the OOS-promoted Full case
-                    // above, or a real pre-existing FullPrivilege)
-                    // still renders dashed for passive arms;
-                    // create_owner_line_string only sets dasharray
-                    // for Gray and won't otherwise.
-                    if branch.e_data.is_empty() || i != 0 {
-                        split_line_data.dasharray = "4 4".to_owned();
-                    }
-                    append_line(&p_state, &mut split_line_data, rap, timeline_data, output, registry);
-
-                    // get ending state
-                    let e_state = branch.states.last().unwrap().2.clone();
-
-                    render_timeline(hash,
-                        rap,
-                        &branch.e_data,
-                        &branch.states,
-                        output,
-                        visualization_data,
-                        &branch.t_data,
-                        registry);
-
-                    // Render the convergence diagonal so the join
-                    // dot at parent_x@merge_point is the meeting
-                    // point of every branch column. The diagonal
-                    // starts at branch_x@(merge_point - 1) — one
-                    // line above the join, where the branch column
-                    // has been trimmed to (see compute_branch_states
-                    // in data.rs) — and ends at parent_x@merge_point.
-                    // Previously y1 was at merge_point + 1, putting
-                    // the convergence one row past the join dot.
-                    let mut merge_line_data = VerticalLineData {
-                        line_class: String::new(),
-                        hash: *hash,
-                        x1: timeline_data.x_val as f64,
-                        y1: get_y_axis_pos(*merge_point),
-                        x2: branch.t_data.x_val as f64,
-                        y2: get_y_axis_pos(merge_point.saturating_sub(1)),
-                        title: timeline_segment_title(&e_state, rap, visualization_data),
-                        opacity: 1.0,
-                        dasharray: "none".to_owned(),
-                    };
-
-                    // Solid vs dashed for the convergence diagonal
-                    // is decided downstream by `create_owner_line_string`
-                    // / `create_reference_line_string` from `e_state`.
-                    // We don't force dashed for empty `e_data` — with
-                    // the body-span treatment of empty branches,
-                    // `e_state` is the active state at merge-1 and
-                    // already says "solid" when this branch is the
-                    // active path at the join (e.g. `else { println!(s) }`
-                    // — no events on s but else IS the active arm).
-
-                    append_line(&e_state, &mut merge_line_data, rap, timeline_data, output, registry);
-                }
-            }
-            _ => {}
-        }
-    }
+    // Branch columns + convergences render as polylines via
+    // `render_branches`; the per-state loop below only emits
+    // column lines for the parent timeline outside the branch
+    // ranges (clean_states leaves an OOS placeholder over the
+    // branch's split..merge span, so those rows naturally render
+    // as nothing).
+    render_branches(hash, rap, history, states, output, visualization_data, timeline_data);
 
     for (line_start, line_end, state) in states {
         // println!("{} -> start: {}, end: {}, state: {}", visualization_data.get_name_from_hash(hash).unwrap(), line_start, line_end, state); // DEBUG PURPOSES

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1880,11 +1880,43 @@ fn append_line(
     }
 }
 
-// Style classifier for branch column segments: returns Some(true)
-// for "dashed" (Gray) states, Some(false) for "solid" (Full) states,
-// and None for states that render as nothing (OOS, ResourceMoved,
-// etc.). Used to slice a branch's `states` into per-style runs that
-// each become one polyline.
+// ── Branch column rendering: invariants ────────────────────────────
+//
+// A branch's column-plus-convergences is rendered from three
+// pieces of the variable's lifecycle within the branch:
+//
+//   • A leading convergence diagonal (parent split dot → top of
+//     column) — emitted iff the variable is "alive" entering the
+//     branch (i.e., owns or borrows a resource — not in OOS or
+//     ResourceMoved).
+//   • A column body, sliced into per-style runs (solid for
+//     active-arm states, dashed for Gray-converted passive-arm
+//     states). Unrenderable states (OOS, ResourceMoved) drop out
+//     of the body — the column visually ends where the variable
+//     stops owning a resource.
+//   • A trailing convergence diagonal (column bottom → parent
+//     merge dot) — emitted iff the variable is "alive" leaving
+//     the branch.
+//
+// The classifiers below name these decisions explicitly so the
+// renderer can never silently bridge across an empty body. The
+// previous regression was exactly that: leading and trailing
+// pieces both rendered solid, and `merge consecutive same-style
+// pieces` collapsed them into a single polyline that "stitched
+// over" a Move event. Naming the rule (`alive_at_end`) and
+// gating the trailing piece on it pulls that invariant into one
+// place where it can be tested and maintained.
+
+/// Classifier for branch column body segments. Returns:
+///   • `Some(true)`  for a dashed segment (Gray-converted, the
+///     branch is the inactive path on this row).
+///   • `Some(false)` for a solid segment (FullPrivilege /
+///     PartialPrivilege at LineState::Full — the active path).
+///   • `None` for states that don't draw a column line
+///     (OutOfScope, ResourceMoved). Their absence in the body
+///     run terminates the column visually so the variable's
+///     "departure" (Move, scope end) is reflected in the column
+///     ending, not in a stray faded line.
 fn segment_style(state: &State) -> Option<bool> {
     match state {
         State::FullPrivilege { s: LineState::Gray }
@@ -1893,6 +1925,18 @@ fn segment_style(state: &State) -> Option<bool> {
         | State::PartialPrivilege { s: LineState::Full } => Some(false),
         _ => None,
     }
+}
+
+/// Whether the variable owns / can-borrow a resource at this
+/// state. The convergence diagonals only render when the variable
+/// is alive at the corresponding branch boundary — drawing them
+/// otherwise would bridge a terminated column to the join dot
+/// across rows that should be empty.
+fn state_is_alive(state: &State) -> bool {
+    !matches!(
+        state,
+        State::ResourceMoved { .. } | State::OutOfScope
+    )
 }
 
 /// Render every branch (and any nested branches) reachable through
@@ -1986,6 +2030,18 @@ fn render_branches(
                     }
                 }
 
+                // Lifecycle invariants — see the architectural
+                // note above this fn. Render the leading edge only
+                // when the variable is alive entering the branch;
+                // render the trailing edge only when alive leaving
+                // the branch. Without these gates a Move at the
+                // top of the body and a still-solid trailing
+                // convergence would form a polyline that bridged
+                // over the Move, putting a stray column line on a
+                // row the variable doesn't exist on.
+                let alive_at_start = state_is_alive(&begin_state.2);
+                let alive_at_end = state_is_alive(&e_state);
+
                 // For each side of the strip emit polylines:
                 // walk pieces (leading | body groups | trailing)
                 // in source order and merge consecutive same-
@@ -1995,14 +2051,16 @@ fn render_branches(
                 for offset in [-half_w, half_w] {
                     let mut pieces: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
 
-                    pieces.push((
-                        leading_dashed,
-                        vec![
-                            (parent_x, get_y_axis_pos(*split_point) as f64),
-                            (branch_x + offset, get_y_axis_pos(*split_point + 1) as f64),
-                        ],
-                        p_title.clone(),
-                    ));
+                    if alive_at_start {
+                        pieces.push((
+                            leading_dashed,
+                            vec![
+                                (parent_x, get_y_axis_pos(*split_point) as f64),
+                                (branch_x + offset, get_y_axis_pos(*split_point + 1) as f64),
+                            ],
+                            p_title.clone(),
+                        ));
+                    }
 
                     for (dashed, top, bot, title) in &groups {
                         pieces.push((
@@ -2015,14 +2073,16 @@ fn render_branches(
                         ));
                     }
 
-                    pieces.push((
-                        trailing_dashed,
-                        vec![
-                            (branch_x + offset, get_y_axis_pos(merge_point.saturating_sub(1)) as f64),
-                            (parent_x, get_y_axis_pos(*merge_point) as f64),
-                        ],
-                        e_title.clone(),
-                    ));
+                    if alive_at_end {
+                        pieces.push((
+                            trailing_dashed,
+                            vec![
+                                (branch_x + offset, get_y_axis_pos(merge_point.saturating_sub(1)) as f64),
+                                (parent_x, get_y_axis_pos(*merge_point) as f64),
+                            ],
+                            e_title.clone(),
+                        ));
+                    }
 
                     let mut polylines: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
                     for (dashed, pts, title) in pieces {

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1,5 +1,5 @@
 extern crate handlebars;
-use crate::svg_generator::data::{convert_back, string_of_branch, string_of_external_event, BranchData, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
+use crate::svg_generator::data::{convert_back, string_of_external_event, BranchData, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
 use crate::svg_generator::hover_messages;
 use crate::svg_generator::svg_frontend::line_styles::OwnerLine;
 use handlebars::Handlebars;
@@ -636,8 +636,12 @@ fn render_dot(
             Event::RefDie { .. } => {
                 continue;
             }
-            Event::Branch { is, branch_history, ty, split_point, merge_point, .. } => {
-                // first append split dot
+            Event::Branch { is, branch_history, ty, merge_point, .. } => {
+                // Top-of-branch dot on the parent column. Tooltip
+                // explains the variable's role ("X is live in a
+                // conditional expression"). Anchors the parent
+                // column visually at the line where the conditional
+                // begins.
                 let b_data = EventDotData {
                     hash: *hash as u64,
                     dot_x: timeline_data.x_val,
@@ -646,38 +650,30 @@ fn render_dot(
                 };
                 append_dot(&b_data, output, timeline_data, registry);
 
-                // render dots for each of the branches
-                for (i, branch) in branch_history.iter().enumerate() {
-                    // render a dot at the beginning of the timeline
-                    let split_data = EventDotData {
-                        hash: *hash as u64,
-                        dot_x: branch.t_data.x_val,
-                        dot_y: get_y_axis_pos(*split_point + 1),
-                        title: string_of_branch(ty, i)
-                    };
-                    append_dot(&split_data, output, &branch.t_data, registry);
-
+                // Each branch column gets its real events rendered.
+                // No "If"/"Else" bookend dots: the per-branch
+                // start-dot (at split_point + 1) was a teaching
+                // distraction — it landed on whichever line the
+                // *other* branch happened to acquire on, with the
+                // wrong arm's label. The per-branch end-dot at
+                // merge_point added another redundant pair on the
+                // closing-brace line. Branch identity is already
+                // communicated by column position; the join dot
+                // below speaks for what happened.
+                for branch in branch_history.iter() {
                     render_dot(hash, &branch.e_data, &branch.t_data, output, visualization_data, registry, false);
-
-                    // render a dot at the end of the timeline
-                    let merge_data = EventDotData {
-                        hash: *hash as u64,
-                        dot_x: branch.t_data.x_val,
-                        dot_y: get_y_axis_pos(*merge_point),
-                        title: string_of_branch(ty, i)
-                    };
-                    append_dot(&merge_data, output, &branch.t_data, registry);
                 }
 
-                // render merge dot. Tooltip is the joined ownership
-                // state for this variable across the branches above —
-                // see `branch_join_message`. Title is empty for the
-                // Unchanged case so the dot stays as a structural
-                // marker without a stray hover.
+                // Per-variable merge dot, on the parent column at
+                // `merge_point` (the closing-brace line). Sat at
+                // `merge_point + 1` previously — a line below the
+                // conditional, which read as a stray dot on
+                // unrelated code below. Empty title for the
+                // Unchanged case keeps it as a structural marker.
                 let m_data = EventDotData {
                     hash: *hash as u64,
                     dot_x: timeline_data.x_val,
-                    dot_y: get_y_axis_pos(*merge_point + 1),
+                    dot_y: get_y_axis_pos(*merge_point),
                     title: branch_join_message(branch_history, ty, &is.real_name()),
                 };
                 append_dot(&m_data, output, timeline_data, registry);

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -2051,11 +2051,24 @@ fn render_branches(
                 for offset in [-half_w, half_w] {
                     let mut pieces: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
 
+                    // Parent-side endpoints carry the same `offset`
+                    // as the branch-side endpoints, so the two
+                    // parallel sides of the strip stay offset by
+                    // half_w throughout — including through the
+                    // convergence diagonals. Pre-fix the parent
+                    // endpoint sat at parent_x (a single apex
+                    // point), which made the two sides converge
+                    // to one point and produced a "diamond"
+                    // taper at each parent junction. Both
+                    // endpoints are inside the parent dot's
+                    // rendered radius so the strip visually meets
+                    // the dot cleanly without losing the
+                    // convergence cue.
                     if alive_at_start {
                         pieces.push((
                             leading_dashed,
                             vec![
-                                (parent_x, get_y_axis_pos(*split_point) as f64),
+                                (parent_x + offset, get_y_axis_pos(*split_point) as f64),
                                 (branch_x + offset, get_y_axis_pos(*split_point + 1) as f64),
                             ],
                             p_title.clone(),
@@ -2078,7 +2091,7 @@ fn render_branches(
                             trailing_dashed,
                             vec![
                                 (branch_x + offset, get_y_axis_pos(merge_point.saturating_sub(1)) as f64),
-                                (parent_x, get_y_axis_pos(*merge_point) as f64),
+                                (parent_x + offset, get_y_axis_pos(*merge_point) as f64),
                             ],
                             e_title.clone(),
                         ));
@@ -2115,6 +2128,76 @@ fn render_branches(
                             TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
                         )).0.timelines.push_str(&svg);
                     }
+                }
+
+                // Hover capture: a single transparent `<polygon>`
+                // covering the strip's perimeter for this branch.
+                // The visible polylines are 1.5px-wide and the
+                // ~3.5px gap between the two parallel sides isn't
+                // covered by any element on its own, so hovering
+                // anywhere in that gap fired no tooltip. The
+                // polygon spans both sides and the convergence
+                // wedges so a hover anywhere over the branch's
+                // visual strip surfaces the column's tooltip.
+                // Stroke is suppressed so it doesn't add visible
+                // outline; fill is transparent so it doesn't
+                // shade the area but still receives pointer
+                // events.
+                let split_y = get_y_axis_pos(*split_point) as f64;
+                let merge_y = get_y_axis_pos(*merge_point) as f64;
+                let column_top_y = get_y_axis_pos(*split_point + 1) as f64;
+                let column_bot_y = get_y_axis_pos(merge_point.saturating_sub(1)) as f64;
+                // Column extent within this strip: bounded by the
+                // first / last body group's row range. With no
+                // body groups (e.g. an `if` arm that consumed the
+                // var at the top of its body), the column extent
+                // collapses to `column_top_y` and the polygon
+                // becomes just the leading-wedge cap — matches
+                // the visible polylines, which are also just the
+                // leading edge in that case.
+                let (col_top_y, col_bot_y) = match (groups.first(), groups.last()) {
+                    (Some(first), Some(last)) => (
+                        get_y_axis_pos(first.1) as f64,
+                        get_y_axis_pos(last.2) as f64,
+                    ),
+                    _ => (column_top_y, column_top_y),
+                };
+                let mut perim: Vec<(f64, f64)> = Vec::new();
+                // Left side, top to bottom.
+                if alive_at_start {
+                    perim.push((parent_x - half_w, split_y));
+                }
+                perim.push((branch_x - half_w, col_top_y));
+                if !groups.is_empty() {
+                    perim.push((branch_x - half_w, col_bot_y));
+                }
+                if alive_at_end {
+                    perim.push((parent_x - half_w, merge_y));
+                }
+                // Right side, bottom to top.
+                if alive_at_end {
+                    perim.push((parent_x + half_w, merge_y));
+                }
+                if !groups.is_empty() {
+                    perim.push((branch_x + half_w, col_bot_y));
+                }
+                perim.push((branch_x + half_w, col_top_y));
+                if alive_at_start {
+                    perim.push((parent_x + half_w, split_y));
+                }
+                if perim.len() >= 3 {
+                    let pts_str = perim.iter()
+                        .map(|p| format!("{},{}", p.0, p.1))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let svg = format!(
+                        "        <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
+                        hash, pts_str, p_title,
+                    );
+                    output.entry(-1).or_insert_with(|| (
+                        TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                        TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                    )).0.timelines.push_str(&svg);
                 }
 
                 // Recurse for any branches nested inside this

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1939,6 +1939,35 @@ fn state_is_alive(state: &State) -> bool {
     )
 }
 
+/// Unit-length perpendicular to the line `p1 → p2`. Used to offset
+/// each side of the strip by `half_w` perpendicular to the line
+/// direction so the *visual* gap between the two parallel sides is
+/// constant regardless of angle. Pre-fix the offset was applied in
+/// the x-axis only, which made diagonals' visual gap shrink as
+/// `cos(θ)` (a 40° diagonal was ~23% narrower than the vertical
+/// body), and the user noticed the diagonals reading as "too close
+/// together" compared to the column.
+fn perp_unit(p1: (f64, f64), p2: (f64, f64)) -> (f64, f64) {
+    let dx = p2.0 - p1.0;
+    let dy = p2.1 - p1.1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < 1e-9 {
+        return (1.0, 0.0);
+    }
+    (-dy / len, dx / len)
+}
+
+/// One centerline segment of a branch's strip — the leading
+/// convergence, a body state run, or the trailing convergence.
+/// Each segment carries its own style (dashed/solid) and a
+/// tooltip; offsets are applied per-side at render time.
+struct CenterSeg {
+    style: bool, // dashed
+    p1: (f64, f64),
+    p2: (f64, f64),
+    title: String,
+}
+
 /// Render every branch (and any nested branches) reachable through
 /// `history`. Each branch's column-plus-convergence is emitted as
 /// `<polyline>` elements: one per side of the strip, broken at
@@ -2042,163 +2071,176 @@ fn render_branches(
                 let alive_at_start = state_is_alive(&begin_state.2);
                 let alive_at_end = state_is_alive(&e_state);
 
-                // For each side of the strip emit polylines:
-                // walk pieces (leading | body groups | trailing)
-                // in source order and merge consecutive same-
-                // style pieces into single `<polyline>`s. Where
-                // styles change, two abutting polylines share a
-                // common endpoint and meet seamlessly.
-                for offset in [-half_w, half_w] {
-                    let mut pieces: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
-
-                    // Parent-side endpoints carry the same `offset`
-                    // as the branch-side endpoints, so the two
-                    // parallel sides of the strip stay offset by
-                    // half_w throughout — including through the
-                    // convergence diagonals. Pre-fix the parent
-                    // endpoint sat at parent_x (a single apex
-                    // point), which made the two sides converge
-                    // to one point and produced a "diamond"
-                    // taper at each parent junction. Both
-                    // endpoints are inside the parent dot's
-                    // rendered radius so the strip visually meets
-                    // the dot cleanly without losing the
-                    // convergence cue.
-                    if alive_at_start {
-                        pieces.push((
-                            leading_dashed,
-                            vec![
-                                (parent_x + offset, get_y_axis_pos(*split_point) as f64),
-                                (branch_x + offset, get_y_axis_pos(*split_point + 1) as f64),
-                            ],
-                            p_title.clone(),
-                        ));
-                    }
-
-                    for (dashed, top, bot, title) in &groups {
-                        pieces.push((
-                            *dashed,
-                            vec![
-                                (branch_x + offset, get_y_axis_pos(*top) as f64),
-                                (branch_x + offset, get_y_axis_pos(*bot) as f64),
-                            ],
-                            title.clone(),
-                        ));
-                    }
-
-                    if alive_at_end {
-                        pieces.push((
-                            trailing_dashed,
-                            vec![
-                                (branch_x + offset, get_y_axis_pos(merge_point.saturating_sub(1)) as f64),
-                                (parent_x + offset, get_y_axis_pos(*merge_point) as f64),
-                            ],
-                            e_title.clone(),
-                        ));
-                    }
-
-                    let mut polylines: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
-                    for (dashed, pts, title) in pieces {
-                        let merged = polylines.last().map(|l| l.0 == dashed).unwrap_or(false);
-                        if merged {
-                            let last = polylines.last_mut().unwrap();
-                            for (i, p) in pts.into_iter().enumerate() {
-                                if i == 0 && last.1.last() == Some(&p) {
-                                    continue;
-                                }
-                                last.1.push(p);
-                            }
-                        } else {
-                            polylines.push((dashed, pts, title));
-                        }
-                    }
-
-                    for (dashed, pts, title) in polylines {
-                        let pts_str = pts.iter()
-                            .map(|p| format!("{},{}", p.0, p.1))
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        let dasharray = if dashed { "4 4" } else { "none" };
-                        let svg = format!(
-                            "        <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
-                            hash, pts_str, title, dasharray,
-                        );
-                        output.entry(-1).or_insert_with(|| (
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                        )).0.timelines.push_str(&svg);
-                    }
-                }
-
-                // Hover capture: a single transparent `<polygon>`
-                // covering the strip's perimeter for this branch.
-                // The visible polylines are 1.5px-wide and the
-                // ~3.5px gap between the two parallel sides isn't
-                // covered by any element on its own, so hovering
-                // anywhere in that gap fired no tooltip. The
-                // polygon spans both sides and the convergence
-                // wedges so a hover anywhere over the branch's
-                // visual strip surfaces the column's tooltip.
-                // Stroke is suppressed so it doesn't add visible
-                // outline; fill is transparent so it doesn't
-                // shade the area but still receives pointer
-                // events.
+                // Build the centerline segment list for this branch.
+                // Each segment carries its own style and tooltip;
+                // perpendicular offsets get applied per-side below.
+                // The segments line up centerline-end to centerline-
+                // start at every transition, so the two sides are
+                // built by walking the same segment list with
+                // different offset signs.
                 let split_y = get_y_axis_pos(*split_point) as f64;
                 let merge_y = get_y_axis_pos(*merge_point) as f64;
                 let column_top_y = get_y_axis_pos(*split_point + 1) as f64;
                 let column_bot_y = get_y_axis_pos(merge_point.saturating_sub(1)) as f64;
-                // Column extent within this strip: bounded by the
-                // first / last body group's row range. With no
-                // body groups (e.g. an `if` arm that consumed the
-                // var at the top of its body), the column extent
-                // collapses to `column_top_y` and the polygon
-                // becomes just the leading-wedge cap — matches
-                // the visible polylines, which are also just the
-                // leading edge in that case.
-                let (col_top_y, col_bot_y) = match (groups.first(), groups.last()) {
-                    (Some(first), Some(last)) => (
-                        get_y_axis_pos(first.1) as f64,
-                        get_y_axis_pos(last.2) as f64,
-                    ),
-                    _ => (column_top_y, column_top_y),
+
+                let mut segs: Vec<CenterSeg> = Vec::new();
+                if alive_at_start {
+                    segs.push(CenterSeg {
+                        style: leading_dashed,
+                        p1: (parent_x, split_y),
+                        p2: (branch_x, column_top_y),
+                        title: p_title.clone(),
+                    });
+                }
+                for (dashed, top, bot, title) in &groups {
+                    segs.push(CenterSeg {
+                        style: *dashed,
+                        p1: (branch_x, get_y_axis_pos(*top) as f64),
+                        p2: (branch_x, get_y_axis_pos(*bot) as f64),
+                        title: title.clone(),
+                    });
+                }
+                if alive_at_end {
+                    segs.push(CenterSeg {
+                        style: trailing_dashed,
+                        p1: (branch_x, column_bot_y),
+                        p2: (parent_x, merge_y),
+                        title: e_title.clone(),
+                    });
+                }
+
+                // Build per-side edge lists (LEFT = +sign offsets
+                // perp.x < 0 outward, RIGHT = -sign). Each segment
+                // contributes one main edge at its perp-offset
+                // endpoints. Where two consecutive segments have
+                // different perp directions (the leading/body and
+                // body/trailing transitions are the canonical
+                // cases — diagonals rotate the perp away from the
+                // body's horizontal), a small bevel edge connects
+                // the previous segment's offset endpoint to the
+                // current segment's offset endpoint. The bevel
+                // inherits the *previous* segment's style so a
+                // dashed-leading → solid-body transition keeps the
+                // bevel dashed (matching what the user reads as
+                // "the leading edge ends here").
+                let build_edges = |sign: f64| -> Vec<(bool, (f64, f64), (f64, f64), String)> {
+                    let mut edges: Vec<(bool, (f64, f64), (f64, f64), String)> = Vec::new();
+                    let mut prev_off_p2: Option<(f64, f64)> = None;
+                    let mut prev_style: Option<bool> = None;
+                    let mut prev_title: Option<String> = None;
+                    for seg in &segs {
+                        let perp = perp_unit(seg.p1, seg.p2);
+                        let off_x = perp.0 * sign * half_w;
+                        let off_y = perp.1 * sign * half_w;
+                        let off_p1 = (seg.p1.0 + off_x, seg.p1.1 + off_y);
+                        let off_p2 = (seg.p2.0 + off_x, seg.p2.1 + off_y);
+                        if let (Some(prev_p2), Some(prev_st), Some(prev_t)) =
+                            (prev_off_p2, prev_style, prev_title.clone())
+                        {
+                            let diff_x = (prev_p2.0 - off_p1.0).abs();
+                            let diff_y = (prev_p2.1 - off_p1.1).abs();
+                            if diff_x > 1e-6 || diff_y > 1e-6 {
+                                edges.push((prev_st, prev_p2, off_p1, prev_t));
+                            }
+                        }
+                        edges.push((seg.style, off_p1, off_p2, seg.title.clone()));
+                        prev_off_p2 = Some(off_p2);
+                        prev_style = Some(seg.style);
+                        prev_title = Some(seg.title.clone());
+                    }
+                    edges
                 };
+
+                let group_edges = |edges: Vec<(bool, (f64, f64), (f64, f64), String)>| -> Vec<(bool, Vec<(f64, f64)>, String)> {
+                    let mut polylines: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
+                    for (style, p1, p2, title) in edges {
+                        if let Some(last) = polylines.last_mut() {
+                            if last.0 == style && last.1.last() == Some(&p1) {
+                                last.1.push(p2);
+                                continue;
+                            }
+                        }
+                        polylines.push((style, vec![p1, p2], title));
+                    }
+                    polylines
+                };
+
+                let path_from_edges = |edges: &[(bool, (f64, f64), (f64, f64), String)]| -> Vec<(f64, f64)> {
+                    let mut path: Vec<(f64, f64)> = Vec::new();
+                    if let Some(first) = edges.first() {
+                        path.push(first.1);
+                    }
+                    for e in edges {
+                        path.push(e.2);
+                    }
+                    path
+                };
+
+                // Build everything for both sides up-front so we
+                // can wrap the whole branch in a `<g>` for unified
+                // hover highlighting.
+                let left_edges = build_edges(1.0);
+                let right_edges = build_edges(-1.0);
+                let left_path = path_from_edges(&left_edges);
+                let right_path = path_from_edges(&right_edges);
+
+                let mut branch_svg = String::new();
+
+                for (style, pts, title) in group_edges(left_edges)
+                    .into_iter()
+                    .chain(group_edges(right_edges).into_iter())
+                {
+                    let pts_str = pts.iter()
+                        .map(|p| format!("{},{}", p.0, p.1))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let dasharray = if style { "4 4" } else { "none" };
+                    branch_svg.push_str(&format!(
+                        "            <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
+                        hash, pts_str, title, dasharray,
+                    ));
+                }
+
+                // Hover capture: a transparent `<polygon>` that
+                // traces the strip's perimeter (left path forward
+                // + right path reversed). The visible polylines
+                // are 1.5px-wide and the gap between the two
+                // parallel sides isn't covered by any element on
+                // its own; without this polygon, hovering in that
+                // gap fired no tooltip. `pointer-events:fill` so
+                // the transparent fill still receives mouse
+                // events.
                 let mut perim: Vec<(f64, f64)> = Vec::new();
-                // Left side, top to bottom.
-                if alive_at_start {
-                    perim.push((parent_x - half_w, split_y));
-                }
-                perim.push((branch_x - half_w, col_top_y));
-                if !groups.is_empty() {
-                    perim.push((branch_x - half_w, col_bot_y));
-                }
-                if alive_at_end {
-                    perim.push((parent_x - half_w, merge_y));
-                }
-                // Right side, bottom to top.
-                if alive_at_end {
-                    perim.push((parent_x + half_w, merge_y));
-                }
-                if !groups.is_empty() {
-                    perim.push((branch_x + half_w, col_bot_y));
-                }
-                perim.push((branch_x + half_w, col_top_y));
-                if alive_at_start {
-                    perim.push((parent_x + half_w, split_y));
-                }
+                perim.extend(left_path.iter().cloned());
+                perim.extend(right_path.iter().rev().cloned());
                 if perim.len() >= 3 {
                     let pts_str = perim.iter()
                         .map(|p| format!("{},{}", p.0, p.1))
                         .collect::<Vec<_>>()
                         .join(" ");
-                    let svg = format!(
-                        "        <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
+                    branch_svg.push_str(&format!(
+                        "            <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
                         hash, pts_str, p_title,
-                    );
-                    output.entry(-1).or_insert_with(|| (
-                        TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                        TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                    )).0.timelines.push_str(&svg);
+                    ));
                 }
+
+                // Wrap polylines + polygon in a `<g class="branch-
+                // group">`. CSS rule (.branch-group:hover .tooltip-
+                // trigger) glows every element in the group when
+                // any one is hovered, so moving the mouse into the
+                // strip area highlights the entire branch column
+                // rather than just whichever line segment the
+                // pointer happens to be over. Single-element hover
+                // pre-fix only highlighted one of the two parallel
+                // sides at a time, with no feedback on the
+                // transparent gap or the convergences.
+                output.entry(-1).or_insert_with(|| (
+                    TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                    TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                )).0.timelines.push_str(&format!(
+                    "        <g class=\"branch-group\">\n{}        </g>\n",
+                    branch_svg,
+                ));
 
                 // Recurse for any branches nested inside this
                 // branch's body. The nested call uses this

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1863,7 +1863,19 @@ fn render_timeline(
     for (_, ev) in history {
         match ev {
             Event::Branch { branch_history, split_point, merge_point, ..} => {
-                let begin_state = states.iter().find(|&item| item.1 == *split_point).unwrap().clone();
+                // Find the state segment that *covers* the split point.
+                // Looking for `.1 == split_point` was a foothold from
+                // the days before let-as-rhs could put a Branch in
+                // live_vars: when the LHS variable doesn't exist
+                // before the conditional, the pre-branch state and
+                // the during-branch placeholder are both OutOfScope
+                // and clean_states merges them, so the boundary at
+                // split_point disappears. Range-containment finds the
+                // right segment in either case.
+                let begin_state = states.iter()
+                    .find(|item| item.0 <= *split_point && *split_point <= item.1)
+                    .unwrap_or_else(|| panic!("no state segment covers split_point {}", split_point))
+                    .clone();
                 let p_state = convert_back(&begin_state.2);
                 for (i, branch) in branch_history.iter().enumerate() {
                     let mut split_line_data = VerticalLineData {

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -2068,7 +2068,19 @@ fn render_branches(
                 // convergence would form a polyline that bridged
                 // over the Move, putting a stray column line on a
                 // row the variable doesn't exist on.
-                let alive_at_start = state_is_alive(&begin_state.2);
+                //
+                // `alive_at_start` is checked on the *synthesized*
+                // `p_state` rather than the raw `begin_state.2`.
+                // For let-as-rhs (`let s = if … { … } else { … };`)
+                // the parent's pre-branch state is OutOfScope —
+                // the variable doesn't exist yet — but the branch
+                // *is* about to bring it into scope by acquiring.
+                // The synthesis above maps OOS → FullPrivilege so
+                // the leading diagonal has a renderable state, and
+                // the liveness check needs to run on that mapped
+                // state too, otherwise the leading edge falls off
+                // for every let-as-rhs binding.
+                let alive_at_start = state_is_alive(&p_state);
                 let alive_at_end = state_is_alive(&e_state);
 
                 // Build the centerline segment list for this branch.

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -116,7 +116,11 @@ struct VerticalLineData {
     y1: i64,
     y2: i64,
     title: String,
-    opacity: f64
+    opacity: f64,
+    /// SVG `stroke-dasharray`. "none" for a solid line; "4 3" or
+    /// similar to dash an inactive (Gray-state) branch column so
+    /// readers can tell which lines a given branch is "passive" on.
+    dasharray: String,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -132,7 +136,11 @@ struct HollowLineData {
     x4: f64,
     y4: f64,
     title: String,
-    opacity: f64
+    opacity: f64,
+    /// Mirrors VerticalLineData::dasharray; propagated through
+    /// `compute_hollow_line_data` so a Gray-state hollow segment
+    /// renders dashed.
+    dasharray: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -282,13 +290,13 @@ fn prepare_registry(registry: &mut Handlebars) {
     let arrow_template =
         "        <g class=\"tooltip-trigger\" data-tooltip-text=\"{{title}}\">\n            <polyline stroke-width=\"5px\" stroke=\"gray\" points=\"{{coordinates_hbs}}\" style=\"fill: none;\"/>\n            <polygon points=\"{{head_points}}\" fill=\"gray\"/>\n        </g>\n";
     let vertical_line_template =
-        "        <line data-hash=\"{{hash}}\" class=\"{{line_class}} tooltip-trigger\" x1=\"{{x1}}\" x2=\"{{x2}}\" y1=\"{{y1}}\" y2=\"{{y2}}\" data-tooltip-text=\"{{title}}\" style=\"opacity: {{opacity}};\"/>\n";
+        "        <line data-hash=\"{{hash}}\" class=\"{{line_class}} tooltip-trigger\" x1=\"{{x1}}\" x2=\"{{x2}}\" y1=\"{{y1}}\" y2=\"{{y2}}\" data-tooltip-text=\"{{title}}\" style=\"opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n";
     let hollow_line_template =
         "        <path data-hash=\"{{hash}}\" class=\"hollow tooltip-trigger\" style=\"fill:transparent;\" d=\"M {{x1}},{{y1}} V {{y2}} h 3.5 V {{y1}} h -3.5\" data-tooltip-text=\"{{title}}\"/>\n";
-    let new_hollow_line_template = "<path 
+    let new_hollow_line_template = "<path
         data-hash=\"{{hash}}\"
         class=\"hollow tooltip-trigger\"
-        style=\"fill:transparent; stroke-opacity: {{opacity}};\"
+        style=\"fill:transparent; stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"
         d=\"M {{x1}},{{y1}} L {{x2}},{{y2}} L {{x3}},{{y3}} L {{x4}},{{y4}} Z\"
         data-tooltip-text=\"{{title}}\"/>";
     let solid_ref_line_template =
@@ -1717,10 +1725,15 @@ fn compute_hollow_line_data(v_data: VerticalLineData, w: f64) -> HollowLineData{
     let x4 = x2 + px;
     let y4 = y2 + py;
 
-    HollowLineData { line_class: v_data.line_class, 
-        hash: v_data.hash, 
-        x1: x1, x2: x2, x3: x4, x4: x3, 
-        y1: y1, y2: y2, y3: y4, y4: y3, title: v_data.title, opacity: v_data.opacity }
+    HollowLineData {
+        line_class: v_data.line_class,
+        hash: v_data.hash,
+        x1: x1, x2: x2, x3: x4, x4: x3,
+        y1: y1, y2: y2, y3: y4, y4: y3,
+        title: v_data.title,
+        opacity: v_data.opacity,
+        dasharray: v_data.dasharray,
+    }
 }
 
 // generate a Owner Line string from the RAP and its State
@@ -1733,9 +1746,16 @@ fn create_owner_line_string(
     // TODO: prevent creating line when function dot already exists
     let style = determine_owner_line_styles(rap, state);
 
+    // Gray-state segments are conditional-branch portions where
+    // *this* branch isn't actively doing anything on the line. Dash
+    // them so readers can scan vertically and see at-a-glance which
+    // arm is producing the events at each row. Faded opacity alone
+    // wasn't visually distinct enough — both arms read as solid
+    // columns to first glance.
     match state {
         State::FullPrivilege { s: LineState::Gray } | State::PartialPrivilege { s: LineState::Gray } => {
             data.opacity = 0.5;
+            data.dasharray = "4 3".to_owned();
         }
         _ => {}
     }
@@ -1768,6 +1788,7 @@ fn create_reference_line_string(
     match state {
         State::FullPrivilege { s: LineState::Gray } | State::PartialPrivilege { s: LineState::Gray } => {
             data.opacity = 0.5;
+            data.dasharray = "4 3".to_owned();
         }
         _ => {}
     }
@@ -1882,7 +1903,8 @@ fn render_timeline(
                         x2: branch.t_data.x_val as f64,
                         y2: get_y_axis_pos(*split_point + 1),
                         title: timeline_segment_title(&p_state, rap, visualization_data),
-                        opacity: 1.0
+                        opacity: 1.0,
+                        dasharray: "none".to_owned(),
                     };
 
                     if branch.e_data.is_empty() || i != 0{
@@ -1893,25 +1915,34 @@ fn render_timeline(
                     // get ending state
                     let e_state = branch.states.last().unwrap().2.clone();
 
-                    render_timeline(hash, 
-                        rap, 
+                    render_timeline(hash,
+                        rap,
                         &branch.e_data,
-                        &branch.states, 
-                        output, 
-                        visualization_data, 
-                        &branch.t_data, 
+                        &branch.states,
+                        output,
+                        visualization_data,
+                        &branch.t_data,
                         registry);
-                    
-                    // render line from branch to merge
+
+                    // Render the convergence diagonal so the join
+                    // dot at parent_x@merge_point is the meeting
+                    // point of every branch column. The diagonal
+                    // starts at branch_x@(merge_point - 1) — one
+                    // line above the join, where the branch column
+                    // has been trimmed to (see compute_branch_states
+                    // in data.rs) — and ends at parent_x@merge_point.
+                    // Previously y1 was at merge_point + 1, putting
+                    // the convergence one row past the join dot.
                     let mut merge_line_data = VerticalLineData {
                         line_class: String::new(),
                         hash: *hash,
                         x1: timeline_data.x_val as f64,
-                        y1: get_y_axis_pos(*merge_point + 1),
+                        y1: get_y_axis_pos(*merge_point),
                         x2: branch.t_data.x_val as f64,
-                        y2: get_y_axis_pos(*merge_point),
+                        y2: get_y_axis_pos(merge_point.saturating_sub(1)),
                         title: timeline_segment_title(&e_state, rap, visualization_data),
-                        opacity: 1.0
+                        opacity: 1.0,
+                        dasharray: "none".to_owned(),
                     };
 
                     if branch.e_data.is_empty() {
@@ -1935,7 +1966,8 @@ fn render_timeline(
                 x2: timeline_data.x_val as f64,
                 y2: get_y_axis_pos(*line_end),
                 title: timeline_segment_title(state, rap, visualization_data),
-                opacity: 1.0
+                opacity: 1.0,
+                dasharray: "none".to_owned(),
         };
         if *line_start != *line_end {
             append_line(state, & mut data, rap, timeline_data, output, registry);

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1924,60 +1924,39 @@ fn render_timeline(
                     State::OutOfScope => State::FullPrivilege { s: LineState::Full },
                     ref s => convert_back(s),
                 };
-                // Half the hollow column's strip width — the column
-                // body is rendered with the two parallel `<line>`
-                // sides offset by ±1.75 from `branch_x` (matches
-                // `compute_hollow_line_data`'s w=3.5 / 2 on a
-                // vertical line). The split / merge convergences
-                // below use the same offset so their endpoints
-                // share exact coordinates with the column's edges
-                // — no corner gap where strip-based perpendicular
-                // offsets don't line up with horizontal column
-                // offsets.
-                let half_w: f64 = 1.75;
-                let parent_x = timeline_data.x_val as f64;
-
                 for (i, branch) in branch_history.iter().enumerate() {
-                    let branch_x = branch.t_data.x_val as f64;
-
-                    // Render the leading wedge: two `<line>`s from
-                    // the parent dot at split_point fanning out to
-                    // the column-top edges (branch_x ± half_w).
-                    // Sharing endpoints with the column's two
-                    // parallel sides — no corner gap. The first
-                    // branch (i = 0, the if-arm or first match-
-                    // arm) renders solid as the leading path;
-                    // alternates / empty branches render dashed.
-                    let leading_dasharray = if branch.e_data.is_empty() || i != 0 {
-                        "4 4".to_owned()
-                    } else {
-                        "none".to_owned()
+                    let mut split_line_data = VerticalLineData {
+                        line_class: String::new(),
+                        hash: *hash,
+                        x1: timeline_data.x_val as f64,
+                        y1: get_y_axis_pos(*split_point),
+                        x2: branch.t_data.x_val as f64,
+                        y2: get_y_axis_pos(*split_point + 1),
+                        title: timeline_segment_title(&p_state, rap, visualization_data),
+                        opacity: 1.0,
+                        dasharray: "none".to_owned(),
                     };
-                    let split_title = timeline_segment_title(&p_state, rap, visualization_data);
-                    for offset in [-half_w, half_w] {
-                        let line_data = VerticalLineData {
-                            line_class: "hollow".to_owned(),
-                            hash: *hash,
-                            x1: parent_x,
-                            y1: get_y_axis_pos(*split_point),
-                            x2: branch_x + offset,
-                            y2: get_y_axis_pos(*split_point + 1),
-                            title: split_title.clone(),
-                            opacity: 1.0,
-                            dasharray: leading_dasharray.clone(),
-                        };
-                        let s = registry.render("vertical_line_template", &line_data).unwrap();
-                        output.entry(-1).or_insert_with(|| (
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                        )).0.timelines.push_str(&s);
-                    }
 
-                    // Body of the branch column: state-driven,
-                    // hollow rendering already emits two parallel
-                    // `<line>`s aligned with branch_x ± half_w
-                    // through `compute_hollow_line_data`.
+                    // The first branch (i = 0, conventionally the
+                    // if-arm or the first match-arm) renders solid
+                    // — it's the "leading" path the user reads
+                    // first. Subsequent branches dash + fade their
+                    // leading split diagonal so it's clear they're
+                    // the alternate paths. Empty branches always
+                    // dash + fade. Pre-set dasharray here so a
+                    // non-Gray state (the OOS-promoted Full case
+                    // above, or a real pre-existing FullPrivilege)
+                    // still renders dashed for passive arms;
+                    // create_owner_line_string only sets dasharray
+                    // for Gray and won't otherwise.
+                    if branch.e_data.is_empty() || i != 0 {
+                        split_line_data.dasharray = "4 4".to_owned();
+                    }
+                    append_line(&p_state, &mut split_line_data, rap, timeline_data, output, registry);
+
+                    // get ending state
                     let e_state = branch.states.last().unwrap().2.clone();
+
                     render_timeline(hash,
                         rap,
                         &branch.e_data,
@@ -1987,37 +1966,38 @@ fn render_timeline(
                         &branch.t_data,
                         registry);
 
-                    // Trailing wedge: two `<line>`s from the
-                    // column-bottom edges (branch_x ± half_w at
-                    // merge_point - 1) converging to the parent
-                    // join dot at merge_point. Solid vs dashed
-                    // tracks `e_state` so a passive (Gray) end
-                    // state surfaces as a dashed wedge while an
-                    // active (Full) end state renders solid.
-                    let trailing_dasharray = match e_state {
-                        State::FullPrivilege { s: LineState::Gray }
-                        | State::PartialPrivilege { s: LineState::Gray } => "4 4".to_owned(),
-                        _ => "none".to_owned(),
+                    // Render the convergence diagonal so the join
+                    // dot at parent_x@merge_point is the meeting
+                    // point of every branch column. The diagonal
+                    // starts at branch_x@(merge_point - 1) — one
+                    // line above the join, where the branch column
+                    // has been trimmed to (see compute_branch_states
+                    // in data.rs) — and ends at parent_x@merge_point.
+                    // Previously y1 was at merge_point + 1, putting
+                    // the convergence one row past the join dot.
+                    let mut merge_line_data = VerticalLineData {
+                        line_class: String::new(),
+                        hash: *hash,
+                        x1: timeline_data.x_val as f64,
+                        y1: get_y_axis_pos(*merge_point),
+                        x2: branch.t_data.x_val as f64,
+                        y2: get_y_axis_pos(merge_point.saturating_sub(1)),
+                        title: timeline_segment_title(&e_state, rap, visualization_data),
+                        opacity: 1.0,
+                        dasharray: "none".to_owned(),
                     };
-                    let merge_title = timeline_segment_title(&e_state, rap, visualization_data);
-                    for offset in [-half_w, half_w] {
-                        let line_data = VerticalLineData {
-                            line_class: "hollow".to_owned(),
-                            hash: *hash,
-                            x1: branch_x + offset,
-                            y1: get_y_axis_pos(merge_point.saturating_sub(1)),
-                            x2: parent_x,
-                            y2: get_y_axis_pos(*merge_point),
-                            title: merge_title.clone(),
-                            opacity: 1.0,
-                            dasharray: trailing_dasharray.clone(),
-                        };
-                        let s = registry.render("vertical_line_template", &line_data).unwrap();
-                        output.entry(-1).or_insert_with(|| (
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                        )).0.timelines.push_str(&s);
-                    }
+
+                    // Solid vs dashed for the convergence diagonal
+                    // is decided downstream by `create_owner_line_string`
+                    // / `create_reference_line_string` from `e_state`.
+                    // We don't force dashed for empty `e_data` — with
+                    // the body-span treatment of empty branches,
+                    // `e_state` is the active state at merge-1 and
+                    // already says "solid" when this branch is the
+                    // active path at the join (e.g. `else { println!(s) }`
+                    // — no events on s but else IS the active arm).
+
+                    append_line(&e_state, &mut merge_line_data, rap, timeline_data, output, registry);
                 }
             }
             _ => {}

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1924,39 +1924,60 @@ fn render_timeline(
                     State::OutOfScope => State::FullPrivilege { s: LineState::Full },
                     ref s => convert_back(s),
                 };
+                // Half the hollow column's strip width — the column
+                // body is rendered with the two parallel `<line>`
+                // sides offset by ±1.75 from `branch_x` (matches
+                // `compute_hollow_line_data`'s w=3.5 / 2 on a
+                // vertical line). The split / merge convergences
+                // below use the same offset so their endpoints
+                // share exact coordinates with the column's edges
+                // — no corner gap where strip-based perpendicular
+                // offsets don't line up with horizontal column
+                // offsets.
+                let half_w: f64 = 1.75;
+                let parent_x = timeline_data.x_val as f64;
+
                 for (i, branch) in branch_history.iter().enumerate() {
-                    let mut split_line_data = VerticalLineData {
-                        line_class: String::new(),
-                        hash: *hash,
-                        x1: timeline_data.x_val as f64,
-                        y1: get_y_axis_pos(*split_point),
-                        x2: branch.t_data.x_val as f64,
-                        y2: get_y_axis_pos(*split_point + 1),
-                        title: timeline_segment_title(&p_state, rap, visualization_data),
-                        opacity: 1.0,
-                        dasharray: "none".to_owned(),
+                    let branch_x = branch.t_data.x_val as f64;
+
+                    // Render the leading wedge: two `<line>`s from
+                    // the parent dot at split_point fanning out to
+                    // the column-top edges (branch_x ± half_w).
+                    // Sharing endpoints with the column's two
+                    // parallel sides — no corner gap. The first
+                    // branch (i = 0, the if-arm or first match-
+                    // arm) renders solid as the leading path;
+                    // alternates / empty branches render dashed.
+                    let leading_dasharray = if branch.e_data.is_empty() || i != 0 {
+                        "4 4".to_owned()
+                    } else {
+                        "none".to_owned()
                     };
-
-                    // The first branch (i = 0, conventionally the
-                    // if-arm or the first match-arm) renders solid
-                    // — it's the "leading" path the user reads
-                    // first. Subsequent branches dash + fade their
-                    // leading split diagonal so it's clear they're
-                    // the alternate paths. Empty branches always
-                    // dash + fade. Pre-set dasharray here so a
-                    // non-Gray state (the OOS-promoted Full case
-                    // above, or a real pre-existing FullPrivilege)
-                    // still renders dashed for passive arms;
-                    // create_owner_line_string only sets dasharray
-                    // for Gray and won't otherwise.
-                    if branch.e_data.is_empty() || i != 0 {
-                        split_line_data.dasharray = "4 4".to_owned();
+                    let split_title = timeline_segment_title(&p_state, rap, visualization_data);
+                    for offset in [-half_w, half_w] {
+                        let line_data = VerticalLineData {
+                            line_class: "hollow".to_owned(),
+                            hash: *hash,
+                            x1: parent_x,
+                            y1: get_y_axis_pos(*split_point),
+                            x2: branch_x + offset,
+                            y2: get_y_axis_pos(*split_point + 1),
+                            title: split_title.clone(),
+                            opacity: 1.0,
+                            dasharray: leading_dasharray.clone(),
+                        };
+                        let s = registry.render("vertical_line_template", &line_data).unwrap();
+                        output.entry(-1).or_insert_with(|| (
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                        )).0.timelines.push_str(&s);
                     }
-                    append_line(&p_state, &mut split_line_data, rap, timeline_data, output, registry);
 
-                    // get ending state
+                    // Body of the branch column: state-driven,
+                    // hollow rendering already emits two parallel
+                    // `<line>`s aligned with branch_x ± half_w
+                    // through `compute_hollow_line_data`.
                     let e_state = branch.states.last().unwrap().2.clone();
-
                     render_timeline(hash,
                         rap,
                         &branch.e_data,
@@ -1966,38 +1987,37 @@ fn render_timeline(
                         &branch.t_data,
                         registry);
 
-                    // Render the convergence diagonal so the join
-                    // dot at parent_x@merge_point is the meeting
-                    // point of every branch column. The diagonal
-                    // starts at branch_x@(merge_point - 1) — one
-                    // line above the join, where the branch column
-                    // has been trimmed to (see compute_branch_states
-                    // in data.rs) — and ends at parent_x@merge_point.
-                    // Previously y1 was at merge_point + 1, putting
-                    // the convergence one row past the join dot.
-                    let mut merge_line_data = VerticalLineData {
-                        line_class: String::new(),
-                        hash: *hash,
-                        x1: timeline_data.x_val as f64,
-                        y1: get_y_axis_pos(*merge_point),
-                        x2: branch.t_data.x_val as f64,
-                        y2: get_y_axis_pos(merge_point.saturating_sub(1)),
-                        title: timeline_segment_title(&e_state, rap, visualization_data),
-                        opacity: 1.0,
-                        dasharray: "none".to_owned(),
+                    // Trailing wedge: two `<line>`s from the
+                    // column-bottom edges (branch_x ± half_w at
+                    // merge_point - 1) converging to the parent
+                    // join dot at merge_point. Solid vs dashed
+                    // tracks `e_state` so a passive (Gray) end
+                    // state surfaces as a dashed wedge while an
+                    // active (Full) end state renders solid.
+                    let trailing_dasharray = match e_state {
+                        State::FullPrivilege { s: LineState::Gray }
+                        | State::PartialPrivilege { s: LineState::Gray } => "4 4".to_owned(),
+                        _ => "none".to_owned(),
                     };
-
-                    // Solid vs dashed for the convergence diagonal
-                    // is decided downstream by `create_owner_line_string`
-                    // / `create_reference_line_string` from `e_state`.
-                    // We don't force dashed for empty `e_data` — with
-                    // the body-span treatment of empty branches,
-                    // `e_state` is the active state at merge-1 and
-                    // already says "solid" when this branch is the
-                    // active path at the join (e.g. `else { println!(s) }`
-                    // — no events on s but else IS the active arm).
-
-                    append_line(&e_state, &mut merge_line_data, rap, timeline_data, output, registry);
+                    let merge_title = timeline_segment_title(&e_state, rap, visualization_data);
+                    for offset in [-half_w, half_w] {
+                        let line_data = VerticalLineData {
+                            line_class: "hollow".to_owned(),
+                            hash: *hash,
+                            x1: branch_x + offset,
+                            y1: get_y_axis_pos(merge_point.saturating_sub(1)),
+                            x2: parent_x,
+                            y2: get_y_axis_pos(*merge_point),
+                            title: merge_title.clone(),
+                            opacity: 1.0,
+                            dasharray: trailing_dasharray.clone(),
+                        };
+                        let s = registry.render("vertical_line_template", &line_data).unwrap();
+                        output.entry(-1).or_insert_with(|| (
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                            TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
+                        )).0.timelines.push_str(&s);
+                    }
                 }
             }
             _ => {}

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1,5 +1,5 @@
 extern crate handlebars;
-use crate::svg_generator::data::{convert_back, string_of_branch, string_of_external_event, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
+use crate::svg_generator::data::{convert_back, string_of_branch, string_of_external_event, BranchData, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
 use crate::svg_generator::hover_messages;
 use crate::svg_generator::svg_frontend::line_styles::OwnerLine;
 use handlebars::Handlebars;
@@ -374,51 +374,44 @@ fn update_timeline_data(events: & mut Vec<(usize, Event)>, parent_data: &Timelin
                     // copy the parent data
                     branch.t_data = parent_data.clone();
                 }
-                // update the xvalue based on width
+                // Update the x-value of each branch based on its width.
+                // The N-branch fanned-out layout used to be Match-only;
+                // the dedicated 2-branch If/Loop arm hardcoded
+                // `branch_history[1]`, which panicked when an `if`
+                // without an `else` produced a single-branch event.
+                // Math reduces to the same x-values as the old If
+                // layout for N=2, so use the generic path for every
+                // BranchType.
                 let mut parent_branch_data: Vec<TimelineColumnData> = Vec::new();
-                match ty {
-                    BranchType::Match(..) => {
-                        let halfway = branch_history.len() / 2;
-                        let mut running_x = parent_data.x_val;
-                        for i in (0..halfway).rev() {
-                            let b_data = branch_history.get_mut(i).unwrap();
-                            let b_width = b_data.width;
-                            let padding = if i == halfway - 1 {1} else {0};
-                            let left_side_coefficient = -1 * (b_width + padding) as i64;
-                            let x = left_side_coefficient * BRANCH_WEIGHT;
-                            running_x += x;
-                            b_data.t_data.x_val = running_x;
-                            running_x -= 2 * BRANCH_WEIGHT;
-                        }
-                        for i in 0..halfway {
-                          let b_data = branch_history.get(i).unwrap();
-                          parent_branch_data.push(b_data.t_data.clone());
-                        }
+                let _ = ty; // BranchType doesn't affect x-positioning
+                let halfway = branch_history.len() / 2;
+                let mut running_x = parent_data.x_val;
+                for i in (0..halfway).rev() {
+                    let b_data = branch_history.get_mut(i).unwrap();
+                    let b_width = b_data.width;
+                    let padding = if i == halfway - 1 { 1 } else { 0 };
+                    let left_side_coefficient = -1 * (b_width + padding) as i64;
+                    let x = left_side_coefficient * BRANCH_WEIGHT;
+                    running_x += x;
+                    b_data.t_data.x_val = running_x;
+                    running_x -= 2 * BRANCH_WEIGHT;
+                }
+                for i in 0..halfway {
+                    let b_data = branch_history.get(i).unwrap();
+                    parent_branch_data.push(b_data.t_data.clone());
+                }
 
-                        running_x = parent_data.x_val;
-                        for i in halfway..branch_history.len() {
-                            let b_data = branch_history.get_mut(i).unwrap();
-                            let b_width = b_data.width;
-                            let padding = if i == halfway {1} else {0};
-                            let right_side_coefficient = (b_width + padding) as i64;
-                            let x = right_side_coefficient * BRANCH_WEIGHT;
-                            running_x += x;
-                            b_data.t_data.x_val = running_x;
-                            running_x += 2 * BRANCH_WEIGHT;
-                            parent_branch_data.push(b_data.t_data.clone());
-                        }
-                    }
-                    _ => {
-                        let if_bw = branch_history.get(0).unwrap().width;
-                        let else_bw = branch_history.get(1).unwrap().width;
-                        let if_offset_coefficient: i64 = -1 * ((if_bw + 1) as i64); // + 1 for padding between branches
-                        let else_offset_coefficient: i64 = (else_bw + 1) as i64;
-
-                        branch_history.get_mut(0).unwrap().t_data.x_val = parent_data.x_val + (if_offset_coefficient * BRANCH_WEIGHT);
-                        branch_history.get_mut(1).unwrap().t_data.x_val = parent_data.x_val + (else_offset_coefficient * BRANCH_WEIGHT);
-                        parent_branch_data.push(branch_history.get(0).unwrap().t_data.clone());
-                        parent_branch_data.push(branch_history.get(1).unwrap().t_data.clone());
-                    }
+                running_x = parent_data.x_val;
+                for i in halfway..branch_history.len() {
+                    let b_data = branch_history.get_mut(i).unwrap();
+                    let b_width = b_data.width;
+                    let padding = if i == halfway { 1 } else { 0 };
+                    let right_side_coefficient = (b_width + padding) as i64;
+                    let x = right_side_coefficient * BRANCH_WEIGHT;
+                    running_x += x;
+                    b_data.t_data.x_val = running_x;
+                    running_x += 2 * BRANCH_WEIGHT;
+                    parent_branch_data.push(b_data.t_data.clone());
                 }
 
                 // recurse
@@ -676,12 +669,16 @@ fn render_dot(
                     append_dot(&merge_data, output, &branch.t_data, registry);
                 }
 
-                // render merge dot
+                // render merge dot. Tooltip is the joined ownership
+                // state for this variable across the branches above —
+                // see `branch_join_message`. Title is empty for the
+                // Unchanged case so the dot stays as a structural
+                // marker without a stray hover.
                 let m_data = EventDotData {
                     hash: *hash as u64,
                     dot_x: timeline_data.x_val,
                     dot_y: get_y_axis_pos(*merge_point + 1),
-                    title: "merge".to_owned()
+                    title: branch_join_message(branch_history, ty, &is.real_name()),
                 };
                 append_dot(&m_data, output, timeline_data, registry);
                 continue;
@@ -808,6 +805,110 @@ fn render_dot(
         }
         // push to individual timelines
         append_dot(&data, output, timeline_data, registry);
+    }
+}
+
+// ── Conditional join-state computation ─────────────────────────────
+//
+// Computes the joined ownership state of one variable across the
+// branches of an `if` / `match` / `if let`, used to label the per-
+// variable merge dot at the bottom of the conditional.
+//
+// We classify each branch's *end state* for the variable as
+// (ends_moved, has_acquire) by walking the per-variable Event list
+// the conversion in data.rs already filtered for us. Move events on
+// that list mean the variable was moved out; Acquire events mean it
+// received a new resource (re-bind or first bind). Borrows / dies /
+// duplicates don't change ownership.
+//
+// Nested conditionals are handled recursively: if any nested path
+// moves the variable, we propagate that up as a possible move on the
+// containing path. If every nested path acquires the variable, we
+// propagate that up as an acquire.
+//
+// Joining across the outer branches:
+//   - Any branch ends moved             → MovedAfter
+//   - Every branch acquires AND every    → BoundHere
+//     conceptual path is represented
+//     (no missing else)
+//   - Otherwise                          → Unchanged (no tooltip)
+//
+// "Every conceptual path is represented" — for `if cond { body }`
+// without an else, the implicit-untouched else means the var can't
+// be considered freshly-bound regardless of what the if branch does.
+// Match arms are exhaustive in Rust, so all paths are present.
+
+enum BranchJoin {
+    Unchanged,
+    MovedAfter,
+    BoundHere,
+}
+
+fn analyze_branch_for_join(events: &[(usize, Event)]) -> (bool, bool) {
+    let mut moved = false;
+    let mut acquired = false;
+    for (_, e) in events {
+        match e {
+            Event::Move { .. } => { moved = true; acquired = false; }
+            Event::Acquire { .. } => { moved = false; acquired = true; }
+            Event::Branch { branch_history, ty, .. } => {
+                let mut nested_any_moved = false;
+                let mut nested_all_acquired = !branch_history.is_empty();
+                for nb in branch_history {
+                    let (m, a) = analyze_branch_for_join(&nb.e_data);
+                    if m { nested_any_moved = true; }
+                    if !a { nested_all_acquired = false; }
+                }
+                if nested_any_moved {
+                    moved = true; acquired = false;
+                } else if nested_all_acquired && all_paths_present(ty, branch_history.len()) {
+                    moved = false; acquired = true;
+                }
+            }
+            // Borrows, returns, copies-from-here, duplicates: don't
+            // change whether the variable still owns its resource.
+            _ => {}
+        }
+    }
+    (moved, acquired)
+}
+
+fn all_paths_present(ty: &BranchType, n_branches: usize) -> bool {
+    match ty {
+        // Plain `if cond { … }` without an else has only one branch
+        // recorded; the implicit-untouched else means not every
+        // conceptual path acquires, so BoundHere can't fire.
+        BranchType::If(labels, _) => labels.len() >= 2 && n_branches >= 2,
+        // Rust match is exhaustive — every path is one of the arms.
+        BranchType::Match(labels, _) => labels.len() == n_branches,
+        // Loop bodies are conditionally entered (zero or more times),
+        // so a "BoundHere" claim isn't appropriate for their merge.
+        BranchType::Loop(_, _) => false,
+    }
+}
+
+fn compute_branch_join(branch_history: &[BranchData], ty: &BranchType) -> BranchJoin {
+    let mut any_moved = false;
+    let mut all_acquired = !branch_history.is_empty();
+    for b in branch_history {
+        let (m, a) = analyze_branch_for_join(&b.e_data);
+        if m { any_moved = true; }
+        if !a { all_acquired = false; }
+    }
+    if any_moved {
+        BranchJoin::MovedAfter
+    } else if all_acquired && all_paths_present(ty, branch_history.len()) {
+        BranchJoin::BoundHere
+    } else {
+        BranchJoin::Unchanged
+    }
+}
+
+fn branch_join_message(branch_history: &[BranchData], ty: &BranchType, var_name: &String) -> String {
+    match compute_branch_join(branch_history, ty) {
+        BranchJoin::MovedAfter => hover_messages::event_dot_branch_merge_moved(var_name),
+        BranchJoin::BoundHere => hover_messages::event_dot_branch_merge_bound(var_name),
+        BranchJoin::Unchanged => String::new(),
     }
 }
 

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -293,19 +293,17 @@ fn prepare_registry(registry: &mut Handlebars) {
         "        <line data-hash=\"{{hash}}\" class=\"{{line_class}} tooltip-trigger\" x1=\"{{x1}}\" x2=\"{{x2}}\" y1=\"{{y1}}\" y2=\"{{y2}}\" data-tooltip-text=\"{{title}}\" style=\"opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n";
     let hollow_line_template =
         "        <path data-hash=\"{{hash}}\" class=\"hollow tooltip-trigger\" style=\"fill:transparent;\" d=\"M {{x1}},{{y1}} V {{y2}} h 3.5 V {{y1}} h -3.5\" data-tooltip-text=\"{{title}}\"/>\n";
-    // No `Z` to close the path: the closed-quadrilateral form
-    // dashes the top and bottom horizontal caps too, which
-    // surfaces a stray ~3.5px tick at the top and bottom of any
-    // dashed segment. Leaving the path open means the dashes only
-    // run along the two parallel verticals plus the bottom
-    // connector — visually the segment reads as one dashed strip
-    // instead of three independent dashed sides.
-    let new_hollow_line_template = "<path
-        data-hash=\"{{hash}}\"
-        class=\"hollow tooltip-trigger\"
-        style=\"fill:transparent; stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"
-        d=\"M {{x1}},{{y1}} L {{x2}},{{y2}} L {{x3}},{{y3}} L {{x4}},{{y4}}\"
-        data-tooltip-text=\"{{title}}\"/>";
+    // Hollow column rendering: two parallel `<line>` elements,
+    // one per side of the strip. No closing horizontal at top or
+    // bottom — those were the source of the "stray dash tick" at
+    // segment boundaries (closed/open paths drew a dashed
+    // horizontal connector that appeared as an extra mark where a
+    // dashed segment met a solid one). Two independent lines have
+    // `stroke-linecap: butt` by default, so adjacent state
+    // segments — dashed leading + solid body + dashed trailing —
+    // meet at exact y-coordinates with nothing between them, and
+    // the column reads as one continuous strip with two textures.
+    let new_hollow_line_template = "<g class=\"tooltip-trigger\" data-tooltip-text=\"{{title}}\">\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x1}}\" y1=\"{{y1}}\" x2=\"{{x2}}\" y2=\"{{y2}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x4}}\" y1=\"{{y4}}\" x2=\"{{x3}}\" y2=\"{{y3}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n        </g>\n";
     let solid_ref_line_template =
         "        <path data-hash=\"{{hash}}\" class=\"mutref {{line_class}} tooltip-trigger\" style=\"fill:transparent; stroke-width: 2px !important;\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
     let hollow_ref_line_template =
@@ -1989,9 +1987,15 @@ fn render_timeline(
                         dasharray: "none".to_owned(),
                     };
 
-                    if branch.e_data.is_empty() {
-                        merge_line_data.dasharray = "4 4".to_owned();
-                    }
+                    // Solid vs dashed for the convergence diagonal
+                    // is decided downstream by `create_owner_line_string`
+                    // / `create_reference_line_string` from `e_state`.
+                    // We don't force dashed for empty `e_data` — with
+                    // the body-span treatment of empty branches,
+                    // `e_state` is the active state at merge-1 and
+                    // already says "solid" when this branch is the
+                    // active path at the join (e.g. `else { println!(s) }`
+                    // — no events on s but else IS the active arm).
 
                     append_line(&e_state, &mut merge_line_data, rap, timeline_data, output, registry);
                 }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1893,7 +1893,22 @@ fn render_timeline(
                     .find(|item| item.0 <= *split_point && *split_point <= item.1)
                     .unwrap_or_else(|| panic!("no state segment covers split_point {}", split_point))
                     .clone();
-                let p_state = convert_back(&begin_state.2);
+                // For let-as-rhs bindings the parent state is
+                // OutOfScope before the conditional — the variable
+                // doesn't exist yet. `create_owner_line_string`
+                // returns "" for OutOfScope, so the leading split
+                // diagonals from the fork dot down to each branch
+                // column would silently vanish, leaving the fork dot
+                // floating above disconnected branches. Treat the
+                // OOS-prior case as if the variable were
+                // FullPrivilege::Full at the split: the *active*
+                // branch's diagonal renders as the regular owner
+                // line (solid for mut, hollow for immut), and the
+                // passive-branch dasharray below dashes the rest.
+                let p_state = match begin_state.2 {
+                    State::OutOfScope => State::FullPrivilege { s: LineState::Full },
+                    ref s => convert_back(s),
+                };
                 for (i, branch) in branch_history.iter().enumerate() {
                     let mut split_line_data = VerticalLineData {
                         line_class: String::new(),
@@ -1907,8 +1922,21 @@ fn render_timeline(
                         dasharray: "none".to_owned(),
                     };
 
-                    if branch.e_data.is_empty() || i != 0{
+                    // The first branch (i = 0, conventionally the
+                    // if-arm or the first match-arm) renders solid
+                    // — it's the "leading" path the user reads
+                    // first. Subsequent branches dash + fade their
+                    // leading split diagonal so it's clear they're
+                    // the alternate paths. Empty branches always
+                    // dash + fade. Pre-set dasharray here so a
+                    // non-Gray state (the OOS-promoted Full case
+                    // above, or a real pre-existing FullPrivilege)
+                    // still renders dashed for passive arms;
+                    // create_owner_line_string only sets dasharray
+                    // for Gray and won't otherwise.
+                    if branch.e_data.is_empty() || i != 0 {
                         split_line_data.opacity = 0.5;
+                        split_line_data.dasharray = "4 3".to_owned();
                     }
                     append_line(&p_state, &mut split_line_data, rap, timeline_data, output, registry);
 

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -293,11 +293,18 @@ fn prepare_registry(registry: &mut Handlebars) {
         "        <line data-hash=\"{{hash}}\" class=\"{{line_class}} tooltip-trigger\" x1=\"{{x1}}\" x2=\"{{x2}}\" y1=\"{{y1}}\" y2=\"{{y2}}\" data-tooltip-text=\"{{title}}\" style=\"opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n";
     let hollow_line_template =
         "        <path data-hash=\"{{hash}}\" class=\"hollow tooltip-trigger\" style=\"fill:transparent;\" d=\"M {{x1}},{{y1}} V {{y2}} h 3.5 V {{y1}} h -3.5\" data-tooltip-text=\"{{title}}\"/>\n";
+    // No `Z` to close the path: the closed-quadrilateral form
+    // dashes the top and bottom horizontal caps too, which
+    // surfaces a stray ~3.5px tick at the top and bottom of any
+    // dashed segment. Leaving the path open means the dashes only
+    // run along the two parallel verticals plus the bottom
+    // connector — visually the segment reads as one dashed strip
+    // instead of three independent dashed sides.
     let new_hollow_line_template = "<path
         data-hash=\"{{hash}}\"
         class=\"hollow tooltip-trigger\"
         style=\"fill:transparent; stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"
-        d=\"M {{x1}},{{y1}} L {{x2}},{{y2}} L {{x3}},{{y3}} L {{x4}},{{y4}} Z\"
+        d=\"M {{x1}},{{y1}} L {{x2}},{{y2}} L {{x3}},{{y3}} L {{x4}},{{y4}}\"
         data-tooltip-text=\"{{title}}\"/>";
     let solid_ref_line_template =
         "        <path data-hash=\"{{hash}}\" class=\"mutref {{line_class}} tooltip-trigger\" style=\"fill:transparent; stroke-width: 2px !important;\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
@@ -1752,10 +1759,15 @@ fn create_owner_line_string(
     // arm is producing the events at each row. Faded opacity alone
     // wasn't visually distinct enough — both arms read as solid
     // columns to first glance.
+    // Gray-state segments: render at full opacity so they read as
+    // the same line as the active solid segments, just textured
+    // differently. Pre-fix the dashed legs sat at 0.5 opacity which
+    // made the dashed-then-solid transitions look like two
+    // independent lines instead of one continuous timeline. The
+    // dash pattern is the only inactive cue now.
     match state {
         State::FullPrivilege { s: LineState::Gray } | State::PartialPrivilege { s: LineState::Gray } => {
-            data.opacity = 0.5;
-            data.dasharray = "4 3".to_owned();
+            data.dasharray = "4 4".to_owned();
         }
         _ => {}
     }
@@ -1785,10 +1797,15 @@ fn create_reference_line_string(
     data: &mut VerticalLineData,
     registry: &Handlebars,
 ) -> String {
+    // Gray-state segments: render at full opacity so they read as
+    // the same line as the active solid segments, just textured
+    // differently. Pre-fix the dashed legs sat at 0.5 opacity which
+    // made the dashed-then-solid transitions look like two
+    // independent lines instead of one continuous timeline. The
+    // dash pattern is the only inactive cue now.
     match state {
         State::FullPrivilege { s: LineState::Gray } | State::PartialPrivilege { s: LineState::Gray } => {
-            data.opacity = 0.5;
-            data.dasharray = "4 3".to_owned();
+            data.dasharray = "4 4".to_owned();
         }
         _ => {}
     }
@@ -1935,8 +1952,7 @@ fn render_timeline(
                     // create_owner_line_string only sets dasharray
                     // for Gray and won't otherwise.
                     if branch.e_data.is_empty() || i != 0 {
-                        split_line_data.opacity = 0.5;
-                        split_line_data.dasharray = "4 3".to_owned();
+                        split_line_data.dasharray = "4 4".to_owned();
                     }
                     append_line(&p_state, &mut split_line_data, rap, timeline_data, output, registry);
 
@@ -1974,7 +1990,7 @@ fn render_timeline(
                     };
 
                     if branch.e_data.is_empty() {
-                        merge_line_data.opacity = 0.5;
+                        merge_line_data.dasharray = "4 4".to_owned();
                     }
 
                     append_line(&e_state, &mut merge_line_data, rap, timeline_data, output, registry);

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -776,18 +776,29 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
         
         let if_map = create_line_map(&if_ev);
-        if if_end != merge { if_end += 1; } // this is for front-end formatting
 
-        // Emit the Branch event with one ExtBranchData per real branch.
-        // Plain `if cond { body }` (no else) is single-branch — emitting
-        // a synthesized "Else" label leaks an "Else" tooltip onto the
-        // visualization for code the user didn't write.
+        // Per-branch "active" line ranges. Each branch is rendered
+        // solid inside its active range and dashed outside. We use
+        // body content ranges (not body spans) so the if-branch's
+        // active range stops at its `}` line — at the line where
+        // the else-branch's body starts, the if-branch transitions
+        // to dashed and the else-branch becomes active. Ranges
+        // can't overlap, otherwise both would draw solid on the
+        // shared row.
+        //
+        // `merge_point - 1` is the last line each branch column is
+        // drawn on (the convergence diagonal then bridges that row
+        // to the join dot at `merge_point` — see render_timeline's
+        // Branch arm). Clamping the else-branch's end there keeps
+        // it consistent with the column-trim done in
+        // compute_branch_states.
+        let merge_minus_one = merge.saturating_sub(1);
         let (b_labels, b_slices, b_branches) = match else_expr {
           Some(_) => {
             let else_map = create_line_map(&else_ev);
             (
               vec!["If".to_owned(), "Else".to_owned()],
-              vec![(split + 1, if_end), (if_end, merge)],
+              vec![(split + 1, if_end), (if_end + 1, merge_minus_one)],
               vec![
                 ExtBranchData { e_data: if_ev,   line_map: if_map,   decl_vars: if_decl   },
                 ExtBranchData { e_data: else_ev, line_map: else_map, decl_vars: else_decl },

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -1075,13 +1075,18 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
             // inside that arm — strip them out so they don't get a
             // branched timeline of their own.
             liveness = liveness.difference(&all_pat_decls).cloned().collect();
-            // add branch event
+            // add branch event. merge_point is the closing-brace
+            // line of the match — same convention as If, where
+            // merge_point is the line of the else-block's closing
+            // `}`. Previously this used `merge - 1` (with a stale
+            // TODO marker), which landed the join dot one row above
+            // the `};`, on the last arm's body line.
             self.add_external_event(split, ExternalEvent::Branch {
               live_vars: liveness,
               branches: branch_data,
               branch_type: BranchType::Match(b_ty_names, b_slices),
               split_point: split,
-              merge_point: merge - 1, // TODO: fix
+              merge_point: merge,
               id: *self.unique_id });
             *self.unique_id += 1;
           }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -749,16 +749,37 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
         
         let if_map = create_line_map(&if_ev);
-        let else_map = create_line_map(&else_ev);
         if if_end != merge { if_end += 1; } // this is for front-end formatting
-        let b_ty = BranchType::If(vec!["If".to_owned(), "Else".to_owned()], vec![(split + 1, if_end), (if_end, merge)]);
-        self.add_external_event(line_num, 
-          ExternalEvent::Branch { 
-            live_vars: liveness, 
-            branches: vec![ExtBranchData{ e_data: if_ev, line_map: if_map, decl_vars: if_decl }, 
-                          ExtBranchData { e_data: else_ev, line_map: else_map, decl_vars: else_decl }], 
-            branch_type: b_ty, 
-            split_point: split, 
+
+        // Emit the Branch event with one ExtBranchData per real branch.
+        // Plain `if cond { body }` (no else) is single-branch — emitting
+        // a synthesized "Else" label leaks an "Else" tooltip onto the
+        // visualization for code the user didn't write.
+        let (b_labels, b_slices, b_branches) = match else_expr {
+          Some(_) => {
+            let else_map = create_line_map(&else_ev);
+            (
+              vec!["If".to_owned(), "Else".to_owned()],
+              vec![(split + 1, if_end), (if_end, merge)],
+              vec![
+                ExtBranchData { e_data: if_ev,   line_map: if_map,   decl_vars: if_decl   },
+                ExtBranchData { e_data: else_ev, line_map: else_map, decl_vars: else_decl },
+              ],
+            )
+          }
+          None => (
+            vec!["If".to_owned()],
+            vec![(split + 1, if_end)],
+            vec![ExtBranchData { e_data: if_ev, line_map: if_map, decl_vars: if_decl }],
+          ),
+        };
+        let b_ty = BranchType::If(b_labels, b_slices);
+        self.add_external_event(line_num,
+          ExternalEvent::Branch {
+            live_vars: liveness,
+            branches: b_branches,
+            branch_type: b_ty,
+            split_point: split,
             merge_point: merge,
             id: *self.unique_id });
             *self.unique_id += 1;

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -778,17 +778,24 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         let if_map = create_line_map(&if_ev);
 
         // Per-branch "active" line ranges. Each branch is rendered
-        // solid inside its active range and dashed outside. We use
-        // body content ranges (not body spans) so the if-branch's
-        // active range stops at its `}` line — at the line where
-        // the else-branch's body starts, the if-branch transitions
-        // to dashed and the else-branch becomes active. Ranges
-        // can't overlap, otherwise both would draw solid on the
-        // shared row.
+        // solid inside its active range and dashed outside. The
+        // ranges are non-overlapping so the if-branch transitions
+        // to dashed at the line where the else-branch becomes
+        // active.
+        //
+        // For the if-branch we use its body content range
+        // (`split + 1 ..= if_end`); for the else-branch we use its
+        // body span starting at the `} else {` line so the
+        // active region has at least two rows even when the body
+        // has a single content line. Without that, an empty or
+        // single-line else (e.g. `else { println!(...) }` whose
+        // formatter doesn't emit per-event entries on `s`) would
+        // collapse to a zero-length solid segment, leaving the
+        // entire else column dashed.
         //
         // `merge_point - 1` is the last line each branch column is
-        // drawn on (the convergence diagonal then bridges that row
-        // to the join dot at `merge_point` — see render_timeline's
+        // drawn on; the convergence diagonal then bridges that row
+        // to the join dot at `merge_point` (see render_timeline's
         // Branch arm). Clamping the else-branch's end there keeps
         // it consistent with the column-trim done in
         // compute_branch_states.
@@ -798,7 +805,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
             let else_map = create_line_map(&else_ev);
             (
               vec!["If".to_owned(), "Else".to_owned()],
-              vec![(split + 1, if_end), (if_end + 1, merge_minus_one)],
+              vec![(split + 1, if_end), (if_end, merge_minus_one)],
               vec![
                 ExtBranchData { e_data: if_ev,   line_map: if_map,   decl_vars: if_decl   },
                 ExtBranchData { e_data: else_ev, line_map: else_map, decl_vars: else_decl },

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -675,12 +675,12 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           };
         self.inside_branch = true; // need this flag to correctly handle variables that are declared inside blocks
         self.visit_expr(&if_expr);
-        let (else_live, else_decl) = match else_expr {
+        let else_decl = match else_expr {
           Some(e) => {
             self.visit_expr(e);
-            (get_live_of_expr(e, &self.tcx, &self.raps), get_decl_of_expr(e, &self.tcx, &self.raps))
+            get_decl_of_expr(e, &self.tcx, &self.raps)
           }
-          None => { (HashSet::new(), HashSet::new()) }
+          None => HashSet::new(),
         };
         self.inside_branch = false;
 
@@ -693,48 +693,75 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           None => self.tcx.sess.source_map().lookup_char_pos(if_expr.span.hi()).line
         };
 
-        // compute liveness
-        // live variables are defined as variables that are defined outside the conditional but
-        // are used inside of it (the ones whose timelines will have a branch in the visualization)
-        let if_live = get_live_of_expr(if_expr, &self.tcx, &self.raps);
         // Bindings declared by an `if let` guard belong in the if
         // branch's decl set (they live for the body block, same as a
         // top-level `let` inside it).
         let mut if_decl = get_decl_of_expr(if_expr, &self.tcx, &self.raps);
-        if_decl.extend(iflet_bindings);
-        let mut liveness: HashSet<ResourceAccessPoint> = if_live.union(&else_live).cloned().collect();
+        if_decl.extend(iflet_bindings.iter().cloned());
 
-        // If the guard sits on a line within the filter range below
-        // (i.e. when the source-level guard and body collapse onto the
-        // same line — the most common cause of this is a macro-expanded
-        // `assert!(cond)` becoming `if !cond { panic!(...) }`, but it
-        // also happens for hand-written one-liners like
-        // `if foo() { bar(); }`), the events emitted while visiting
-        // the guard get filtered into the branch's `e_data` alongside
-        // body events. Without adding the guard's live vars to
-        // `liveness`, the affected variables don't get a Branch entry
-        // on their timelines, and the renderer's fetch_timeline lookup
-        // panics when it tries to find a guard-side event id in the
-        // variable's history. In the normal multi-line case the guard
-        // line is strictly less than `split`, so this conditional is
-        // false and we don't add empty-Branch placeholders to
-        // unrelated timelines.
-        if line_num >= split && line_num <= merge {
-          let guard_live = get_live_of_expr(&guard_expr, &self.tcx, &self.raps);
-          liveness.extend(guard_live);
-        }
+        // Filter events that landed inside each branch's body. The
+        // ranges deliberately exclude the brace lines: `split` is the
+        // line of the if-body's opening `{` (which in normal Rust
+        // formatting is the same line as the guard), and the guard's
+        // events shouldn't be folded into the if-branch — the guard
+        // runs once before either branch, not as part of one. Same
+        // logic for the else side: the `} else {` line carries the
+        // closing of the if-body and the opening of the else-body,
+        // and any events on it are structural noise from either side.
+        // Single-line ifs (split == merge) collapse the ranges to
+        // empty, intentionally — line-based filtering can't separate
+        // body from guard there. The dropdown fix in #117 keeps the
+        // canonical examples multi-line for now.
+        let _ = line_num; // no longer used for guard-live extension
+        // For plain `if cond { … }` we exclude the split line (the
+        // line of the body's opening `{`, normally the same line as
+        // the guard) so guard reads stay on the global timeline. For
+        // `if let pat = expr { … }` the destructure events emitted by
+        // `register_iflet_let_bindings` *are* on the split line and
+        // belong inside the if-branch — include split when an if-let
+        // is in play.
+        let if_filter_lo = if iflet_bindings.is_empty() { split + 1 } else { split };
+        let if_filter_hi = if_end;
+        let else_filter_lo = if_end + 1;
+        let else_filter_hi = merge;
+        let mut if_ev: Vec<(usize, ExternalEvent)> =
+          self.preprocessed_events.iter()
+            .filter(|i| filter_ev(i, if_filter_lo, if_filter_hi))
+            .cloned().collect();
+        let mut else_ev: Vec<(usize, ExternalEvent)> =
+          self.preprocessed_events.iter()
+            .filter(|i| filter_ev(i, else_filter_lo, else_filter_hi))
+            .cloned().collect();
+        // Align the global-event purge with the per-branch filters
+        // above. Removing the entire `[split, merge]` slab (the old
+        // behaviour) drops events that *didn't* make it into either
+        // branch — chiefly the let-as-rhs Moves emitted on the split
+        // line for single-line ifs, and a plain `if cond { … }`'s
+        // guard reads (also on the split line). Those events still
+        // belong on the global timeline; only the events the
+        // branches claimed should be evicted from there.
+        self.preprocessed_events.retain(|(l, _)| {
+          let in_if = *l >= if_filter_lo && *l <= if_filter_hi;
+          let in_else = *l >= else_filter_lo && *l <= else_filter_hi;
+          !(in_if || in_else)
+        });
 
-        // filter events that happened in the if/else block
-        let mut if_ev: Vec<(usize, ExternalEvent)> = self.preprocessed_events.iter().filter(|i| filter_ev(i, split, if_end)).cloned().collect();
-        let mut else_ev: Vec<(usize, ExternalEvent)> = self.preprocessed_events.iter().filter(|i| filter_ev(i, if_end, merge)).cloned().collect();
-        self.preprocessed_events.retain(|(l, _)| 
-          if *l <= merge && *l >= split {
-            false
-          }
-          else {
-            true
-          }
-        );
+        // Compute liveness from the events actually inside the
+        // branches — only variables touched by a real event get a
+        // branched timeline. Avoids the previous behaviour where
+        // `get_live_of_expr(guard_expr)` always promoted guard
+        // variables (e.g. the `n` in `if n > 0 { … }`) into branched
+        // columns even when neither branch references them.
+        let mut liveness: HashSet<ResourceAccessPoint> = HashSet::new();
+        collect_event_live_vars(&if_ev, &mut liveness);
+        collect_event_live_vars(&else_ev, &mut liveness);
+        // Variables declared inside a branch (let-stmts within the
+        // body, plus if-let pattern bindings) live only for that
+        // branch — they're not pre-existing variables that need a
+        // branched timeline. Subtract them out.
+        let declared_in_branches: HashSet<ResourceAccessPoint> =
+          if_decl.union(&else_decl).cloned().collect();
+        liveness = liveness.difference(&declared_in_branches).cloned().collect();
 
         // add gos events for variables declared in each block
         for var in if_decl.iter() {
@@ -901,7 +928,16 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         let mut b_ty_names: Vec<String> = Vec::new();
         let mut b_slices: Vec<(usize, usize)> = Vec::new();
         let mut branch_data: Vec<ExtBranchData> = Vec::new();
-        let mut liveness: HashSet<ResourceAccessPoint> = get_live_of_expr(guard_expr, &self.tcx, &self.raps);
+        // Liveness is computed from the events actually folded into
+        // each arm's `branch_e_data` below — see the symmetric note
+        // in the If arm. Pat-decls (variables bound by the arm's
+        // pattern) are subtracted off per arm so they don't show up
+        // as branched columns of their own.
+        let mut liveness: HashSet<ResourceAccessPoint> = HashSet::new();
+        // Track every binding introduced by an arm pattern so we
+        // can subtract the union from `liveness` after all arms have
+        // been processed.
+        let mut all_pat_decls: HashSet<ResourceAccessPoint> = HashSet::new();
 
         
         match source {
@@ -981,9 +1017,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
               self.visit_expr(arm.body);
               self.inside_branch = false;
 
-              // update liveness info
-              liveness = liveness.union(&get_live_of_expr(arm.body, &self.tcx, &self.raps)).cloned().collect();
-              liveness = liveness.difference(&pat_decls).cloned().collect();
+              all_pat_decls.extend(pat_decls.iter().cloned());
               let arm_decls: HashSet<ResourceAccessPoint> = pat_decls.union(&get_decl_of_expr(arm.body, &self.tcx, &self.raps)).cloned().collect();
 
 
@@ -991,6 +1025,10 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
               branch_e_data.extend(
                 self.preprocessed_events.iter().filter(|i| filter_ev(i, begin, end)).cloned()
               );
+
+              // contribute events-touched variables to liveness; the
+              // arm's own pat-decls are subtracted at the end.
+              collect_event_live_vars(&branch_e_data, &mut liveness);
 
               // remove elements from global container
               self.preprocessed_events.retain(|(l, _)| 
@@ -1022,12 +1060,16 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
               branch_data.push(ExtBranchData { e_data: branch_e_data, line_map: branch_line_map, decl_vars: arm_decls});
             }
+            // Variables introduced by an arm's pattern only exist
+            // inside that arm — strip them out so they don't get a
+            // branched timeline of their own.
+            liveness = liveness.difference(&all_pat_decls).cloned().collect();
             // add branch event
-            self.add_external_event(split, ExternalEvent::Branch { 
-              live_vars: liveness, 
-              branches: branch_data, 
-              branch_type: BranchType::Match(b_ty_names, b_slices), 
-              split_point: split, 
+            self.add_external_event(split, ExternalEvent::Branch {
+              live_vars: liveness,
+              branches: branch_data,
+              branch_type: BranchType::Match(b_ty_names, b_slices),
+              split_point: split,
               merge_point: merge - 1, // TODO: fix
               id: *self.unique_id });
             *self.unique_id += 1;
@@ -1260,10 +1302,29 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
     init: &'tcx Expr<'tcx>,
     is_skipped: bool,
   ) {
-    if !is_skipped {
+    // For `let s = if … { … } else { … };` (and the match analog),
+    // emit the Move-into-LHS events FIRST. Match_rhs's If/Match arms
+    // recurse into each branch's trailing expression and emit a
+    // Move/Copy/Bind event at that line — when those events exist
+    // in `preprocessed_events` before visit_expr's If arm filters
+    // events into per-branch e_data, the LHS naturally becomes a
+    // branched timeline with an Acquire dot inside each branch and
+    // the merge dot picks up the BoundHere join tooltip.
+    //
+    // For other init shapes the original ordering (visit RHS for
+    // side effects, then register LHS) stays — there's no Branch
+    // event to fold the bind into.
+    let init_is_branching = !is_skipped
+      && matches!(init.kind, ExprKind::If(..) | ExprKind::Match(..));
+    if init_is_branching {
+      self.bind_pat(pat, init, is_skipped);
       self.visit_expr(init);
+    } else {
+      if !is_skipped {
+        self.visit_expr(init);
+      }
+      self.bind_pat(pat, init, is_skipped);
     }
-    self.bind_pat(pat, init, is_skipped);
   }
 
   /// Structural pat-against-init decomposition. When the pattern's

--- a/rustviz-plugin/tests/if_else_move_join.rs
+++ b/rustviz-plugin/tests/if_else_move_join.rs
@@ -1,0 +1,15 @@
+// Conditional join state — issue #108. `s` is moved on one branch
+// and only borrowed on the other; at the merge `s` is "may have
+// been moved" (Rust treats it as moved regardless of branch).
+
+fn consume(_s: String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true;
+    if cond {
+        consume(s);
+    } else {
+        println!("kept: {}", s);
+    }
+}

--- a/rustviz-plugin/tests/if_else_rebind_join.rs
+++ b/rustviz-plugin/tests/if_else_rebind_join.rs
@@ -1,0 +1,19 @@
+// Conditional join state — issue #108. Both branches consume `s`
+// and rebind it from a fresh source; at the merge `s` is "bound
+// here from one of the branches above" (owns a resource regardless
+// of which branch ran).
+
+fn consume(_s: String) {}
+
+fn main() {
+    let mut s = String::from("orig");
+    let cond = true;
+    if cond {
+        consume(s);
+        s = String::from("new");
+    } else {
+        consume(s);
+        s = String::from("alt");
+    }
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/if_no_else.rs
+++ b/rustviz-plugin/tests/if_no_else.rs
@@ -1,12 +1,16 @@
 // `if cond { body }` (no else). Pre-fix the visualization
 // synthesized an empty "Else" branch label even when the user
 // didn't write one; now the Branch event is single-branch with
-// just the "If" label.
+// just the "If" label, and `s`'s join state at the merge reflects
+// the implicit-untouched else (still owned in the no-else path,
+// so MovedAfter — not BoundHere).
+
+fn consume(_s: String) {}
 
 fn main() {
     let s = String::from("hi");
-    if s.len() > 0 {
-        println!("non-empty: {}", s);
+    let cond = true;
+    if cond {
+        consume(s);
     }
-    println!("{}", s);
 }

--- a/rustviz-plugin/tests/if_no_else.rs
+++ b/rustviz-plugin/tests/if_no_else.rs
@@ -1,0 +1,12 @@
+// `if cond { body }` (no else). Pre-fix the visualization
+// synthesized an empty "Else" branch label even when the user
+// didn't write one; now the Branch event is single-branch with
+// just the "If" label.
+
+fn main() {
+    let s = String::from("hi");
+    if s.len() > 0 {
+        println!("non-empty: {}", s);
+    }
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/match_as_let_rhs.rs
+++ b/rustviz-plugin/tests/match_as_let_rhs.rs
@@ -1,0 +1,12 @@
+// `match` as the RHS of a `let` (issue #87). Pre-fix: zero `Move`
+// tooltips because match_rhs had no ExprKind::Match arm; arm labels
+// rendered as raw AST tokens (`Int(Pu128(0), Unsuffixed)`, `Wild`).
+
+fn main() {
+    let n = 3;
+    let s = match n {
+        0 => String::from("zero"),
+        _ => String::from("other"),
+    };
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/nested_if_move_join.rs
+++ b/rustviz-plugin/tests/nested_if_move_join.rs
@@ -1,0 +1,22 @@
+// Nested conditional join — issue #108. The inner `if` already
+// produces a "may have been moved" join for `s` (consume on one
+// inner branch, borrow on the other); the outer `if`'s else branch
+// also consumes `s`, so the outer merge has to surface "may have
+// been moved" too.
+
+fn consume(_s: String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let c1 = true;
+    let c2 = false;
+    if c1 {
+        if c2 {
+            consume(s);
+        } else {
+            println!("kept inner: {}", s);
+        }
+    } else {
+        consume(s);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #87 and #108: per-variable join-state messaging at every `if` / `match` / `if let` merge point, plus a comprehensive overhaul of how branch columns render so they read as a single coherent shape across nested branches, mut-vs-immut bindings, and partial moves.

## Merge-state classifier

The plugin already had `ExternalEvent::Branch` plumbing (live_vars, per-branch `ExtBranchData`, split / merge points) but the merge dot's tooltip was hardcoded to the literal `"merge"`. We now classify every merge against each branch's *effective* end state (which already encodes implicit drops from any nested merge) and pick a tooltip + dot shape:

| Joined state         | When                                                          | Visual                                                                                                            |
| -------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| `BoundHere`          | Every conceptual path acquires a fresh resource (rebind).     | Plain dot · *"X acquired ownership of a resource (in all branches above)"*                                        |
| `MovedMixed`         | Some arm moved, at least one didn't (counting if-without-else's implicit untouched else as a didn't-move arm). | **Drop dot** (down-triangle in circle) · *"X was moved in at least one branch above; in branches where it was not, its resource is dropped at the branch's end."* |
| `MovedAll`           | Every recorded arm ends without the resource, no implicit-untouched arm dilutes it.                            | Plain dot · *"X was moved or dropped in every branch above"*                                                      |
| `Unchanged`          | No branch moves or rebinds the variable.                      | Plain dot · *(no tooltip — structural marker)*                                                                    |

Ownership-at-join is binary in Rust ("moved on any path → unusable after"), but the messaging now distinguishes the *mixed* case — where Rust silently inserts a drop at the end of branches that didn't move — from the *every-branch* case, and surfaces that distinction with a drop-dot indicator.

Nested conditionals propagate via recursion: an inner merge's join state contributes to the containing branch's effective end-state, so a move buried in a sub-`if` surfaces correctly at the outer merge (and chains through implicit drops as the levels collapse).

## Single-arm conditionals inline onto the parent timeline

`if cond { … }` (no else), `if let pat = expr { … }` (no else), and `match scrutinee { pat => body }` (one arm) all skip the Branch event and emit their body events inline on the parent timeline. A one-arm Branch otherwise zigzagged the column off-axis with no merge symmetry to balance it. The conditionality of a one-arm body ("only runs if cond is true") is no longer visually encoded — a Move inside shows as an unconditional Move on the parent — but the alternative was a structural anomaly that obscured the same flow.

With-else forms keep their Branch behavior and the conditional metaphor.

## Branch column rendering: state-driven, top to bottom

Replaces the previous accumulated-heuristic stack (`leading_dashed`, `trailing_dashed`, `segment_style`, `state_is_alive` gates) with a single per-segment `BranchSeg { p1, p2, state, title }` that runs through `determine_owner_line_styles` — the same classifier the regular column uses. Solid for mut + Full, hollow paired-line for immut or PartialPrivilege, OOS / Moved drops out, Gray adds a dasharray. Same classifier whether the segment is the leading converge, a body row, or the trailing converge.

Other rendering invariants pinned in this work:
- **Per-side asymmetric extents.** `compute_extent` walks each timeline's branch tree mirroring `update_timeline_data`'s placement formula and returns separate `(left, right)` reservations in BW units. A deeply nested if/else's leftmost leaf can no longer encroach on the column to its left or the code panel.
- **Centerline-contiguous runs.** Segments split into runs where adjacent endpoints meet at the same centerline; each run is its own strip with its own perimeter polygon. A parent branch whose body span is taken over by a nested Branch event renders its leading and trailing as separate runs instead of bridging across the gap with a phantom column.
- **Corner bevels.** Adjacent hollow segments with rotated perpendiculars (diagonal converge meeting vertical body, etc.) get a short connector line on each side so corners close cleanly. Inherits the previous segment's dasharray so a dashed leading → solid body reads as "leading ends here".
- **Trailing converge.** Renders only when the variable is alive at branch end. A Move terminates the column at the move event, same convention as a Move on a non-branch timeline.
- **Let-as-RHS pre-acquire rows.** `compute_branch_states` now emits Gray-Full for the rows between an arm's body span and its first acquire event when the parent state is OOS (let-as-rhs). The strip stays continuous from the leading converge into the acquire dot rather than gapping over a structurally-passive region.

## Hover-target consistency

The regular hollow column and the borrow trapezoid shapes had transparent fills with default `pointer-events="visiblePainted"`, so hover only registered on the visible 1.5–2px strokes. Both now pick up tooltips + glow anywhere inside the strip / trapezoid: the column's `<g>` adds a transparent fill `<polygon>` over its four corner points, and the trapezoid path gets `pointer-events:all`. Same hover-capture pattern branch strips already use.

## #87 incidentals folded in

- **`get_name_of_pat`** — render literal arm patterns from the source span (`0`, `_`) instead of debug-printing AST nodes (`Int(Pu128(0), Unsuffixed)`, `Wild`). Falls back to the debug print only for macro-expanded patterns where there's no source-text view.
- **`match_rhs`** — add the `ExprKind::Match` arm mirroring the existing `ExprKind::If` arm. Resolves silently-empty match-as-RHS visualizations.
- **`get_decl_of_stmt`** — walk the pat for nested `PatKind::Binding` instead of panicking on destructuring lets inside a conditional body.

## Tuple pattern over a single tuple-typed scrutinee

`match pair { (x, y) => … }` — where `pair` is a tuple variable, not a literal tuple expression — used to panic with `parents[i]` out-of-bounds. The destructure code assumed `parents.len() == pat_list.len()` (the literal-tuple-guard shape). Detect the arity mismatch and reuse `parents[0]` for every inner pattern slot. Same fix covers TupleStruct over multi-field enum variants (`match res { Ok(a, b, c) => … }`).

## Conditionals dropdown (10 examples)

Curated teaching sequence. Helper bindings (`cond`, `n`, `c1`…) carry `// rustviz: skip` so the diagrams stay focused on the variable whose ownership / borrow flow each example illustrates.

1. if/else: move on one side, borrow on other
2. if/else: move on both sides
3. if/else with disjoint variables
4. if without else
5. if as let RHS
6. match as let RHS
7. rebind on both sides ("bound here" join)
8. nested if (move propagates outward)
9. deeply nested if (3 levels)
10. match: 3 arms (consume vs borrow)

## Corpus regression coverage

Pinned end-to-end behaviour for:
- `match_as_let_rhs`, `if_else_move_join`, `if_else_rebind_join`, `nested_if_move_join`, `if_no_else` — original join-state cases.
- `if_else_mut_reassign` — mut binding renders as solid (regression guard for the missing-classifier-path that drove the state-driven rewrite).
- `if_as_let_rhs_multiline` — Gray-Full pre-acquire rows on both arms.
- `if_else_move_both` — every-branch wording (no hedge).
- `deep_nested_if` — three-level merge classification chains correctly.
- `match_three_arms` — N>2 branch placement + merge classification.
- `if_let_no_else`, `match_one_arm`, `match_tuple_destructure` — single-arm inlining + tuple-over-single-scrutinee fix.

## Test plan

- [x] `RV_RUNNER=local cargo test -p rustviz-lib` — full corpus passes (51 well-formed + 50 tooltip assertions).
- [x] `cargo check -p rustviz-plugin` — clean (one pre-existing unused-fn warning).
- [x] All ten dropdown examples render correctly in the live playground at `127.0.0.1:3005` after `npm run build`.
- [ ] CI runs `setup.sh` then the same `cargo test`.

Closes #87. Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)