### PR TITLE
Conditionals: finish landing the #116 work + perp-unit guard + cond×iteration tests

### DIFF
--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -378,62 +378,27 @@ fn main() {
   },
   {
     chapter: 'Conditionals',
+    // Branches written on their own lines on purpose. The
+    // timeline positions per-branch dots by source line, so the
+    // single-line form `if … { … } else { … }` collapses both
+    // branches onto one row and renders as a bowtie / X-shape
+    // rather than the intended pair. The canonical examples stay
+    // multi-line until the renderer grows synthetic offsets for
+    // same-line branches.
+    //
+    // Helper bindings (`cond`, `n`, `c1`…) carry `// rustviz: skip`
+    // so they don't add scaffolding columns to the visualization —
+    // the diagrams stay focused on the variable whose ownership /
+    // borrow flow the example illustrates.
     examples: [
       {
-        name: "if as let RHS",
-        // Branches written on their own lines on purpose. The
-        // timeline panel positions per-branch dots by source line,
-        // so the single-line form `if … { … } else { … }` collapses
-        // both branches onto one row and renders as a bowtie /
-        // X-shape rather than the intended pair of branches. Until
-        // the renderer grows synthetic offsets for same-line
-        // branches, the canonical examples stay multi-line.
-        code: `fn main() {
-    let n = 3;
-    let s = if n > 0 {
-        String::from("a")
-    } else {
-        String::from("b")
-    };
-    println!("{}", s);
-}`,
-      },
-      {
-        name: "if without else",
-        code: `fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let s = String::from("hi");
-    let cond = true;
-    if cond {
-        show(&s);
-    }
-    show(&s);
-}`,
-      },
-      {
-        name: "if/else with disjoint variables",
-        code: `fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let cond = true;
-    let a = String::from("a");
-    let b = String::from("b");
-    if cond {
-        show(&a);
-    } else {
-        show(&b);
-    }
-}`,
-      },
-      {
-        name: "if/else: same var moved on one side",
+        name: "if/else: move on one side, borrow on other",
         code: `fn consume(_s: String) {} // rustviz: hide
 fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
-    let cond = true;
+    let cond = true; // rustviz: skip
     if cond {
         consume(s);
     } else {
@@ -447,12 +412,52 @@ fn main() {
 
 fn main() {
     let s = String::from("hi");
-    let cond = true;
+    let cond = true; // rustviz: skip
     if cond {
         consume(s);
     } else {
         consume(s);
     }
+}`,
+      },
+      {
+        name: "if/else with disjoint variables",
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let cond = true; // rustviz: skip
+    let a = String::from("a");
+    let b = String::from("b");
+    if cond {
+        show(&a);
+    } else {
+        show(&b);
+    }
+}`,
+      },
+      {
+        name: "if without else",
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true; // rustviz: skip
+    if cond {
+        show(&s);
+    }
+    show(&s);
+}`,
+      },
+      {
+        name: "if as let RHS",
+        code: `fn main() {
+    let n = 3; // rustviz: skip
+    let s = if n > 0 {
+        String::from("a")
+    } else {
+        String::from("b")
+    };
+    println!("{}", s);
 }`,
       },
       {
@@ -460,80 +465,12 @@ fn main() {
         code: `fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
-    let n = 3;
+    let n = 3; // rustviz: skip
     let s = match n {
         0 => String::from("zero"),
         _ => String::from("other"),
     };
     show(&s);
-}`,
-      },
-      {
-        name: "if let Some",
-        code: `fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let opt: Option<String> = Some(String::from("x"));
-    if let Some(x) = opt {
-        show(&x);
-    }
-}`,
-      },
-      {
-        name: "if let Some / else",
-        code: `fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let opt: Option<String> = Some(String::from("x"));
-    if let Some(x) = opt {
-        show(&x);
-    } else {
-        // pattern didn't match — opt was None
-    }
-}`,
-      },
-      {
-        name: "match with a borrow in one arm",
-        code: `fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let s = String::from("hello");
-    let n = 1;
-    match n {
-        0 => {}
-        _ => show(&s),
-    }
-    show(&s);
-}`,
-      },
-      {
-        name: "match: 3 arms (consume vs borrow)",
-        code: `fn consume(_s: String) {} // rustviz: hide
-fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let s = String::from("hi");
-    let n = 1;
-    match n {
-        0 => consume(s),
-        1 => show(&s),
-        _ => show(&s),
-    }
-}`,
-      },
-      {
-        name: "if/else: move on one side, borrow on other",
-        code: `fn consume(_s: String) {} // rustviz: hide
-fn show(_s: &String) {} // rustviz: hide
-
-fn main() {
-    let s = String::from("hi");
-    let cond = true;
-    if cond {
-        consume(s);
-    } else {
-        show(&s);
-    }
 }`,
       },
       {
@@ -543,7 +480,7 @@ fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let mut s = String::from("orig");
-    let cond = true;
+    let cond = true; // rustviz: skip
     if cond {
         consume(s);
         s = String::from("new");
@@ -561,8 +498,8 @@ fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
-    let c1 = true;
-    let c2 = false;
+    let c1 = true; // rustviz: skip
+    let c2 = false; // rustviz: skip
     if c1 {
         if c2 {
             consume(s);
@@ -581,9 +518,9 @@ fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
-    let c1 = true;
-    let c2 = false;
-    let c3 = true;
+    let c1 = true; // rustviz: skip
+    let c2 = false; // rustviz: skip
+    let c3 = true; // rustviz: skip
     if c1 {
         if c2 {
             if c3 {
@@ -596,6 +533,21 @@ fn main() {
         }
     } else {
         consume(s);
+    }
+}`,
+      },
+      {
+        name: "match: 3 arms (consume vs borrow)",
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 1; // rustviz: skip
+    match n {
+        0 => consume(s),
+        1 => show(&s),
+        _ => show(&s),
     }
 }`,
       },

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -400,30 +400,36 @@ fn main() {
       },
       {
         name: "if without else",
-        code: `fn main() {
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
     let s = String::from("hi");
-    if s.len() > 0 {
-        println!("non-empty: {}", s);
+    let cond = true;
+    if cond {
+        show(&s);
     }
-    println!("{}", s);
+    show(&s);
 }`,
       },
       {
         name: "if/else with disjoint variables",
-        code: `fn main() {
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
     let cond = true;
     let a = String::from("a");
     let b = String::from("b");
     if cond {
-        println!("{}", a);
+        show(&a);
     } else {
-        println!("{}", b);
+        show(&b);
     }
 }`,
       },
       {
         name: "if/else: same var moved on one side",
-        code: `fn consume(_s: String) {}
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
@@ -431,45 +437,81 @@ fn main() {
     if cond {
         consume(s);
     } else {
-        println!("kept: {}", s);
+        show(&s);
+    }
+}`,
+      },
+      {
+        name: "if/else: move on both sides",
+        code: `fn consume(_s: String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true;
+    if cond {
+        consume(s);
+    } else {
+        consume(s);
     }
 }`,
       },
       {
         name: "match as let RHS",
-        code: `fn main() {
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
     let n = 3;
     let s = match n {
         0 => String::from("zero"),
         _ => String::from("other"),
     };
-    println!("{}", s);
+    show(&s);
 }`,
       },
       {
         name: "if let Some",
-        code: `fn main() {
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
     let opt: Option<String> = Some(String::from("x"));
     if let Some(x) = opt {
-        println!("got {}", x);
+        show(&x);
     }
 }`,
       },
       {
         name: "match with a borrow in one arm",
-        code: `fn main() {
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
     let s = String::from("hello");
     let n = 1;
     match n {
-        0 => println!("zero"),
-        _ => println!("borrowed: {}", s),
+        0 => {}
+        _ => show(&s),
     }
-    println!("after: {}", s);
+    show(&s);
+}`,
+      },
+      {
+        name: "match: 3 arms (consume vs borrow)",
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 1;
+    match n {
+        0 => consume(s),
+        1 => show(&s),
+        _ => show(&s),
+    }
 }`,
       },
       {
         name: "if/else: move on one side, borrow on other",
-        code: `fn consume(_s: String) {}
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
@@ -477,13 +519,14 @@ fn main() {
     if cond {
         consume(s);
     } else {
-        println!("borrow: {}", s);
+        show(&s);
     }
 }`,
       },
       {
         name: "rebind on both sides (\"bound here\" join)",
-        code: `fn consume(_s: String) {}
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let mut s = String::from("orig");
@@ -495,12 +538,13 @@ fn main() {
         consume(s);
         s = String::from("alt");
     }
-    println!("{}", s);
+    show(&s);
 }`,
       },
       {
         name: "nested if (move propagates outward)",
-        code: `fn consume(_s: String) {}
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
 
 fn main() {
     let s = String::from("hi");
@@ -510,7 +554,32 @@ fn main() {
         if c2 {
             consume(s);
         } else {
-            println!("kept inner: {}", s);
+            show(&s);
+        }
+    } else {
+        consume(s);
+    }
+}`,
+      },
+      {
+        name: "deeply nested if (3 levels)",
+        code: `fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let c1 = true;
+    let c2 = false;
+    let c3 = true;
+    if c1 {
+        if c2 {
+            if c3 {
+                consume(s);
+            } else {
+                show(&s);
+            }
+        } else {
+            show(&s);
         }
     } else {
         consume(s);

--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -480,6 +480,19 @@ fn main() {
 }`,
       },
       {
+        name: "if let Some / else",
+        code: `fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let opt: Option<String> = Some(String::from("x"));
+    if let Some(x) = opt {
+        show(&x);
+    } else {
+        // pattern didn't match — opt was None
+    }
+}`,
+      },
+      {
         name: "match with a borrow in one arm",
         code: `fn show(_s: &String) {} // rustviz: hide
 

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -117,6 +117,7 @@ const EXPECTED_OK: &[&str] = &[
     "match_three_arms",
     "if_let_no_else",
     "match_one_arm",
+    "match_tuple_destructure",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -793,6 +794,25 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from opt to x",
             "show reads from x",
             "x goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+            "in a conditional expression",
+        ],
+    },
+    TooltipExpect {
+        name: "match_tuple_destructure",
+        // Tuple pattern over a single tuple-typed scrutinee. Each
+        // inner binding destructures out of the same single parent
+        // (`pair`); pre-fix this panicked with index-out-of-bounds.
+        // Single-arm match also inlines.
+        must_contain: &[
+            "show reads from x",
+            "show reads from y",
+            "x goes out of scope. Its resource is dropped.",
+            "y goes out of scope. Its resource is dropped.",
         ],
         must_not_contain: &[
             "may have been moved",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -671,11 +671,14 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     TooltipExpect {
         name: "if_else_move_join",
         // Variable `s` consumed in if branch, only borrowed in else
-        // branch. Merge dot says `s` may have been moved (Rust treats
-        // it as moved regardless of which branch ran).
+        // branch. Mixed move/alive merge → drop dot with the
+        // implicit-drop explanation (Rust drops `s` at the end of
+        // any branch that didn't move it so the post-state is
+        // consistent across branches).
         must_contain: &[
             "Move from s to consume",
-            "s may have been moved (consumed in at least one branch above)",
+            "s was moved in at least one branch above; \
+             in branches that didn't, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &["merge"],
     },
@@ -694,24 +697,29 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     },
     TooltipExpect {
         name: "nested_if_move_join",
-        // Inner if: consume on one inner branch, borrow on the other
-        // → inner merge is "may have been moved". Outer if's else
-        // also consumes `s` → outer merge propagates the move.
-        // Two merge tooltips, both reading "may have been moved".
+        // Inner if: consume on one inner branch, borrow on the
+        // other → mixed → inner merge gets the implicit-drop
+        // tooltip. Outer if: both branches end without the
+        // resource (else by direct consume, then-arm by the inner
+        // merge's implicit drop) → outer merge says every branch.
         must_contain: &[
-            "s may have been moved (consumed in at least one branch above)",
+            "s was moved in at least one branch above; \
+             in branches that didn't, its resource is dropped at the branch's end.",
+            "s was moved or dropped in every branch above",
         ],
         must_not_contain: &["merge"],
     },
     TooltipExpect {
         name: "if_no_else",
         // Plain `if cond { body }` with `s` moved inside the body.
-        // The merge dot says `s` may have been moved — the implicit-
-        // untouched else means BoundHere can't fire. No "If" / "Else"
-        // tooltips: those bookend dots got dropped because they were
-        // a teaching distraction (see render_dot's Branch arm).
+        // The implicit untouched else keeps `s` alive on that
+        // path, so the merge is mixed → drop-dot tooltip with the
+        // implicit-drop wording. No "If" / "Else" bookend
+        // tooltips (dropped as a teaching distraction in
+        // render_dot's Branch arm).
         must_contain: &[
-            "s may have been moved (consumed in at least one branch above)",
+            "s was moved in at least one branch above; \
+             in branches that didn't, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &[
             "If",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -118,6 +118,18 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_no_else",
     "match_one_arm",
     "match_tuple_destructure",
+    // — Conditionals composed with iteration / capture. Verifies
+    //   the merge classifier from #116 picks the right wording
+    //   when the branches are non-trivially shaped (a closure
+    //   capture in one arm, a for-loop borrow in another, etc.).
+    //   Tooltip-level pinning lives below in EXPECTED_TOOLTIPS.
+    "cond_with_for_loop",
+    "cond_with_closure",
+    "if_inside_for",
+    "closure_with_cond",
+    "if_let_inside_for",
+    "cond_with_move_closure",
+    "match_with_closure_arms",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -873,6 +885,114 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "in branches where it was not",
             "in a conditional expression",
             "acquired ownership of a resource (in all branches above)",
+        ],
+    },
+
+    // ─── Conditionals composed with iteration / capture ──────────────
+    TooltipExpect {
+        name: "cond_with_for_loop",
+        // for-loop body in if-arm borrows `s`; else consumes.
+        // Mixed merge → drop dot + implicit-drop wording.
+        must_contain: &[
+            "Move from s to consume",
+            "show reads from s",
+            "s was moved in at least one branch above; \
+             in branches where it was not, its resource is dropped at the branch's end.",
+        ],
+        must_not_contain: &[
+            "may have been moved (consumed in at least one branch above)",
+            "moved or dropped in every branch",
+        ],
+    },
+    TooltipExpect {
+        name: "cond_with_closure",
+        // Borrow-only closure captures `s` inside if-arm; else
+        // consumes. Mixed merge → drop dot.
+        must_contain: &[
+            "Closure capture (immutable borrow) from s to f",
+            "Move from s to consume",
+            "s was moved in at least one branch above; \
+             in branches where it was not, its resource is dropped at the branch's end.",
+        ],
+        must_not_contain: &[
+            "may have been moved (consumed in at least one branch above)",
+            "moved or dropped in every branch",
+        ],
+    },
+    TooltipExpect {
+        name: "cond_with_move_closure",
+        // `move` closure captures `s` (consuming it) in if-arm;
+        // else consumes directly. Both arms end without `s` →
+        // all-moved wording.
+        must_contain: &[
+            "Closure capture (move) from s to f",
+            "Move from s to consume",
+            "s was moved or dropped in every branch above",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "in branches where it was not",
+        ],
+    },
+    TooltipExpect {
+        name: "if_inside_for",
+        // if/else inside a for-loop body, both inner arms borrow
+        // the loop variable. Inner merge classifies as Unchanged,
+        // so no merge wording surfaces.
+        must_contain: &[
+            "show reads from x",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+        ],
+    },
+    TooltipExpect {
+        name: "closure_with_cond",
+        // Closure body wraps an if/else over a captured variable;
+        // both inner arms borrow it. The closure-capture event is
+        // what surfaces at the outer scope (the if's body events
+        // live inside the closure, not on the parent timeline).
+        // No merge wording — the outer scope sees a regular
+        // closure capture + return, not a Branch.
+        must_contain: &[
+            "Closure capture (immutable borrow) from s to f",
+            "Return immutably borrowed resource from f to s",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+        ],
+    },
+    TooltipExpect {
+        name: "if_let_inside_for",
+        // Single-arm if-let inlines per #116 — no Branch event,
+        // no merge wording. Loop body's per-iteration destructure
+        // shows as inline events.
+        must_contain: &[
+            "show reads from inner",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+            "in a conditional expression",
+        ],
+    },
+    TooltipExpect {
+        name: "match_with_closure_arms",
+        // Each arm declares its own closure that borrows `s`.
+        // The capture events are per-arm. The shared scrutinee
+        // `s` stays alive throughout — no may-have-been-moved
+        // wording for it.
+        must_contain: &[
+            "Closure capture (immutable borrow) from s to f",
+            "Closure capture (immutable borrow) from s to g",
+        ],
+        must_not_contain: &[
+            "may have been moved (consumed in at least one branch above)",
         ],
     },
 ];

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -111,6 +111,7 @@ const EXPECTED_OK: &[&str] = &[
     "nested_if_move_join",
     "if_no_else",
     "if_else_mut_reassign",
+    "if_as_let_rhs_multiline",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -709,6 +710,21 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "s was moved or dropped in every branch above",
         ],
         must_not_contain: &["merge"],
+    },
+    TooltipExpect {
+        name: "if_as_let_rhs_multiline",
+        // Multi-line `let s = if cond { ... } else { ... };`. Both
+        // arms acquire `s`, so the merge is BoundHere. The pre-
+        // first-acquire rows in each arm are now Gray-Full so the
+        // rendered column stays continuous from the leading
+        // converge into the acquire event without a visible gap.
+        must_contain: &[
+            "s acquired ownership of a resource (in all branches above)",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+        ],
     },
     TooltipExpect {
         name: "if_else_mut_reassign",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -112,6 +112,9 @@ const EXPECTED_OK: &[&str] = &[
     "if_no_else",
     "if_else_mut_reassign",
     "if_as_let_rhs_multiline",
+    "if_else_move_both",
+    "deep_nested_if",
+    "match_three_arms",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -738,6 +741,58 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         ],
         must_not_contain: &[
             "may have been moved",
+            "moved or dropped in every branch",
+        ],
+    },
+    TooltipExpect {
+        name: "if_else_move_both",
+        // Both arms consume → merge is all-moved (no may-have-been
+        // hedge, no drop dot since there's no didn't-move branch
+        // to insert an implicit drop into).
+        must_contain: &[
+            "Move from s to consume",
+            "s was moved or dropped in every branch above",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "in branches that didn't",
+        ],
+    },
+    TooltipExpect {
+        name: "deep_nested_if",
+        // Three-level nesting. Each merge classifies on its own
+        // branches' end states; the outermost ends up all-moved
+        // because every path reaches a consume (some directly,
+        // some via the chain of nested merges already inserting
+        // implicit drops).
+        must_contain: &[
+            "Move from s to consume",
+            "s was moved or dropped in every branch above",
+            // At least one inner merge is the mixed implicit-drop
+            // case (consume on one path, borrow on the other).
+            "s was moved in at least one branch above; \
+             in branches that didn't, its resource is dropped at the branch's end.",
+        ],
+        must_not_contain: &[
+            // The outer merge no longer hedges with "at least one";
+            // the deepest mixed merges still do, but the corpus
+            // pins exact strings so an outer regression to the
+            // hedge wording is caught here too.
+            "may have been moved (consumed in at least one branch above)",
+        ],
+    },
+    TooltipExpect {
+        name: "match_three_arms",
+        // 3-arm match: consume, borrow, borrow. Mixed merge →
+        // implicit-drop wording. Each arm gets its own column;
+        // even/odd N just affects placement, not classification.
+        must_contain: &[
+            "Move from s to consume",
+            "s was moved in at least one branch above; \
+             in branches that didn't, its resource is dropped at the branch's end.",
+        ],
+        must_not_contain: &[
+            "may have been moved (consumed in at least one branch above)",
             "moved or dropped in every branch",
         ],
     },

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -115,6 +115,7 @@ const EXPECTED_OK: &[&str] = &[
     "if_else_move_both",
     "deep_nested_if",
     "match_three_arms",
+    "if_let_no_else",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -779,6 +780,24 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // pins exact strings so an outer regression to the
             // hedge wording is caught here too.
             "may have been moved (consumed in at least one branch above)",
+        ],
+    },
+    TooltipExpect {
+        name: "if_let_no_else",
+        // Single-arm if-let inlines: destructure Move from opt to
+        // x, then a borrow from x to show. No Branch event, so no
+        // merge tooltip wording.
+        must_contain: &[
+            "Move from Some to opt",
+            "Move from opt to x",
+            "show reads from x",
+            "x goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+            "in a conditional expression",
         ],
     },
     TooltipExpect {

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -116,6 +116,7 @@ const EXPECTED_OK: &[&str] = &[
     "deep_nested_if",
     "match_three_arms",
     "if_let_no_else",
+    "match_one_arm",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -801,6 +802,24 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         ],
     },
     TooltipExpect {
+        name: "match_one_arm",
+        // Single-arm match with an irrefutable binding. Body shows
+        // inline; the pattern's Move (s → x) emits on the
+        // destructure line; show borrows x; x drops at arm end.
+        // No Branch event, no merge tooltip.
+        must_contain: &[
+            "Move from s to x",
+            "show reads from x",
+            "x goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+            "in a conditional expression",
+        ],
+    },
+    TooltipExpect {
         name: "match_three_arms",
         // 3-arm match: consume, borrow, borrow. Mixed merge →
         // implicit-drop wording. Each arm gets its own column;
@@ -817,20 +836,22 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
     },
     TooltipExpect {
         name: "if_no_else",
-        // Plain `if cond { body }` with `s` moved inside the body.
-        // The implicit untouched else keeps `s` alive on that
-        // path, so the merge is mixed → drop-dot tooltip with the
-        // implicit-drop wording. No "If" / "Else" bookend
-        // tooltips (dropped as a teaching distraction in
-        // render_dot's Branch arm).
+        // Plain `if cond { body }`: the Branch event is now
+        // skipped (single-arm conditional). The Move from `s` to
+        // `consume` shows inline on the parent timeline, with no
+        // merge tooltip and no "live in a conditional expression"
+        // labelling.
         must_contain: &[
-            "s was moved in at least one branch above; \
-             in branches where it was not, its resource is dropped at the branch's end.",
+            "Move from s to consume",
         ],
         must_not_contain: &[
             "If",
             "Else",
             "merge",
+            "may have been moved",
+            "moved or dropped in every branch",
+            "in branches where it was not",
+            "in a conditional expression",
             "acquired ownership of a resource (in all branches above)",
         ],
     },

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -110,6 +110,7 @@ const EXPECTED_OK: &[&str] = &[
     "if_else_rebind_join",
     "nested_if_move_join",
     "if_no_else",
+    "if_else_mut_reassign",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -708,6 +709,21 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "s was moved or dropped in every branch above",
         ],
         must_not_contain: &["merge"],
+    },
+    TooltipExpect {
+        name: "if_else_mut_reassign",
+        // mut binding consumed and reassigned in each arm. At the
+        // merge `s` is bound again (every branch rebound) so the
+        // join message is BoundHere, not MovedAfter.
+        must_contain: &[
+            "Move from s to consume",
+            "Move from String::from to s",
+            "s acquired ownership of a resource (in all branches above)",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+        ],
     },
     TooltipExpect {
         name: "if_no_else",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -683,7 +683,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "Move from s to consume",
             "s was moved in at least one branch above; \
-             in branches that didn't, its resource is dropped at the branch's end.",
+             in branches where it was not, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &["merge"],
     },
@@ -709,7 +709,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // merge's implicit drop) → outer merge says every branch.
         must_contain: &[
             "s was moved in at least one branch above; \
-             in branches that didn't, its resource is dropped at the branch's end.",
+             in branches where it was not, its resource is dropped at the branch's end.",
             "s was moved or dropped in every branch above",
         ],
         must_not_contain: &["merge"],
@@ -755,7 +755,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         ],
         must_not_contain: &[
             "may have been moved",
-            "in branches that didn't",
+            "in branches where it was not",
         ],
     },
     TooltipExpect {
@@ -771,7 +771,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             // At least one inner merge is the mixed implicit-drop
             // case (consume on one path, borrow on the other).
             "s was moved in at least one branch above; \
-             in branches that didn't, its resource is dropped at the branch's end.",
+             in branches where it was not, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &[
             // The outer merge no longer hedges with "at least one";
@@ -789,7 +789,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "Move from s to consume",
             "s was moved in at least one branch above; \
-             in branches that didn't, its resource is dropped at the branch's end.",
+             in branches where it was not, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &[
             "may have been moved (consumed in at least one branch above)",
@@ -806,7 +806,7 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // render_dot's Branch arm).
         must_contain: &[
             "s was moved in at least one branch above; \
-             in branches that didn't, its resource is dropped at the branch's end.",
+             in branches where it was not, its resource is dropped at the branch's end.",
         ],
         must_not_contain: &[
             "If",

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1503,7 +1503,24 @@ impl Visualizable for VisualizationData {
 
         let mut previous_line = begin;
         for (l, e) in history {
-            states.push((previous_line, *l, previous_state.clone()));
+            // For let-as-rhs (`let s = if … { … } else { … };`) the
+            // parent's pre-branch state is OOS — the variable
+            // doesn't exist yet — but the rows between this arm's
+            // body span starting and its first acquire event are
+            // structurally passive (a column-position is reserved,
+            // we just haven't acquired into it yet). Render them
+            // as Gray rather than blank so the column stays
+            // visually continuous from the leading converge into
+            // the acquire dot. After the first state-changing
+            // event `previous_state` is no longer OOS so this
+            // conversion no-ops for subsequent pushes; the nested-
+            // branch OOS push below is in a different arm of the
+            // match and stays unaffected.
+            let pre_event_state = match previous_state {
+                State::OutOfScope => branch_state_converter(&previous_state),
+                ref s => s.clone(),
+            };
+            states.push((previous_line, *l, pre_event_state));
             match e {
                 Event::Branch { branch_history, ty, split_point, merge_point, .. } => {
                     // Timeline is empty in the middle during a branch

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -795,7 +795,7 @@ pub fn event_dot_branch_merge_moved_with_drop(my_name: &String) -> String {
     let my_name_fmt = fmt_style(my_name);
     format!(
         "{0} was moved in at least one branch above; \
-         in branches that didn't, its resource is dropped at the branch's end.",
+         in branches where it was not, its resource is dropped at the branch's end.",
         my_name_fmt
     )
 }

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -759,6 +759,19 @@ pub fn event_dot_branch_merge_moved(my_name: &String) -> String {
     )
 }
 
+/// Every branch above ended without the resource — either by a
+/// direct move/consume or because a nested merge already ended in
+/// an implicit-drop state. Distinct from the "may have been moved"
+/// wording: there's no maybe here, the variable definitely doesn't
+/// own anything after the conditional.
+pub fn event_dot_branch_merge_all_moved(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!(
+        "{0} was moved or dropped in every branch above",
+        my_name_fmt
+    )
+}
+
 /// Every branch above contributed a value that ends up in this
 /// variable (the `let s = if … { … } else { … };` shape, plus the
 /// match-as-rhs analog). After the conditional the variable owns a
@@ -767,6 +780,22 @@ pub fn event_dot_branch_merge_bound(my_name: &String) -> String {
     let my_name_fmt = fmt_style(my_name);
     format!(
         "{0} acquired ownership of a resource (in all branches above)",
+        my_name_fmt
+    )
+}
+
+/// Some-moved-some-alive case: at least one branch consumed the
+/// variable, at least one didn't. Rust treats the variable as
+/// possibly-moved after the conditional (so it can't be used) and
+/// inserts an *implicit drop* at the end of every branch where the
+/// variable wasn't moved — this keeps the merged state consistent
+/// across branches. The drop dot at the join makes that semantics
+/// visible; the tooltip names it.
+pub fn event_dot_branch_merge_moved_with_drop(my_name: &String) -> String {
+    let my_name_fmt = fmt_style(my_name);
+    format!(
+        "{0} was moved in at least one branch above; \
+         in branches that didn't, its resource is dropped at the branch's end.",
         my_name_fmt
     )
 }

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -379,6 +379,54 @@ fn compute_width(events: & mut Vec<(usize, Event)>) -> usize {
     max_width
 }
 
+// Returns (max_left, max_right) extent in BRANCH_WEIGHT units that any
+// nested branch leaf reaches from the timeline's center x. Mirrors the
+// halfway-style placement formula in `update_timeline_data`, then walks
+// each branch's recursive extent and maxes both sides separately.
+//
+// `compute_width` returns a single sum-of-children value that's adequate
+// when the layout is symmetric, but nesting (e.g. an inner if/else inside
+// the outer if's if-arm) cascades placement leftward without contributing
+// proportionally to the rightward sum, leaving the column-layout reservation
+// short on one side and the leftmost leaf intruding into the code panel.
+// Tracking left/right separately fixes that. Requires `branch.width` to
+// already be populated by `compute_width`.
+fn compute_extent(events: &Vec<(usize, Event)>) -> (i64, i64) {
+    let mut max_left: i64 = 0;
+    let mut max_right: i64 = 0;
+    for (_, ev) in events {
+        if let Event::Branch { branch_history, .. } = ev {
+            let n = branch_history.len();
+            let halfway = n / 2;
+            let mut centers: Vec<i64> = vec![0; n];
+
+            let mut running: i64 = 0;
+            for i in (0..halfway).rev() {
+                let padding = if i == halfway - 1 { 1 } else { 0 };
+                running += -(branch_history[i].width as i64 + padding);
+                centers[i] = running;
+                running -= 2;
+            }
+            running = 0;
+            for i in halfway..n {
+                let padding = if i == halfway { 1 } else { 0 };
+                running += branch_history[i].width as i64 + padding;
+                centers[i] = running;
+                running += 2;
+            }
+
+            for (i, center) in centers.iter().enumerate() {
+                let (cl, cr) = compute_extent(&branch_history[i].e_data);
+                let left_leaf = -center + cl;
+                let right_leaf = center + cr;
+                if left_leaf > max_left { max_left = left_leaf; }
+                if right_leaf > max_right { max_right = right_leaf; }
+            }
+        }
+    }
+    (max_left, max_right)
+}
+
 fn update_timeline_data(events: & mut Vec<(usize, Event)>, parent_data: &TimelineColumnData) {
     for (_, ev) in events {
         match ev {
@@ -445,12 +493,15 @@ fn compute_column_layout<'a>(
 ) -> (BTreeMap< u64, TimelineColumnData>, i32) {
     let mut resource_owners_layout = BTreeMap::new();
     let mut max_x: i64 = 0;
-    let mut w_map: HashMap<u64, i64> = HashMap::new();
+    let mut extent_map: HashMap<u64, (i64, i64)> = HashMap::new();
 
-    // get all the widths of each timeline
+    // get the left/right extent of each timeline (in BRANCH_WEIGHT units).
+    // compute_width populates branch.width as a side-effect; compute_extent
+    // then walks the same tree to derive each side's actual leaf reach.
     for (h, timeline) in visualization_data.timelines.iter_mut() {
-        let width = compute_width(&mut timeline.history);
-        w_map.insert(*h, width as i64);
+        let _ = compute_width(&mut timeline.history);
+        let extent = compute_extent(&timeline.history);
+        extent_map.insert(*h, extent);
     }
 
     // Group RAPs by their owning fn so each fn's columns get their
@@ -480,9 +531,10 @@ fn compute_column_layout<'a>(
                 None => panic!("no matching resource owner for hash {}", hash),
             };
             let mut x_space = cmp::max(70, (&(name.len() as i64) - 1) * 13);
-            let branch_width = *w_map.get(hash).unwrap() * BRANCH_WEIGHT;
-            let branch_offset = branch_width / 2;
-            x = x + x_space + branch_offset;
+            let (extent_left, extent_right) = *extent_map.get(hash).unwrap();
+            let left_px = extent_left * BRANCH_WEIGHT;
+            let right_px = extent_right * BRANCH_WEIGHT;
+            x = x + x_space + left_px;
             let title = match visualization_data.is_mut(hash) {
                 true => String::from("mutable"),
                 false => String::from("immutable"),
@@ -522,7 +574,7 @@ fn compute_column_layout<'a>(
                     is_member: timeline.resource_access_point.is_member(),
                     owner: timeline.resource_access_point.get_owner(),
                 });
-            x += branch_offset;
+            x += right_px;
         }
         // Finalize any open struct group at the end of this fn
         // (same trailing-struct fix as before, scoped per-fn).
@@ -683,13 +735,92 @@ fn render_dot(
                 // conditional, which read as a stray dot on
                 // unrelated code below. Empty title for the
                 // Unchanged case keeps it as a structural marker.
-                let m_data = EventDotData {
-                    hash: *hash as u64,
-                    dot_x: timeline_data.x_val,
-                    dot_y: get_y_axis_pos(*merge_point),
-                    title: branch_join_message(branch_history, ty, &is.real_name()),
-                };
-                append_dot(&m_data, output, timeline_data, registry);
+                //
+                // When some branches moved the variable and at
+                // least one didn't, Rust inserts an *implicit
+                // drop* at the end of the non-moving branches so
+                // the merged state stays consistent. Render the
+                // merge dot as a drop dot (down-arrow triangle
+                // inside the circle, same shape as a regular OOS
+                // drop) and use a tooltip that explains the
+                // semantics. The all-moved and all-alive cases
+                // get the regular dot — no implicit drop is
+                // inserted in those situations.
+                // Look at each branch's *effective* end state — what
+                // `branch.states.last()` reports — rather than just
+                // walking events for syntactic Move/Acquire. That's
+                // what carries the implicit-drop result of any
+                // nested merge already in the column: an outer
+                // branch whose body is `if c2 { consume(s) } else
+                // { ... }` ends with ResourceMoved even though
+                // there's no syntactic Move directly in the outer
+                // branch's events.
+                let any_moved = branch_history.iter().any(|b| {
+                    b.states.last()
+                        .map(|s| !state_is_alive(&s.2))
+                        .unwrap_or(true)
+                });
+                let any_alive = branch_history.iter().any(|b| {
+                    b.states.last()
+                        .map(|s| state_is_alive(&s.2))
+                        .unwrap_or(false)
+                });
+                // `if cond { … }` records one branch; the implicit
+                // untouched else still keeps the resource alive on
+                // the path the user didn't write. Treat that
+                // implicit path as an alive branch when classifying
+                // the merge: an all-moved-recorded if-without-else
+                // is semantically a *mixed* merge (drop dot), not an
+                // every-branch one.
+                let has_implicit_untouched = !all_paths_present(ty, branch_history.len());
+                let mixed_moved = (any_moved && any_alive)
+                    || (any_moved && has_implicit_untouched);
+                let all_moved = !any_alive
+                    && !branch_history.is_empty()
+                    && !has_implicit_untouched;
+                let cx = timeline_data.x_val;
+                let cy = get_y_axis_pos(*merge_point);
+                if mixed_moved {
+                    // Mixed: at least one branch moved, at least
+                    // one didn't (counting the implicit untouched
+                    // else of an `if` without an else as a
+                    // didn't-move branch). Rust inserts an
+                    // implicit drop in the non-moving branches so
+                    // the post state matches; the drop dot at the
+                    // merge makes that visible.
+                    let title = hover_messages::event_dot_branch_merge_moved_with_drop(&is.real_name());
+                    let drop_data = DropDotData {
+                        hash: *hash as u64,
+                        dot_x: cx,
+                        dot_y: cy,
+                        title,
+                        p1x: cx - 3, p1y: cy - 1,
+                        p2x: cx + 3, p2y: cy - 1,
+                        p3x: cx,     p3y: cy + 3,
+                    };
+                    append_drop_dot(&drop_data, output, timeline_data, registry);
+                } else if all_moved {
+                    // Every branch ends without the resource —
+                    // either by a direct move or by an implicit
+                    // drop already inserted at a nested merge.
+                    // Don't say "at least one"; pin it as "every".
+                    let title = hover_messages::event_dot_branch_merge_all_moved(&is.real_name());
+                    let m_data = EventDotData {
+                        hash: *hash as u64,
+                        dot_x: cx,
+                        dot_y: cy,
+                        title,
+                    };
+                    append_dot(&m_data, output, timeline_data, registry);
+                } else {
+                    let m_data = EventDotData {
+                        hash: *hash as u64,
+                        dot_x: cx,
+                        dot_y: cy,
+                        title: branch_join_message(branch_history, ty, &is.real_name()),
+                    };
+                    append_dot(&m_data, output, timeline_data, registry);
+                }
                 continue;
             }
             _ => {} //do nothing
@@ -2029,12 +2160,14 @@ fn render_branches(
                 // empty branches dash; the leading active arm
                 // renders solid.
                 let leading_dashed = branch.e_data.is_empty() || i != 0;
-                // Trailing edge style: tracks the branch's
-                // ending state (Gray → dashed, anything else →
-                // solid). Lets `else { println!(s) }` (active arm
-                // with no surfaced events but Owner end-state)
-                // converge solid into the join dot.
-                let trailing_dashed = matches!(
+                // Trailing edge style: solid when the branch still
+                // owns the resource at the join; dashed when it
+                // ended Gray (passive owner) or doesn't own
+                // anything anymore (moved / OOS). The dashed-when-
+                // not-alive case is what makes flow lines reach
+                // the join dot even after a Move — without it the
+                // merge dot floats with no incoming convergences.
+                let trailing_dashed = !state_is_alive(&e_state) || matches!(
                     e_state,
                     State::FullPrivilege { s: LineState::Gray }
                     | State::PartialPrivilege { s: LineState::Gray }
@@ -2112,6 +2245,12 @@ fn render_branches(
                         title: title.clone(),
                     });
                 }
+                // Trailing converge from column bottom to the merge
+                // dot, gated on `alive_at_end`. A branch that
+                // ended in a Move (or any non-owning state)
+                // terminates its column at the move event, same as
+                // a Move anywhere else in a timeline — no
+                // post-move diagonal continues toward the join.
                 if alive_at_end {
                     segs.push(CenterSeg {
                         style: trailing_dashed,
@@ -2119,6 +2258,37 @@ fn render_branches(
                         p2: (parent_x, merge_y),
                         title: e_title.clone(),
                     });
+                }
+
+                // Split segs into runs of centerline-contiguous
+                // segments. A run is a maximal subsequence where
+                // consecutive segments meet at the same centerline
+                // point — i.e. the strip is one continuous shape.
+                // A break appears when a parent branch's body span
+                // is taken over by a nested Branch event, leaving
+                // the parent's leading ending at line N and its
+                // trailing starting many rows below with empty
+                // body in between. Each run is rendered as its own
+                // strip (its own polylines + perimeter polygon)
+                // so the gap stays empty rather than getting
+                // bridged with a phantom column or a polygon that
+                // covers rows the parent doesn't own.
+                let mut runs: Vec<Vec<&CenterSeg>> = Vec::new();
+                {
+                    let mut current: Vec<&CenterSeg> = Vec::new();
+                    let mut last_p2: Option<(f64, f64)> = None;
+                    for seg in &segs {
+                        if let Some(p) = last_p2 {
+                            let gap = (p.0 - seg.p1.0).abs() > 1e-6
+                                || (p.1 - seg.p1.1).abs() > 1e-6;
+                            if gap && !current.is_empty() {
+                                runs.push(std::mem::take(&mut current));
+                            }
+                        }
+                        current.push(seg);
+                        last_p2 = Some(seg.p2);
+                    }
+                    if !current.is_empty() { runs.push(current); }
                 }
 
                 // Build per-side edge lists (LEFT = +sign offsets
@@ -2135,12 +2305,12 @@ fn render_branches(
                 // dashed-leading → solid-body transition keeps the
                 // bevel dashed (matching what the user reads as
                 // "the leading edge ends here").
-                let build_edges = |sign: f64| -> Vec<(bool, (f64, f64), (f64, f64), String)> {
+                let build_edges = |run: &[&CenterSeg], sign: f64| -> Vec<(bool, (f64, f64), (f64, f64), String)> {
                     let mut edges: Vec<(bool, (f64, f64), (f64, f64), String)> = Vec::new();
                     let mut prev_off_p2: Option<(f64, f64)> = None;
                     let mut prev_style: Option<bool> = None;
                     let mut prev_title: Option<String> = None;
-                    for seg in &segs {
+                    for seg in run {
                         let perp = perp_unit(seg.p1, seg.p2);
                         let off_x = perp.0 * sign * half_w;
                         let off_y = perp.1 * sign * half_w;
@@ -2188,52 +2358,50 @@ fn render_branches(
                     path
                 };
 
-                // Build everything for both sides up-front so we
-                // can wrap the whole branch in a `<g>` for unified
-                // hover highlighting.
-                let left_edges = build_edges(1.0);
-                let right_edges = build_edges(-1.0);
-                let left_path = path_from_edges(&left_edges);
-                let right_path = path_from_edges(&right_edges);
-
                 let mut branch_svg = String::new();
 
-                for (style, pts, title) in group_edges(left_edges)
-                    .into_iter()
-                    .chain(group_edges(right_edges).into_iter())
-                {
-                    let pts_str = pts.iter()
-                        .map(|p| format!("{},{}", p.0, p.1))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    let dasharray = if style { "4 4" } else { "none" };
-                    branch_svg.push_str(&format!(
-                        "            <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
-                        hash, pts_str, title, dasharray,
-                    ));
-                }
+                for run in &runs {
+                    let left_edges = build_edges(run, 1.0);
+                    let right_edges = build_edges(run, -1.0);
+                    let left_path = path_from_edges(&left_edges);
+                    let right_path = path_from_edges(&right_edges);
 
-                // Hover capture: a transparent `<polygon>` that
-                // traces the strip's perimeter (left path forward
-                // + right path reversed). The visible polylines
-                // are 1.5px-wide and the gap between the two
-                // parallel sides isn't covered by any element on
-                // its own; without this polygon, hovering in that
-                // gap fired no tooltip. `pointer-events:fill` so
-                // the transparent fill still receives mouse
-                // events.
-                let mut perim: Vec<(f64, f64)> = Vec::new();
-                perim.extend(left_path.iter().cloned());
-                perim.extend(right_path.iter().rev().cloned());
-                if perim.len() >= 3 {
-                    let pts_str = perim.iter()
-                        .map(|p| format!("{},{}", p.0, p.1))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    branch_svg.push_str(&format!(
-                        "            <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
-                        hash, pts_str, p_title,
-                    ));
+                    for (style, pts, title) in group_edges(left_edges)
+                        .into_iter()
+                        .chain(group_edges(right_edges).into_iter())
+                    {
+                        let pts_str = pts.iter()
+                            .map(|p| format!("{},{}", p.0, p.1))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let dasharray = if style { "4 4" } else { "none" };
+                        branch_svg.push_str(&format!(
+                            "            <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
+                            hash, pts_str, title, dasharray,
+                        ));
+                    }
+
+                    // Hover capture: a transparent <polygon>
+                    // tracing this run's perimeter (left forward +
+                    // right reversed). The visible polylines are
+                    // 1.5px-wide and the gap between them isn't
+                    // covered without this polygon. `pointer-events:
+                    // fill` lets the transparent fill receive mouse
+                    // events. One polygon per run keeps the hover
+                    // surface aligned with what's actually drawn.
+                    let mut perim: Vec<(f64, f64)> = Vec::new();
+                    perim.extend(left_path.iter().cloned());
+                    perim.extend(right_path.iter().rev().cloned());
+                    if perim.len() >= 3 {
+                        let pts_str = perim.iter()
+                            .map(|p| format!("{},{}", p.0, p.1))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        branch_svg.push_str(&format!(
+                            "            <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
+                            hash, pts_str, p_title,
+                        ));
+                    }
                 }
 
                 // Wrap polylines + polygon in a `<g class="branch-

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -303,11 +303,22 @@ fn prepare_registry(registry: &mut Handlebars) {
     // segments — dashed leading + solid body + dashed trailing —
     // meet at exact y-coordinates with nothing between them, and
     // the column reads as one continuous strip with two textures.
-    let new_hollow_line_template = "<g class=\"tooltip-trigger\" data-tooltip-text=\"{{title}}\">\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x1}}\" y1=\"{{y1}}\" x2=\"{{x2}}\" y2=\"{{y2}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x4}}\" y1=\"{{y4}}\" x2=\"{{x3}}\" y2=\"{{y3}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n        </g>\n";
+    // Hollow column = two thin parallel lines plus a transparent
+    // fill polygon over the gap between them. The polygon catches
+    // mouse events in the strip's interior so hovering anywhere
+    // inside the column (not just precisely on a line) fires the
+    // wrapping `<g>`'s tooltip + glow. Without it, the cursor had
+    // to land on one of the 1.5px line strokes to highlight.
+    // (Same hover-capture pattern as branch strips in render_branch_run.)
+    let new_hollow_line_template = "<g class=\"tooltip-trigger\" data-tooltip-text=\"{{title}}\">\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x1}}\" y1=\"{{y1}}\" x2=\"{{x2}}\" y2=\"{{y2}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n            <line data-hash=\"{{hash}}\" class=\"hollow\" x1=\"{{x4}}\" y1=\"{{y4}}\" x2=\"{{x3}}\" y2=\"{{y3}}\" style=\"stroke-opacity: {{opacity}}; stroke-dasharray: {{dasharray}};\"/>\n            <polygon data-hash=\"{{hash}}\" points=\"{{x1}},{{y1}} {{x2}},{{y2}} {{x3}},{{y3}} {{x4}},{{y4}}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n        </g>\n";
+    // Borrow-region trapezoids — visible as outlines (fill is
+    // transparent), but `pointer-events:all` makes the fill area
+    // hit-test too so hovering anywhere inside the trapezoid fires
+    // the tooltip + glow, not just on the 2px outline strokes.
     let solid_ref_line_template =
-        "        <path data-hash=\"{{hash}}\" class=\"mutref {{line_class}} tooltip-trigger\" style=\"fill:transparent; stroke-width: 2px !important;\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
+        "        <path data-hash=\"{{hash}}\" class=\"mutref {{line_class}} tooltip-trigger\" style=\"fill:transparent; stroke-width: 2px !important; pointer-events: all;\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
     let hollow_ref_line_template =
-        "        <path data-hash=\"{{hash}}\" class=\"staticref tooltip-trigger\" style=\"fill: transparent;\" stroke-width=\"2px\" stroke-dasharray=\"3\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
+        "        <path data-hash=\"{{hash}}\" class=\"staticref tooltip-trigger\" style=\"fill: transparent; pointer-events: all;\" stroke-width=\"2px\" stroke-dasharray=\"3\" d=\"M {{x1}} {{y1}} l {{dx}} {{dy}} v {{v}} l -{{dx}} {{dy}}\" data-tooltip-text=\"{{title}}\"/>\n";
     let box_template =
         "        <rect id=\"{{name}}\" x=\"{{x}}\" y=\"{{y}}\" rx=\"20\" ry=\"20\" width=\"{{w}}\" height=\"{{h}}\" style=\"fill:white;stroke:black;stroke-width:3;opacity:0.1\" pointer-events=\"none\" />\n";
 

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1,5 +1,5 @@
 extern crate handlebars;
-use crate::svg_generator::data::{convert_back, string_of_external_event, BranchData, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
+use crate::svg_generator::data::{branch_state_converter, convert_back, string_of_external_event, BranchData, BranchType, Event, ExternalEvent, LineState, ResourceAccessPoint, ResourceAccessPoint_extract, ResourceTy, State, StructsInfo, Visualizable, VisualizationData, LINE_SPACE};
 use crate::svg_generator::hover_messages;
 use crate::svg_generator::svg_frontend::line_styles::OwnerLine;
 use handlebars::Handlebars;
@@ -2011,106 +2011,80 @@ fn append_line(
     }
 }
 
-// ── Branch column rendering: invariants ────────────────────────────
+// ── Branch column rendering ────────────────────────────────────────
 //
-// A branch's column-plus-convergences is rendered from three
-// pieces of the variable's lifecycle within the branch:
+// A branch event renders as one strip per recorded arm. Each arm's
+// strip is a sequence of segments:
 //
-//   • A leading convergence diagonal (parent split dot → top of
-//     column) — emitted iff the variable is "alive" entering the
-//     branch (i.e., owns or borrows a resource — not in OOS or
-//     ResourceMoved).
-//   • A column body, sliced into per-style runs (solid for
-//     active-arm states, dashed for Gray-converted passive-arm
-//     states). Unrenderable states (OOS, ResourceMoved) drop out
-//     of the body — the column visually ends where the variable
-//     stops owning a resource.
-//   • A trailing convergence diagonal (column bottom → parent
-//     merge dot) — emitted iff the variable is "alive" leaving
-//     the branch.
+//   leading converge:  (parent split-dot) → (top of branch column)
+//   body:              one per `branch.states` segment
+//   trailing converge: (bottom of branch column) → (parent merge-dot)
 //
-// The classifiers below name these decisions explicitly so the
-// renderer can never silently bridge across an empty body. The
-// previous regression was exactly that: leading and trailing
-// pieces both rendered solid, and `merge consecutive same-style
-// pieces` collapsed them into a single polyline that "stitched
-// over" a Move event. Naming the rule (`alive_at_end`) and
-// gating the trailing piece on it pulls that invariant into one
-// place where it can be tested and maintained.
+// Every segment carries the State that drives its rendering. The
+// per-segment style decision goes through `determine_owner_line_styles`
+// — the same classifier the regular column uses — so the branch
+// strip honors mut-vs-immut and PartialPrivilege identically to a
+// non-branch column. Gray states (the convention for "this row
+// belongs to a different arm") get a dashed stroke regardless of
+// solid/hollow.
+//
+// Structural invariants:
+//
+//   * The leading converge is dropped when the parent's pre-branch
+//     state classifies as Empty (variable not alive entering the
+//     branch). Synthesized to FullPrivilege::Full for let-as-rhs,
+//     where the parent state is OOS but the branch is about to
+//     bring the variable into scope.
+//   * The trailing converge is dropped when the branch's last
+//     state classifies as Empty. A Move terminates the column at
+//     the move event; nothing diagonal trails toward the merge.
+//   * Body segments with Empty classification (OOS / Moved) drop
+//     out, so a Move mid-body ends the visible column right there.
+//   * Segments are grouped into centerline-contiguous runs before
+//     rendering. A run is a maximal subsequence whose adjacent
+//     segments meet at the same centerline point. When a parent
+//     branch's body span is taken over by a nested Branch event
+//     (leading ends at line N, trailing starts many rows later,
+//     no body in between), each becomes its own run with its own
+//     hover polygon — the gap stays empty rather than getting
+//     bridged.
 
-/// Classifier for branch column body segments. Returns:
-///   • `Some(true)`  for a dashed segment (Gray-converted, the
-///     branch is the inactive path on this row).
-///   • `Some(false)` for a solid segment (FullPrivilege /
-///     PartialPrivilege at LineState::Full — the active path).
-///   • `None` for states that don't draw a column line
-///     (OutOfScope, ResourceMoved). Their absence in the body
-///     run terminates the column visually so the variable's
-///     "departure" (Move, scope end) is reflected in the column
-///     ending, not in a stray faded line.
-fn segment_style(state: &State) -> Option<bool> {
-    match state {
-        State::FullPrivilege { s: LineState::Gray }
-        | State::PartialPrivilege { s: LineState::Gray } => Some(true),
-        State::FullPrivilege { s: LineState::Full }
-        | State::PartialPrivilege { s: LineState::Full } => Some(false),
-        _ => None,
-    }
-}
-
-/// Whether the variable owns / can-borrow a resource at this
-/// state. The convergence diagonals only render when the variable
-/// is alive at the corresponding branch boundary — drawing them
-/// otherwise would bridge a terminated column to the join dot
-/// across rows that should be empty.
+/// Whether the variable still owns / can-borrow a resource at this
+/// state. Used by the merge-dot classifier to decide between the
+/// drop-dot (mixed branches), all-moved, and unchanged tooltips.
 fn state_is_alive(state: &State) -> bool {
-    !matches!(
-        state,
-        State::ResourceMoved { .. } | State::OutOfScope
-    )
+    !matches!(state, State::ResourceMoved { .. } | State::OutOfScope)
 }
 
-/// Unit-length perpendicular to the line `p1 → p2`. Used to offset
-/// each side of the strip by `half_w` perpendicular to the line
-/// direction so the *visual* gap between the two parallel sides is
-/// constant regardless of angle. Pre-fix the offset was applied in
-/// the x-axis only, which made diagonals' visual gap shrink as
-/// `cos(θ)` (a 40° diagonal was ~23% narrower than the vertical
-/// body), and the user noticed the diagonals reading as "too close
-/// together" compared to the column.
+/// Half-width of a hollow strip — matches `compute_hollow_line_data`'s
+/// `w = 3.5 / 2`, so branch strips share endpoint coordinates with
+/// regular columns at the seams.
+const BRANCH_HALF_W: f64 = 1.75;
+
+/// One centerline segment of a branch's strip. The state drives
+/// rendering style via `determine_owner_line_styles`.
+struct BranchSeg {
+    p1: (f64, f64),
+    p2: (f64, f64),
+    state: State,
+    title: String,
+}
+
+/// Unit-length perpendicular to `p1 → p2`. Used to offset the two
+/// sides of a hollow strip by `±BRANCH_HALF_W` perpendicular to the
+/// segment direction so the visual gap between sides is constant
+/// regardless of angle (a vertical body and a 45° diagonal both
+/// read at the same width).
 fn perp_unit(p1: (f64, f64), p2: (f64, f64)) -> (f64, f64) {
     let dx = p2.0 - p1.0;
     let dy = p2.1 - p1.1;
     let len = (dx * dx + dy * dy).sqrt();
-    if len < 1e-9 {
-        return (1.0, 0.0);
-    }
+    if len < 1e-9 { return (1.0, 0.0); }
     (-dy / len, dx / len)
 }
 
-/// One centerline segment of a branch's strip — the leading
-/// convergence, a body state run, or the trailing convergence.
-/// Each segment carries its own style (dashed/solid) and a
-/// tooltip; offsets are applied per-side at render time.
-struct CenterSeg {
-    style: bool, // dashed
-    p1: (f64, f64),
-    p2: (f64, f64),
-    title: String,
-}
-
-/// Render every branch (and any nested branches) reachable through
-/// `history`. Each branch's column-plus-convergence is emitted as
-/// `<polyline>` elements: one per side of the strip, broken at
-/// style boundaries (solid ↔ dashed). Adjacent polylines share
-/// endpoints exactly so a dashed leading edge meets the column's
-/// dashed leading run with no gap, the column's solid body meets
-/// the trailing solid wedge with no gap, etc.
-///
-/// Replaces the previous "split_line + body + merge_line" trio of
-/// independently-rendered strip elements, where the strip-via-
-/// perpendicular orientation of the diagonals didn't line up with
-/// the column's horizontal-perpendicular sides at the corners.
+/// Render every Branch event reachable through `history`. Recurses
+/// into nested branches.
 fn render_branches(
     hash: &u64,
     rap: &ResourceAccessPoint,
@@ -2122,322 +2096,227 @@ fn render_branches(
 ) {
     if rap.is_fn() { return; }
     for (_, ev) in history {
-        if let Event::Branch { branch_history, split_point, merge_point, .. } = ev {
-            // Find the parent state segment that *covers* the
-            // split point. Range-containment (rather than exact
-            // end-line match) handles the let-as-rhs case where
-            // the parent's pre-branch and during-branch OOS
-            // segments get merged by clean_states.
-            let begin_state = parent_states.iter()
-                .find(|item| item.0 <= *split_point && *split_point <= item.1)
-                .cloned()
-                .unwrap_or((0, 0, State::OutOfScope));
-            // Let-as-rhs (variable doesn't exist before the
-            // conditional, parent state is OOS): synthesize a
-            // FullPrivilege::Full leading state so the active
-            // arm's leading diagonal has something to render. The
-            // passive-arm dasharray override below handles the
-            // alternates.
-            let p_state = match begin_state.2 {
-                State::OutOfScope => State::FullPrivilege { s: LineState::Full },
-                ref s => convert_back(s),
+        let Event::Branch { branch_history, split_point, merge_point, .. } = ev else { continue };
+
+        let parent_x = timeline_data.x_val as f64;
+        let split_y = get_y_axis_pos(*split_point) as f64;
+        let merge_y = get_y_axis_pos(*merge_point) as f64;
+        let column_top_y = get_y_axis_pos(*split_point + 1) as f64;
+        let column_bot_y = get_y_axis_pos(merge_point.saturating_sub(1)) as f64;
+
+        // Parent's state at the split, with let-as-rhs synthesized
+        // to FullPrivilege::Full (the variable's about to be
+        // brought into scope by acquiring inside a branch). The
+        // active arm uses this directly; passive arms Gray-convert
+        // it so their leading reads as inactive.
+        let parent_pre = parent_states.iter()
+            .find(|(s, e, _)| *s <= *split_point && *split_point <= *e)
+            .map(|item| item.2.clone())
+            .unwrap_or(State::OutOfScope);
+        let parent_active = match parent_pre {
+            State::OutOfScope => State::FullPrivilege { s: LineState::Full },
+            ref s => convert_back(s),
+        };
+
+        for (i, branch) in branch_history.iter().enumerate() {
+            let branch_x = branch.t_data.x_val as f64;
+            // Active arm: i == 0 with non-empty body. Other arms,
+            // and any empty body, render passive (Gray-converted
+            // leading so it's dashed).
+            let is_active = i == 0 && !branch.e_data.is_empty();
+            let leading_state = if is_active {
+                parent_active.clone()
+            } else {
+                branch_state_converter(&parent_active)
             };
-            let p_title = timeline_segment_title(&p_state, rap, visualization_data);
+            let end_state = branch.states.last()
+                .map(|s| s.2.clone())
+                .unwrap_or(State::OutOfScope);
 
-            // Half the hollow column's strip width — matches
-            // `compute_hollow_line_data`'s w=3.5 / 2 on a vertical
-            // line, so the polyline endpoints share coordinates
-            // with the column body's two parallel `<line>`s.
-            let half_w: f64 = 1.75;
-            let parent_x = timeline_data.x_val as f64;
-
-            for (i, branch) in branch_history.iter().enumerate() {
-                let branch_x = branch.t_data.x_val as f64;
-                let e_state = branch.states.last().map(|s| s.2.clone()).unwrap_or(State::OutOfScope);
-                let e_title = timeline_segment_title(&e_state, rap, visualization_data);
-
-                // Leading edge style: passive arms (i != 0) and
-                // empty branches dash; the leading active arm
-                // renders solid.
-                let leading_dashed = branch.e_data.is_empty() || i != 0;
-                // Trailing edge style: solid when the branch still
-                // owns the resource at the join; dashed when it
-                // ended Gray (passive owner) or doesn't own
-                // anything anymore (moved / OOS). The dashed-when-
-                // not-alive case is what makes flow lines reach
-                // the join dot even after a Move — without it the
-                // merge dot floats with no incoming convergences.
-                let trailing_dashed = !state_is_alive(&e_state) || matches!(
-                    e_state,
-                    State::FullPrivilege { s: LineState::Gray }
-                    | State::PartialPrivilege { s: LineState::Gray }
-                );
-
-                // Body groups: contiguous-style runs of state
-                // segments. Zero-length and unrenderable states
-                // (OOS, ResourceMoved, ...) drop out so the
-                // surrounding polylines connect through the gap.
-                let mut groups: Vec<(bool, usize, usize, String)> = Vec::new();
-                for seg in &branch.states {
-                    if seg.0 == seg.1 { continue; }
-                    if let Some(dashed) = segment_style(&seg.2) {
-                        let title = timeline_segment_title(&seg.2, rap, visualization_data);
-                        if let Some(last) = groups.last_mut() {
-                            if last.0 == dashed && last.2 == seg.0 {
-                                last.2 = seg.1;
-                                continue;
-                            }
-                        }
-                        groups.push((dashed, seg.0, seg.1, title));
-                    }
-                }
-
-                // Lifecycle invariants — see the architectural
-                // note above this fn. Render the leading edge only
-                // when the variable is alive entering the branch;
-                // render the trailing edge only when alive leaving
-                // the branch. Without these gates a Move at the
-                // top of the body and a still-solid trailing
-                // convergence would form a polyline that bridged
-                // over the Move, putting a stray column line on a
-                // row the variable doesn't exist on.
-                //
-                // `alive_at_start` is checked on the *synthesized*
-                // `p_state` rather than the raw `begin_state.2`.
-                // For let-as-rhs (`let s = if … { … } else { … };`)
-                // the parent's pre-branch state is OutOfScope —
-                // the variable doesn't exist yet — but the branch
-                // *is* about to bring it into scope by acquiring.
-                // The synthesis above maps OOS → FullPrivilege so
-                // the leading diagonal has a renderable state, and
-                // the liveness check needs to run on that mapped
-                // state too, otherwise the leading edge falls off
-                // for every let-as-rhs binding.
-                let alive_at_start = state_is_alive(&p_state);
-                let alive_at_end = state_is_alive(&e_state);
-
-                // Build the centerline segment list for this branch.
-                // Each segment carries its own style and tooltip;
-                // perpendicular offsets get applied per-side below.
-                // The segments line up centerline-end to centerline-
-                // start at every transition, so the two sides are
-                // built by walking the same segment list with
-                // different offset signs.
-                let split_y = get_y_axis_pos(*split_point) as f64;
-                let merge_y = get_y_axis_pos(*merge_point) as f64;
-                let column_top_y = get_y_axis_pos(*split_point + 1) as f64;
-                let column_bot_y = get_y_axis_pos(merge_point.saturating_sub(1)) as f64;
-
-                let mut segs: Vec<CenterSeg> = Vec::new();
-                if alive_at_start {
-                    segs.push(CenterSeg {
-                        style: leading_dashed,
-                        p1: (parent_x, split_y),
-                        p2: (branch_x, column_top_y),
-                        title: p_title.clone(),
-                    });
-                }
-                for (dashed, top, bot, title) in &groups {
-                    segs.push(CenterSeg {
-                        style: *dashed,
-                        p1: (branch_x, get_y_axis_pos(*top) as f64),
-                        p2: (branch_x, get_y_axis_pos(*bot) as f64),
-                        title: title.clone(),
-                    });
-                }
-                // Trailing converge from column bottom to the merge
-                // dot, gated on `alive_at_end`. A branch that
-                // ended in a Move (or any non-owning state)
-                // terminates its column at the move event, same as
-                // a Move anywhere else in a timeline — no
-                // post-move diagonal continues toward the join.
-                if alive_at_end {
-                    segs.push(CenterSeg {
-                        style: trailing_dashed,
-                        p1: (branch_x, column_bot_y),
-                        p2: (parent_x, merge_y),
-                        title: e_title.clone(),
-                    });
-                }
-
-                // Split segs into runs of centerline-contiguous
-                // segments. A run is a maximal subsequence where
-                // consecutive segments meet at the same centerline
-                // point — i.e. the strip is one continuous shape.
-                // A break appears when a parent branch's body span
-                // is taken over by a nested Branch event, leaving
-                // the parent's leading ending at line N and its
-                // trailing starting many rows below with empty
-                // body in between. Each run is rendered as its own
-                // strip (its own polylines + perimeter polygon)
-                // so the gap stays empty rather than getting
-                // bridged with a phantom column or a polygon that
-                // covers rows the parent doesn't own.
-                let mut runs: Vec<Vec<&CenterSeg>> = Vec::new();
-                {
-                    let mut current: Vec<&CenterSeg> = Vec::new();
-                    let mut last_p2: Option<(f64, f64)> = None;
-                    for seg in &segs {
-                        if let Some(p) = last_p2 {
-                            let gap = (p.0 - seg.p1.0).abs() > 1e-6
-                                || (p.1 - seg.p1.1).abs() > 1e-6;
-                            if gap && !current.is_empty() {
-                                runs.push(std::mem::take(&mut current));
-                            }
-                        }
-                        current.push(seg);
-                        last_p2 = Some(seg.p2);
-                    }
-                    if !current.is_empty() { runs.push(current); }
-                }
-
-                // Build per-side edge lists (LEFT = +sign offsets
-                // perp.x < 0 outward, RIGHT = -sign). Each segment
-                // contributes one main edge at its perp-offset
-                // endpoints. Where two consecutive segments have
-                // different perp directions (the leading/body and
-                // body/trailing transitions are the canonical
-                // cases — diagonals rotate the perp away from the
-                // body's horizontal), a small bevel edge connects
-                // the previous segment's offset endpoint to the
-                // current segment's offset endpoint. The bevel
-                // inherits the *previous* segment's style so a
-                // dashed-leading → solid-body transition keeps the
-                // bevel dashed (matching what the user reads as
-                // "the leading edge ends here").
-                let build_edges = |run: &[&CenterSeg], sign: f64| -> Vec<(bool, (f64, f64), (f64, f64), String)> {
-                    let mut edges: Vec<(bool, (f64, f64), (f64, f64), String)> = Vec::new();
-                    let mut prev_off_p2: Option<(f64, f64)> = None;
-                    let mut prev_style: Option<bool> = None;
-                    let mut prev_title: Option<String> = None;
-                    for seg in run {
-                        let perp = perp_unit(seg.p1, seg.p2);
-                        let off_x = perp.0 * sign * half_w;
-                        let off_y = perp.1 * sign * half_w;
-                        let off_p1 = (seg.p1.0 + off_x, seg.p1.1 + off_y);
-                        let off_p2 = (seg.p2.0 + off_x, seg.p2.1 + off_y);
-                        if let (Some(prev_p2), Some(prev_st), Some(prev_t)) =
-                            (prev_off_p2, prev_style, prev_title.clone())
-                        {
-                            let diff_x = (prev_p2.0 - off_p1.0).abs();
-                            let diff_y = (prev_p2.1 - off_p1.1).abs();
-                            if diff_x > 1e-6 || diff_y > 1e-6 {
-                                edges.push((prev_st, prev_p2, off_p1, prev_t));
-                            }
-                        }
-                        edges.push((seg.style, off_p1, off_p2, seg.title.clone()));
-                        prev_off_p2 = Some(off_p2);
-                        prev_style = Some(seg.style);
-                        prev_title = Some(seg.title.clone());
-                    }
-                    edges
-                };
-
-                let group_edges = |edges: Vec<(bool, (f64, f64), (f64, f64), String)>| -> Vec<(bool, Vec<(f64, f64)>, String)> {
-                    let mut polylines: Vec<(bool, Vec<(f64, f64)>, String)> = Vec::new();
-                    for (style, p1, p2, title) in edges {
-                        if let Some(last) = polylines.last_mut() {
-                            if last.0 == style && last.1.last() == Some(&p1) {
-                                last.1.push(p2);
-                                continue;
-                            }
-                        }
-                        polylines.push((style, vec![p1, p2], title));
-                    }
-                    polylines
-                };
-
-                let path_from_edges = |edges: &[(bool, (f64, f64), (f64, f64), String)]| -> Vec<(f64, f64)> {
-                    let mut path: Vec<(f64, f64)> = Vec::new();
-                    if let Some(first) = edges.first() {
-                        path.push(first.1);
-                    }
-                    for e in edges {
-                        path.push(e.2);
-                    }
-                    path
-                };
-
-                let mut branch_svg = String::new();
-
-                for run in &runs {
-                    let left_edges = build_edges(run, 1.0);
-                    let right_edges = build_edges(run, -1.0);
-                    let left_path = path_from_edges(&left_edges);
-                    let right_path = path_from_edges(&right_edges);
-
-                    for (style, pts, title) in group_edges(left_edges)
-                        .into_iter()
-                        .chain(group_edges(right_edges).into_iter())
-                    {
-                        let pts_str = pts.iter()
-                            .map(|p| format!("{},{}", p.0, p.1))
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        let dasharray = if style { "4 4" } else { "none" };
-                        branch_svg.push_str(&format!(
-                            "            <polyline data-hash=\"{}\" class=\"hollow tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:none; stroke-opacity: 1.0; stroke-dasharray: {};\"/>\n",
-                            hash, pts_str, title, dasharray,
-                        ));
-                    }
-
-                    // Hover capture: a transparent <polygon>
-                    // tracing this run's perimeter (left forward +
-                    // right reversed). The visible polylines are
-                    // 1.5px-wide and the gap between them isn't
-                    // covered without this polygon. `pointer-events:
-                    // fill` lets the transparent fill receive mouse
-                    // events. One polygon per run keeps the hover
-                    // surface aligned with what's actually drawn.
-                    let mut perim: Vec<(f64, f64)> = Vec::new();
-                    perim.extend(left_path.iter().cloned());
-                    perim.extend(right_path.iter().rev().cloned());
-                    if perim.len() >= 3 {
-                        let pts_str = perim.iter()
-                            .map(|p| format!("{},{}", p.0, p.1))
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        branch_svg.push_str(&format!(
-                            "            <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
-                            hash, pts_str, p_title,
-                        ));
-                    }
-                }
-
-                // Wrap polylines + polygon in a `<g class="branch-
-                // group">`. CSS rule (.branch-group:hover .tooltip-
-                // trigger) glows every element in the group when
-                // any one is hovered, so moving the mouse into the
-                // strip area highlights the entire branch column
-                // rather than just whichever line segment the
-                // pointer happens to be over. Single-element hover
-                // pre-fix only highlighted one of the two parallel
-                // sides at a time, with no feedback on the
-                // transparent gap or the convergences.
-                output.entry(-1).or_insert_with(|| (
-                    TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                    TimelinePanelData{ labels: String::new(), dots: String::new(), timelines: String::new(), ref_line: String::new(), arrows: String::new() },
-                )).0.timelines.push_str(&format!(
-                    "        <g class=\"branch-group\">\n{}        </g>\n",
-                    branch_svg,
-                ));
-
-                // Recurse for any branches nested inside this
-                // branch's body. The nested call uses this
-                // branch's own state list as `parent_states` so
-                // its begin_state lookup hits the right segment.
-                render_branches(
-                    hash,
-                    rap,
-                    &branch.e_data,
-                    &branch.states,
-                    output,
-                    visualization_data,
-                    &branch.t_data,
+            // Build segments. Empty-classified states drop out so
+            // a Move (anywhere) ends the visible run there.
+            let mut segs: Vec<BranchSeg> = Vec::new();
+            push_seg_if_renderable(
+                &mut segs, rap,
+                (parent_x, split_y), (branch_x, column_top_y),
+                leading_state, visualization_data,
+            );
+            for (top, bot, state) in &branch.states {
+                if top == bot { continue; }
+                push_seg_if_renderable(
+                    &mut segs, rap,
+                    (branch_x, get_y_axis_pos(*top) as f64),
+                    (branch_x, get_y_axis_pos(*bot) as f64),
+                    state.clone(), visualization_data,
                 );
             }
+            push_seg_if_renderable(
+                &mut segs, rap,
+                (branch_x, column_bot_y), (parent_x, merge_y),
+                end_state, visualization_data,
+            );
+
+            let runs = split_centerline_runs(&segs);
+
+            let mut branch_svg = String::new();
+            for run in &runs {
+                branch_svg.push_str(&render_branch_run(rap, *hash, run));
+            }
+
+            // Wrap in branch-group so any `:hover` inside the
+            // strip glows the whole arm via
+            // `.branch-group:hover .tooltip-trigger` in the CSS.
+            output.entry(-1).or_insert_with(empty_panel_pair).0.timelines.push_str(&format!(
+                "        <g class=\"branch-group\">\n{}        </g>\n",
+                branch_svg,
+            ));
+
+            render_branches(
+                hash, rap, &branch.e_data, &branch.states,
+                output, visualization_data, &branch.t_data,
+            );
         }
     }
+}
+
+/// Push a `BranchSeg` for the given centerline endpoints + state
+/// only when the state classifies as renderable (not Empty).
+fn push_seg_if_renderable(
+    segs: &mut Vec<BranchSeg>,
+    rap: &ResourceAccessPoint,
+    p1: (f64, f64),
+    p2: (f64, f64),
+    state: State,
+    visualization_data: &VisualizationData,
+) {
+    if matches!(determine_owner_line_styles(rap, &state), OwnerLine::Empty | OwnerLine::Dotted) {
+        return;
+    }
+    let title = timeline_segment_title(&state, rap, visualization_data);
+    segs.push(BranchSeg { p1, p2, state, title });
+}
+
+/// Group segments into maximal centerline-contiguous runs.
+fn split_centerline_runs<'a>(segs: &'a [BranchSeg]) -> Vec<Vec<&'a BranchSeg>> {
+    let mut runs: Vec<Vec<&BranchSeg>> = Vec::new();
+    let mut current: Vec<&BranchSeg> = Vec::new();
+    let mut last_p2: Option<(f64, f64)> = None;
+    for seg in segs {
+        if let Some(p) = last_p2 {
+            let gap = (p.0 - seg.p1.0).abs() > 1e-6
+                || (p.1 - seg.p1.1).abs() > 1e-6;
+            if gap && !current.is_empty() {
+                runs.push(std::mem::take(&mut current));
+            }
+        }
+        current.push(seg);
+        last_p2 = Some(seg.p2);
+    }
+    if !current.is_empty() { runs.push(current); }
+    runs
+}
+
+/// Render one centerline-contiguous run: per-segment visible lines
+/// (solid or hollow per state) plus a single transparent perimeter
+/// polygon for hover capture.
+fn render_branch_run(
+    rap: &ResourceAccessPoint,
+    hash: u64,
+    run: &[&BranchSeg],
+) -> String {
+    let mut svg = String::new();
+    for seg in run {
+        let dashed = matches!(
+            seg.state,
+            State::FullPrivilege { s: LineState::Gray }
+            | State::PartialPrivilege { s: LineState::Gray }
+        );
+        let dasharray = if dashed { "4 4" } else { "none" };
+        match determine_owner_line_styles(rap, &seg.state) {
+            OwnerLine::Solid => svg.push_str(&format!(
+                "            <line data-hash=\"{}\" class=\"solid tooltip-trigger\" x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" data-tooltip-text=\"{}\" style=\"stroke-dasharray: {};\"/>\n",
+                hash, seg.p1.0, seg.p1.1, seg.p2.0, seg.p2.1, seg.title, dasharray,
+            )),
+            OwnerLine::Hollow => {
+                let perp = perp_unit(seg.p1, seg.p2);
+                for sign in [1.0_f64, -1.0] {
+                    let ox = perp.0 * sign * BRANCH_HALF_W;
+                    let oy = perp.1 * sign * BRANCH_HALF_W;
+                    svg.push_str(&format!(
+                        "            <line data-hash=\"{}\" class=\"hollow tooltip-trigger\" x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" data-tooltip-text=\"{}\" style=\"stroke-dasharray: {};\"/>\n",
+                        hash, seg.p1.0 + ox, seg.p1.1 + oy, seg.p2.0 + ox, seg.p2.1 + oy, seg.title, dasharray,
+                    ));
+                }
+            }
+            OwnerLine::Empty | OwnerLine::Dotted => {} // unreachable: filtered before push
+        }
+    }
+
+    // Perimeter polygon. Always uses ±BRANCH_HALF_W offsets so
+    // pure-solid runs still get a hover surface wider than the
+    // visible centerline. `pointer-events:fill` so the transparent
+    // fill catches mouse events.
+    if let Some(perim) = run_perimeter(run) {
+        if perim.len() >= 3 {
+            let pts_str = perim.iter()
+                .map(|p| format!("{},{}", p.0, p.1))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let title = run.first().map(|s| s.title.clone()).unwrap_or_default();
+            svg.push_str(&format!(
+                "            <polygon data-hash=\"{}\" class=\"tooltip-trigger\" points=\"{}\" data-tooltip-text=\"{}\" style=\"fill:transparent; stroke:none; pointer-events:fill;\"/>\n",
+                hash, pts_str, title,
+            ));
+        }
+    }
+
+    svg
+}
+
+/// Closed-loop perimeter for a centerline-contiguous run: left
+/// side forward, right side reversed. At corners (adjacent
+/// segments with different perpendicular directions) intermediate
+/// points get added so the polygon outlines the strip cleanly
+/// instead of cutting across the interior.
+fn run_perimeter(run: &[&BranchSeg]) -> Option<Vec<(f64, f64)>> {
+    if run.is_empty() { return None; }
+    let mut left: Vec<(f64, f64)> = Vec::new();
+    let mut right: Vec<(f64, f64)> = Vec::new();
+    let mut prev_l: Option<(f64, f64)> = None;
+    let mut prev_r: Option<(f64, f64)> = None;
+    for seg in run {
+        let perp = perp_unit(seg.p1, seg.p2);
+        let lx = perp.0 * BRANCH_HALF_W;
+        let ly = perp.1 * BRANCH_HALF_W;
+        let l1 = (seg.p1.0 + lx, seg.p1.1 + ly);
+        let l2 = (seg.p2.0 + lx, seg.p2.1 + ly);
+        let r1 = (seg.p1.0 - lx, seg.p1.1 - ly);
+        let r2 = (seg.p2.0 - lx, seg.p2.1 - ly);
+        match prev_l {
+            Some(p) if (p.0 - l1.0).abs() < 1e-6 && (p.1 - l1.1).abs() < 1e-6 => {}
+            _ => left.push(l1),
+        }
+        left.push(l2);
+        match prev_r {
+            Some(p) if (p.0 - r1.0).abs() < 1e-6 && (p.1 - r1.1).abs() < 1e-6 => {}
+            _ => right.push(r1),
+        }
+        right.push(r2);
+        prev_l = Some(l2);
+        prev_r = Some(r2);
+    }
+    let mut perim = left;
+    perim.extend(right.into_iter().rev());
+    Some(perim)
+}
+
+fn empty_panel_pair() -> (TimelinePanelData, TimelinePanelData) {
+    let blank = || TimelinePanelData {
+        labels: String::new(), dots: String::new(),
+        timelines: String::new(), ref_line: String::new(),
+        arrows: String::new(),
+    };
+    (blank(), blank())
 }
 
 // render timeline given a hash

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -2217,22 +2217,34 @@ fn split_centerline_runs<'a>(segs: &'a [BranchSeg]) -> Vec<Vec<&'a BranchSeg>> {
 }
 
 /// Render one centerline-contiguous run: per-segment visible lines
-/// (solid or hollow per state) plus a single transparent perimeter
-/// polygon for hover capture.
+/// (solid or hollow per state), plus bevel lines at any corners
+/// between adjacent hollow segments where the perpendicular rotates
+/// (e.g. diagonal leading meeting vertical body), plus a single
+/// transparent perimeter polygon for hover capture.
 fn render_branch_run(
     rap: &ResourceAccessPoint,
     hash: u64,
     run: &[&BranchSeg],
 ) -> String {
     let mut svg = String::new();
-    for seg in run {
+
+    // Classify each segment up front so the bevel pass can
+    // consult both neighbors without re-evaluating the
+    // classifier.
+    let classified: Vec<(OwnerLine, bool, &BranchSeg)> = run.iter().map(|seg| {
+        let style = determine_owner_line_styles(rap, &seg.state);
         let dashed = matches!(
             seg.state,
             State::FullPrivilege { s: LineState::Gray }
             | State::PartialPrivilege { s: LineState::Gray }
         );
-        let dasharray = if dashed { "4 4" } else { "none" };
-        match determine_owner_line_styles(rap, &seg.state) {
+        (style, dashed, *seg)
+    }).collect();
+
+    // Visible lines per segment.
+    for (style, dashed, seg) in &classified {
+        let dasharray = if *dashed { "4 4" } else { "none" };
+        match style {
             OwnerLine::Solid => svg.push_str(&format!(
                 "            <line data-hash=\"{}\" class=\"solid tooltip-trigger\" x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" data-tooltip-text=\"{}\" style=\"stroke-dasharray: {};\"/>\n",
                 hash, seg.p1.0, seg.p1.1, seg.p2.0, seg.p2.1, seg.title, dasharray,
@@ -2249,6 +2261,44 @@ fn render_branch_run(
                 }
             }
             OwnerLine::Empty | OwnerLine::Dotted => {} // unreachable: filtered before push
+        }
+    }
+
+    // Bevel pass. Adjacent hollow segments with different
+    // perpendicular directions (a diagonal converge meeting a
+    // vertical body, or vice versa) leave a small gap on each side
+    // because the offset endpoints don't quite touch — the
+    // diagonal's perp rotates relative to the body's. Emit a small
+    // connector line on each side bridging them. The connector
+    // inherits the previous segment's dasharray so a dashed
+    // leading-into-body transition reads as "the leading ends
+    // here". Solid segments share a centerline with their
+    // neighbors and need no bevel.
+    for window in classified.windows(2) {
+        let (prev_style, prev_dashed, prev_seg) = &window[0];
+        let (curr_style, _, curr_seg) = &window[1];
+        if !matches!(prev_style, OwnerLine::Hollow) { continue; }
+        if !matches!(curr_style, OwnerLine::Hollow) { continue; }
+        let prev_perp = perp_unit(prev_seg.p1, prev_seg.p2);
+        let curr_perp = perp_unit(curr_seg.p1, curr_seg.p2);
+        let dasharray = if *prev_dashed { "4 4" } else { "none" };
+        for sign in [1.0_f64, -1.0] {
+            let prev_off = (
+                prev_seg.p2.0 + prev_perp.0 * sign * BRANCH_HALF_W,
+                prev_seg.p2.1 + prev_perp.1 * sign * BRANCH_HALF_W,
+            );
+            let curr_off = (
+                curr_seg.p1.0 + curr_perp.0 * sign * BRANCH_HALF_W,
+                curr_seg.p1.1 + curr_perp.1 * sign * BRANCH_HALF_W,
+            );
+            if (prev_off.0 - curr_off.0).abs() > 1e-6
+                || (prev_off.1 - curr_off.1).abs() > 1e-6
+            {
+                svg.push_str(&format!(
+                    "            <line data-hash=\"{}\" class=\"hollow tooltip-trigger\" x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" data-tooltip-text=\"{}\" style=\"stroke-dasharray: {};\"/>\n",
+                    hash, prev_off.0, prev_off.1, curr_off.0, curr_off.1, prev_seg.title, dasharray,
+                ));
+            }
         }
     }
 

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1848,13 +1848,22 @@ fn compute_hollow_line_data(v_data: VerticalLineData, w: f64) -> HollowLineData{
     let y2 = v_data.y2 as f64;
     let dx = x1 - x2;
     let dy = y1 - y2;
-    
-    // Length of the direction vector
+
+    // Length of the direction vector. Zero-length inputs (a state
+    // segment whose top and bottom landed on the same line) would
+    // produce NaN coordinates downstream when we divide by it; the
+    // rendering filters such segments out today, but a defensive
+    // fallback to a vertical orientation keeps the output finite
+    // for any future caller that hasn't done that filtering.
     let d_length = (dx.powi(2) + dy.powi(2)).sqrt();
+    let (ux, uy) = if d_length < 1e-9 {
+        (0.0_f64, 1.0_f64)
+    } else {
+        (dx / d_length, dy / d_length)
+    };
 
-
-    let p_x = -dy / d_length * (-w / 2.0);
-    let p_y  = dx / d_length * (-w / 2.0);
+    let p_x = -uy * (-w / 2.0);
+    let p_y =  ux * (-w / 2.0);
 
     // create new x and y coordinates
     let x1 = x1 + p_x;
@@ -1863,8 +1872,8 @@ fn compute_hollow_line_data(v_data: VerticalLineData, w: f64) -> HollowLineData{
     let y2 = y2 + p_y;
     
     // Perpendicular vector components, normalized and scaled by the width
-    let px = -dy / d_length * w;
-    let py = dx / d_length * w;
+    let px = -uy * w;
+    let py =  ux * w;
 
     // Compute the remaining points
     let x3 = x1 + px;

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -1023,11 +1023,24 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
               match arm.pat.kind {
                 // (<pat>, <pat>, ..) => <expr>
                 // First need to annotate events that occur between parents (the variables being matched upon)
-                // and the pattern bindings in each arm
+                // and the pattern bindings in each arm.
+                //
+                // `parents.len() == pat_list.len()` is the
+                // "guard-was-a-tuple-literal" shape (`match (a, b)
+                // { (x, y) => … }`): each inner pattern maps to its
+                // own parent expression. Otherwise the guard is a
+                // single tuple-/enum-typed scrutinee and every
+                // inner pattern destructures out of it (`match
+                // pair { (x, y) => … }`, `match res { Ok(a, b, c)
+                // => … }`); use the single parent for all inner
+                // pattern slots. Without that fallback, `parents[i]`
+                // for i>0 panics with an index-out-of-bounds.
                 PatKind::TupleStruct(_, pat_list, _) | PatKind::Tuple(pat_list, _)=> {
+                  let same_arity = pat_list.len() == parents.len();
                   for (i, p) in pat_list.iter().enumerate() {
+                    let parent_idx = if same_arity { i } else { 0 };
                     let mut associated_ro = Vec::new();
-                    self.get_dec_of_pat2(p, &typeck_res, &parents[i], &parents_ty[i], end, & mut associated_ro);
+                    self.get_dec_of_pat2(p, &typeck_res, &parents[parent_idx], &parents_ty[parent_idx], end, & mut associated_ro);
                     let temp: Vec<ResourceAccessPoint> = associated_ro.iter().map(|(r, _, _)| {r.clone()}).collect();
                     let temp2: HashSet<ResourceAccessPoint> = temp.into_iter().collect();
                     pat_decls.extend(temp2);
@@ -1036,7 +1049,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
                       let is_partial = !(*parent_ty == typeck_res.node_type(p.hir_id));
                       let id = *self.unique_id;
                       *self.unique_id += 1;
-                      let ext_ev = self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()), parents[i].clone(), id, is_partial);
+                      let ext_ev = self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()), parents[parent_idx].clone(), id, is_partial);
                       if inline {
                         self.add_external_event(pat_line, ext_ev);
                       } else {
@@ -1044,10 +1057,10 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
                       }
                       match e {
                         Evt::SBorrow => {
-                          callback_events.push((parents[i].clone(), ResourceTy::Value(to_ro.clone()), Evt::SDie));
+                          callback_events.push((parents[parent_idx].clone(), ResourceTy::Value(to_ro.clone()), Evt::SDie));
                         }
                         Evt::MBorrow => {
-                          callback_events.push((parents[i].clone(), ResourceTy::Value(to_ro.clone()), Evt::MDie));
+                          callback_events.push((parents[parent_idx].clone(), ResourceTy::Value(to_ro.clone()), Evt::MDie));
                         }
                         _ => {}
                       }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -699,16 +699,23 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         let mut if_decl = get_decl_of_expr(if_expr, &self.tcx, &self.raps);
         if_decl.extend(iflet_bindings.iter().cloned());
 
-        // Single-arm `if let pat = expr { … }` (no else): inline.
-        // The destructure (Move from scrutinee to binding) and body
-        // events are already in `preprocessed_events`; emit
-        // GoOutOfScope events for the if-let bindings and skip the
-        // Branch construction so the column doesn't zigzag off into
-        // a lone arm with no symmetric merge. Plain `if cond { … }`
-        // no-else still records as a Branch — there's no implicit
-        // destructure that needs to weave inline alongside the
-        // parent column.
-        if !iflet_bindings.is_empty() && else_expr.is_none() {
+        // Single-arm `if cond { … }` and `if let pat = expr { … }`
+        // (both no-else): inline. Body events are already in
+        // `preprocessed_events` from the body visit above; the only
+        // thing the lone-arm Branch construction adds is a zigzag
+        // column off into a lone arm with no symmetric merge to
+        // counter-balance it. Skip it. Just emit GoOutOfScope events
+        // for any branch-local bindings (if-let pattern bindings,
+        // body-internal let-stmts) so they wind down at the closing
+        // brace as they would inside the Branch.
+        //
+        // Tradeoff: the conditionality of the body ("only runs if
+        // cond is true") is no longer encoded — a Move inside the
+        // body shows as an unconditional Move on the parent
+        // timeline. Acceptable given the alternative is the
+        // single-arm zigzag, which obscured the same flow with a
+        // structural anomaly.
+        if else_expr.is_none() {
             for var in if_decl.iter() {
                 self.preprocessed_events.push((
                     if_end,
@@ -981,6 +988,16 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         match source {
           // A normal match (not desugared)
           rustc_hir::MatchSource::Normal => {
+            // Single-arm match: inline. Don't filter body events
+            // out of preprocessed_events / don't emit a Branch
+            // event — same rationale as single-arm if / if-let
+            // above. The directly-built events (pattern
+            // destructures, post-arm callbacks, per-arm
+            // GoOutOfScope) get routed through add_external_event
+            // after the loop so line_map picks them up; body
+            // events are already in preprocessed_events from the
+            // arm's visit_expr below.
+            let inline = arms.len() == 1;
             for arm in arms.iter() {
               let mut branch_e_data: Vec<(usize, ExternalEvent)> = Vec::new();
               let mut callback_events: Vec<(ResourceTy, ResourceTy, Evt)> = Vec::new();
@@ -997,6 +1014,12 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
               // need to also get their types, in order to figure out if we are moving, copying or borrowing something into the block
               let mut pat_decls: HashSet<ResourceAccessPoint> = HashSet::new();
               // println!("arm pat {:#?}", arm.pat);
+              // Route pattern-destructure events into either
+              // `branch_e_data` (multi-arm: events live inside the
+              // Branch's per-arm event list) or `preprocessed_events`
+              // via `add_external_event` (single-arm inline: events
+              // join the global timeline before `visit_expr` so they
+              // appear in source order with the body).
               match arm.pat.kind {
                 // (<pat>, <pat>, ..) => <expr>
                 // First need to annotate events that occur between parents (the variables being matched upon)
@@ -1011,8 +1034,14 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
                     for (to_ro, e, parent_ty) in associated_ro.iter() {
                       // If the type of the pat is not the same as the parent associated with it then it must be a partial move
                       let is_partial = !(*parent_ty == typeck_res.node_type(p.hir_id));
-                      branch_e_data.push((pat_line, self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()), parents[i].clone(), *self.unique_id, is_partial)));
+                      let id = *self.unique_id;
                       *self.unique_id += 1;
+                      let ext_ev = self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()), parents[i].clone(), id, is_partial);
+                      if inline {
+                        self.add_external_event(pat_line, ext_ev);
+                      } else {
+                        branch_e_data.push((pat_line, ext_ev));
+                      }
                       match e {
                         Evt::SBorrow => {
                           callback_events.push((parents[i].clone(), ResourceTy::Value(to_ro.clone()), Evt::SDie));
@@ -1034,8 +1063,14 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
                     let temp2: HashSet<ResourceAccessPoint> = temp.into_iter().collect();
                     pat_decls.extend(temp2);
                     for (to_ro, e, _) in associated_ro.iter() {
-                      branch_e_data.push((pat_line, self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()),parents[i].clone(), *self.unique_id, false)));
+                      let id = *self.unique_id;
                       *self.unique_id += 1;
+                      let ext_ev = self.ext_ev_of_evt(e.clone(), ResourceTy::Value(to_ro.clone()), parents[i].clone(), id, false);
+                      if inline {
+                        self.add_external_event(pat_line, ext_ev);
+                      } else {
+                        branch_e_data.push((pat_line, ext_ev));
+                      }
                       match e {               // A borrow, mut/immut must be returned at the end of the block
                         Evt::SBorrow => {
                           callback_events.push((parents[i].clone(), ResourceTy::Value(to_ro.clone()), Evt::SDie));
@@ -1060,43 +1095,64 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
 
               // get events that occured in the arm
-              branch_e_data.extend(
-                self.preprocessed_events.iter().filter(|i| filter_ev(i, begin, end)).cloned()
-              );
+              if !inline {
+                branch_e_data.extend(
+                  self.preprocessed_events.iter().filter(|i| filter_ev(i, begin, end)).cloned()
+                );
 
-              // contribute events-touched variables to liveness; the
-              // arm's own pat-decls are subtracted at the end.
-              collect_event_live_vars(&branch_e_data, &mut liveness);
+                // contribute events-touched variables to liveness; the
+                // arm's own pat-decls are subtracted at the end.
+                collect_event_live_vars(&branch_e_data, &mut liveness);
 
-              // remove elements from global container
-              self.preprocessed_events.retain(|(l, _)| 
-                if *l <= end && *l >= begin {
-                  false
-                }
-                else {
-                  true
-                }
-              );
+                // remove elements from global container
+                self.preprocessed_events.retain(|(l, _)|
+                  if *l <= end && *l >= begin {
+                    false
+                  }
+                  else {
+                    true
+                  }
+                );
+              }
 
               // add callback events - events that need to happen at the end of an arm block
               // ex: if a pattern binding borrows from a parent
               for (to, from, e) in callback_events {
                 let name = from.real_name();
                 self.borrow_map.remove(&name);
-                branch_e_data.push((end, self.ext_ev_of_evt(e, to, from, *self.unique_id, false)));
+                let id = *self.unique_id;
                 *self.unique_id += 1;
+                let ext_ev = self.ext_ev_of_evt(e, to, from, id, false);
+                if inline {
+                  self.add_external_event(end, ext_ev);
+                } else {
+                  branch_e_data.push((end, ext_ev));
+                }
               }
 
               // add gos events
               for r in arm_decls.iter() {
-                branch_e_data.push((end, ExternalEvent::GoOutOfScope { ro: r.clone(), id: *self.unique_id }));
+                let id = *self.unique_id;
                 *self.unique_id += 1;
+                let gos = ExternalEvent::GoOutOfScope { ro: r.clone(), id };
+                if inline {
+                  self.add_external_event(end, gos);
+                } else {
+                  branch_e_data.push((end, gos));
+                }
               }
 
-              // branch_e_data.push((end, self.ext_ev_of_evt(parent_ev.clone(), ResourceTy::Anonymous, parent.clone())));
-              let branch_line_map = create_line_map(&branch_e_data);
-
-              branch_data.push(ExtBranchData { e_data: branch_e_data, line_map: branch_line_map, decl_vars: arm_decls});
+              if !inline {
+                let branch_line_map = create_line_map(&branch_e_data);
+                branch_data.push(ExtBranchData { e_data: branch_e_data, line_map: branch_line_map, decl_vars: arm_decls });
+              }
+            }
+            // Single-arm: events already routed through
+            // add_external_event during the loop, nothing else
+            // to do — bail out of the Normal arm before the
+            // multi-arm Branch construction below.
+            if inline {
+                return;
             }
             // Variables introduced by an arm's pattern only exist
             // inside that arm — strip them out so they don't get a

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -699,6 +699,26 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         let mut if_decl = get_decl_of_expr(if_expr, &self.tcx, &self.raps);
         if_decl.extend(iflet_bindings.iter().cloned());
 
+        // Single-arm `if let pat = expr { … }` (no else): inline.
+        // The destructure (Move from scrutinee to binding) and body
+        // events are already in `preprocessed_events`; emit
+        // GoOutOfScope events for the if-let bindings and skip the
+        // Branch construction so the column doesn't zigzag off into
+        // a lone arm with no symmetric merge. Plain `if cond { … }`
+        // no-else still records as a Branch — there's no implicit
+        // destructure that needs to weave inline alongside the
+        // parent column.
+        if !iflet_bindings.is_empty() && else_expr.is_none() {
+            for var in if_decl.iter() {
+                self.preprocessed_events.push((
+                    if_end,
+                    ExternalEvent::GoOutOfScope { ro: var.clone(), id: *self.unique_id },
+                ));
+                *self.unique_id += 1;
+            }
+            return;
+        }
+
         // Filter events that landed inside each branch's body. The
         // ranges deliberately exclude the brace lines: `split` is the
         // line of the if-body's opening `{` (which in normal Rust

--- a/rustviz-plugin/tests/closure_with_cond.rs
+++ b/rustviz-plugin/tests/closure_with_cond.rs
@@ -1,0 +1,20 @@
+// Combination test: a closure whose body is an if/else over a
+// captured variable. Rust's closure inference picks the captured
+// variable's borrow/move kind by what the body does on each
+// path; we want the visualization not to panic on the conditional
+// inside a closure body.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true; // rustviz: skip
+    let f = || {
+        if cond {
+            show(&s);
+        } else {
+            show(&s);
+        }
+    };
+    f();
+}

--- a/rustviz-plugin/tests/cond_with_closure.rs
+++ b/rustviz-plugin/tests/cond_with_closure.rs
@@ -1,0 +1,17 @@
+// Combination test: a closure declared inside one branch of an
+// if/else captures `s` and is then called within the same arm.
+// Probes how closure-capture events interact with branch-scoped
+// bindings.
+
+fn consume(_s: String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true; // rustviz: skip
+    if cond {
+        let f = || println!("{}", s);
+        f();
+    } else {
+        consume(s);
+    }
+}

--- a/rustviz-plugin/tests/cond_with_for_loop.rs
+++ b/rustviz-plugin/tests/cond_with_for_loop.rs
@@ -1,0 +1,19 @@
+// Combination test: a `for` loop inside one branch of an if/else.
+// Each iteration borrows `s`; the other arm consumes it. Probes
+// how the loop's per-iteration borrow events compose with the
+// branch's join-state classifier.
+
+fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true; // rustviz: skip
+    if cond {
+        for _i in 0..3 {
+            show(&s);
+        }
+    } else {
+        consume(s);
+    }
+}

--- a/rustviz-plugin/tests/cond_with_move_closure.rs
+++ b/rustviz-plugin/tests/cond_with_move_closure.rs
@@ -1,0 +1,16 @@
+// Combination test: a `move` closure declared inside one branch
+// of an if/else takes ownership of `s`. The other arm consumes
+// `s` directly. Both arms end without `s` → all-moved merge.
+
+fn consume(_s: String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true; // rustviz: skip
+    if cond {
+        let f = move || println!("captured: {}", s);
+        f();
+    } else {
+        consume(s);
+    }
+}

--- a/rustviz-plugin/tests/deep_nested_if.rs
+++ b/rustviz-plugin/tests/deep_nested_if.rs
@@ -1,0 +1,28 @@
+// Three-level nested if/else mixing consumes and borrows. Each
+// merge re-classifies based on its branches' end states:
+//   * innermost (c3): consume vs borrow → mixed → drop dot.
+//   * middle (c2): inner-merge-moved vs borrow → mixed → drop dot.
+//   * outer (c1): middle-moved vs direct consume → all-moved.
+
+fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let c1 = true;
+    let c2 = false;
+    let c3 = true;
+    if c1 {
+        if c2 {
+            if c3 {
+                consume(s);
+            } else {
+                show(&s);
+            }
+        } else {
+            show(&s);
+        }
+    } else {
+        consume(s);
+    }
+}

--- a/rustviz-plugin/tests/if_as_let_rhs_multiline.rs
+++ b/rustviz-plugin/tests/if_as_let_rhs_multiline.rs
@@ -1,0 +1,14 @@
+// `if`/`else` as RHS of `let`, formatted across multiple lines.
+// Both arms acquire `s` (BoundHere). The branch column should
+// converge from the parent split into each arm's acquire dot —
+// no gap between the leading and the body's first event.
+
+fn main() {
+    let n = 3;
+    let s = if n > 0 {
+        String::from("a")
+    } else {
+        String::from("b")
+    };
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/if_else_move_both.rs
+++ b/rustviz-plugin/tests/if_else_move_both.rs
@@ -1,0 +1,17 @@
+// Both arms consume `s` directly. Merge classifies as all-moved
+// (every recorded branch ends without the resource and the if/else
+// has no implicit untouched arm), so the merge dot's tooltip
+// pins the every-branch wording rather than the may-have-been or
+// implicit-drop wording.
+
+fn consume(_s: String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let cond = true;
+    if cond {
+        consume(s);
+    } else {
+        consume(s);
+    }
+}

--- a/rustviz-plugin/tests/if_else_mut_reassign.rs
+++ b/rustviz-plugin/tests/if_else_mut_reassign.rs
@@ -1,0 +1,21 @@
+// `let mut s` with branches that consume + reassign. Each arm
+// moves `s` and immediately rebinds it from a fresh String, so at
+// the merge `s` again owns a resource. The mutable binding means
+// the column should render solid (single 5px line), not hollow
+// (two parallel lines) — matching the regular column's
+// determine_owner_line_styles logic for `(FullPrivilege, mut=true)`.
+
+fn consume(_s: String) {}
+
+fn main() {
+    let mut s = String::from("orig");
+    let cond = true;
+    if cond {
+        consume(s);
+        s = String::from("new");
+    } else {
+        consume(s);
+        s = String::from("alt");
+    }
+    println!("{}", s);
+}

--- a/rustviz-plugin/tests/if_inside_for.rs
+++ b/rustviz-plugin/tests/if_inside_for.rs
@@ -1,0 +1,21 @@
+// Combination test: an if/else inside a for loop body. The body's
+// branch event should fire per iteration; in our visualization
+// the loop renders as a single iteration so we just need the
+// branch to compose with the loop body.
+
+fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let xs = [String::from("a"), String::from("b")];
+    let cond = true; // rustviz: skip
+    for x in &xs {
+        if cond {
+            show(x);
+        } else {
+            show(x);
+        }
+    }
+    let s = String::from("end");
+    consume(s);
+}

--- a/rustviz-plugin/tests/if_let_inside_for.rs
+++ b/rustviz-plugin/tests/if_let_inside_for.rs
@@ -1,0 +1,16 @@
+// Combination test: an `if let` inside a for-loop body. Each
+// iteration matches the loop variable against `Some(_)`; the
+// destructure event should fire per iteration. Probes whether
+// single-arm if-let inlining (#116) composes with for-loop body
+// rendering.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let xs: [Option<String>; 2] = [Some(String::from("a")), None];
+    for x in &xs {
+        if let Some(inner) = x {
+            show(inner);
+        }
+    }
+}

--- a/rustviz-plugin/tests/if_let_no_else.rs
+++ b/rustviz-plugin/tests/if_let_no_else.rs
@@ -1,0 +1,15 @@
+// Single-arm `if let Some(x) = opt { … }` over an Option<String>
+// (non-Copy). With no else clause, the visualization inlines the
+// destructure and body events onto the parent timeline — no
+// Branch event, no zigzag column, no merge dot. The destructure
+// emits a Move from opt to x; the body emits a borrow on x; x
+// goes out of scope at the closing brace.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let opt: Option<String> = Some(String::from("x"));
+    if let Some(x) = opt {
+        show(&x);
+    }
+}

--- a/rustviz-plugin/tests/match_one_arm.rs
+++ b/rustviz-plugin/tests/match_one_arm.rs
@@ -1,0 +1,14 @@
+// Single-arm match (irrefutable pattern). Same treatment as
+// single-arm if / if-let no-else: skip the Branch event so the
+// arm's body events render inline on the parent timeline. A
+// one-arm Branch would zigzag off into a lone column with no
+// merge symmetry.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    match s {
+        x => show(&x),
+    }
+}

--- a/rustviz-plugin/tests/match_three_arms.rs
+++ b/rustviz-plugin/tests/match_three_arms.rs
@@ -1,0 +1,17 @@
+// Three-arm match mixing a consume, a borrow, and a borrow. The
+// merge classifies as mixed (consume + alive arms) → drop dot
+// with the implicit-drop wording. Pinned in the corpus to guard
+// against regressions in N>2 branch placement / classification.
+
+fn consume(_s: String) {} // rustviz: hide
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 1;
+    match n {
+        0 => consume(s),
+        1 => show(&s),
+        _ => show(&s),
+    }
+}

--- a/rustviz-plugin/tests/match_tuple_destructure.rs
+++ b/rustviz-plugin/tests/match_tuple_destructure.rs
@@ -1,0 +1,22 @@
+// `match pair { (x, y) => … }` — tuple pattern over a single
+// tuple-typed scrutinee. Pre-fix this panicked with an out-of-
+// bounds `parents[i]` because the destructure code assumed
+// parents.len() == pat_list.len() (the guard-was-a-literal-tuple
+// shape, `match (a, b) { (x, y) => … }`). When parents has length
+// 1 and pat_list has more, every inner pattern destructures out of
+// the same single parent.
+//
+// Single-arm match too — same inlining as the other single-arm
+// conditionals.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let pair = (String::from("a"), String::from("b"));
+    match pair {
+        (x, y) => {
+            show(&x);
+            show(&y);
+        }
+    }
+}

--- a/rustviz-plugin/tests/match_with_closure_arms.rs
+++ b/rustviz-plugin/tests/match_with_closure_arms.rs
@@ -1,0 +1,22 @@
+// Combination test: each match arm declares its own closure that
+// captures `s`. Multi-arm match (Branch) + per-arm closures (each
+// emits its own capture event). Probes whether
+// `register_iflet_let_bindings`-style decl tracking generalises
+// to closures inside Branch arms.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 1; // rustviz: skip
+    match n {
+        0 => {
+            let f = || show(&s);
+            f();
+        }
+        _ => {
+            let g = || show(&s);
+            g();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Recovers the work that was supposed to land in #116 but never made it onto the remote — twelve commits I committed locally but forgot to push before the PR was merged. Plus the perp-unit zero-length guard and the conditionals × iteration / capture composition tests we discussed afterward.

## What's in here

### #116 recovery (commits `cc6c8dd` through `df681ef`)

The full set described in #116's PR description but absent from the merged main:

- **Implicit-drop classifier at merges.** Drop dot for the mixed case (some-moved-some-alive); "every branch above" wording for all-moved; if-without-else's implicit untouched arm classifies as a didn't-move arm; legacy "may have been moved" wording reserved for the fallthrough.
- **State-driven branch column rendering.** Per-segment classification through `determine_owner_line_styles` (the same classifier non-branch columns use). Solid for mut+Full, hollow paired-line for immut / PartialPrivilege, OOS / Moved drops out, Gray adds dasharray. Replaces the boolean `leading_dashed` / `trailing_dashed` / `segment_style` heuristic stack.
- **Per-side asymmetric column extents.** `compute_extent` walks the branch tree mirroring `update_timeline_data`'s placement formula and returns separate `(left, right)` BW reservations. A deeply nested if/else's leftmost leaf can no longer encroach on the column to its left or the code panel.
- **Centerline-contiguous run splitting.** Each maximal centerline-contiguous segment run is its own strip with its own perimeter polygon, so a parent branch whose body span is taken over by a nested Branch event renders its leading and trailing as separate strips instead of bridging across the gap.
- **Corner bevels** on adjacent hollow segments with rotated perpendiculars (diagonal converge meeting vertical body).
- **Single-arm conditional inlining.** `if cond { … }`, `if let pat = expr { … }`, and `match scrutinee { pat => body }` (one arm) all skip the Branch construction and emit body events inline.
- **Let-as-rhs Gray-fill.** `compute_branch_states` emits Gray-Full instead of OOS for the rows between an arm's body span starting and its first acquire when the parent state is OOS.
- **Tuple-pattern over single tuple-typed scrutinee.** `match pair { (x, y) => … }` no longer panics on `parents[i]` out-of-bounds. Same fix covers TupleStruct over multi-field enum variants.
- **Hover-active fills.** Regular hollow column adds a transparent fill polygon over its four corners; borrow trapezoids get `pointer-events:all` so the interior catches mouse events.
- **Curated 10-entry Conditionals dropdown** with `// rustviz: skip` on every helper binding.

### New in this PR

- **`compute_hollow_line_data` zero-length guard.** Falls back to a vertical orientation when the input direction vector is degenerate, so a future caller that doesn't pre-filter zero-length state segments can't produce NaN coordinates downstream. The robustness gap noted in #116's tech-debt list.
- **Conditionals × iteration / capture corpus tests.** Seven snippets exercising combinations the existing fixtures didn't cover individually: for-loop inside an if-arm, closure capture inside an if-arm, if/else inside a for body, if/else inside a closure body, if-let inside a for body, `move` closure in one arm + consume in the other, closure declared per match arm. Pinned end-to-end at both layers — well-formed-SVG floor *and* per-merge tooltip wording. The classifier from #116 picks the right wording for every shape:
  - Mixed (capture + consume) → drop dot + implicit-drop wording.
  - `move` capture in one arm + consume in the other → all-moved.
  - Both inner arms borrow → Unchanged (no merge tooltip).
  - Single-arm if-let inside a for body → inlined (no merge).

## Corpus regression coverage

Total: 58 well-formed-SVG floors + 57 tooltip assertions, all green.

The full set from #116 is pinned: `match_as_let_rhs`, `if_else_move_join`, `if_else_rebind_join`, `nested_if_move_join`, `if_no_else`, `if_else_mut_reassign`, `if_as_let_rhs_multiline`, `if_else_move_both`, `deep_nested_if`, `match_three_arms`, `if_let_no_else`, `match_one_arm`, `match_tuple_destructure`. Plus this PR's seven composition snippets.

## Test plan
- [x] `RV_RUNNER=local cargo test -p rustviz-lib` — green.
- [x] Playground builds; conditionals dropdown matches the curated 10-entry list.
- [ ] CI runs `setup.sh` then the same `cargo test`.

Closes the gap from #116. Follow-up issue #119 (odd-N match asymmetry) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)