### PR TITLE
Deploy: split Dockerfile into musl + glibc stages so plugin compiles

### DIFF
--- a/playground/deploy/Dockerfile
+++ b/playground/deploy/Dockerfile
@@ -1,39 +1,46 @@
 # syntax=docker/dockerfile:1.7
 #
 # Deploy image for the RustViz playground. Multi-stage:
-#   1. rust-builder: compile playground against the workspace's pinned
-#      nightly, AND install the rustviz CLI for stage 2's prerender.
-#   2. frontend-builder: vite build for the SPA, including the prebuild
-#      hook that prerenders every dropdown example through `rustviz svg`
-#      so first-paint dropdown clicks don't pay for the cold-start
-#      compile-API round-trip. Inherits from stage 1 to avoid a second
-#      toolchain install.
-#   3. final: docker:dind base — playground runs alongside an in-VM dockerd
+#   1. playground-builder (alpine, musl): compile the playground binary
+#      against the workspace's pinned nightly. Alpine matches the final
+#      docker:dind stage's libc, so the binary drops in without
+#      cross-compilation. The plugin is *not* installed here — rustc-dev
+#      isn't shipped as rlibs for the musl target, so a `cargo install
+#      --path rustviz-plugin` would fail with `rustc_driver required to
+#      be available in rlib format, but was not found in this form`.
+#   2. plugin-builder (bookworm, glibc): install rustviz-plugin and
+#      rustviz-cli on a glibc base where rustc-dev rlibs exist. The
+#      installed binaries here are only used by stage 3's prerender hook;
+#      they don't ride into the final image.
+#   3. frontend-builder (FROM plugin-builder): vite build for the SPA,
+#      including the prebuild hook that prerenders every dropdown example
+#      through `rustviz svg` so first-paint dropdown clicks don't pay for
+#      the cold-start compile-API round-trip. Inherits plugin-builder so
+#      `rustviz` is already on PATH and the workspace tree is already at
+#      /src/.
+#   4. final (docker:dind): playground runs alongside an in-VM dockerd
 #      and shells out to `docker run rustviz/rustviz-runner` per request
-#      (see ../SECURITY.md). The runner image itself is published separately
-#      to GHCR by .github/workflows/runner-image.yml, and entrypoint.sh
-#      pulls it on first boot. This keeps the deploy image small (~135 MiB)
-#      and Fly Machines stateless wrt the runner — `fly scale count N`
-#      horizontal scaling needs no per-Machine bootstrap.
+#      (see ../SECURITY.md). The runner image itself is published
+#      separately to GHCR by .github/workflows/runner-image.yml, and
+#      entrypoint.sh pulls it on first boot. This keeps the deploy image
+#      small (~135 MiB) and Fly Machines stateless wrt the runner —
+#      `fly scale count N` horizontal scaling needs no per-Machine
+#      bootstrap.
 
 ARG RUST_NIGHTLY=nightly-2025-08-20
 
-# ---------- 1. rust-builder ----------
-# Alpine base shares its libc (musl) with the docker:dind final stage, so
-# the playground binary we produce here drops directly into stage 3 without
-# cross-compilation. We also install Node here so stage 2 can inherit and
-# run the SPA build without a second toolchain install.
-FROM rust:1.83-alpine AS rust-builder
+# ---------- 1. playground-builder (musl) ----------
+FROM rust:1.83-alpine AS playground-builder
 ARG RUST_NIGHTLY
-RUN apk add --no-cache musl-dev gcc make perl pkgconfig nodejs npm \
+RUN apk add --no-cache musl-dev gcc make perl pkgconfig \
  && rustup toolchain install ${RUST_NIGHTLY} --profile minimal \
-        --component rust-src,rustc-dev,llvm-tools-preview \
  && rustup default ${RUST_NIGHTLY}
 
 WORKDIR /src
 # Build context is the repo root. Copy enough of the workspace that cargo
-# can resolve and build playground + install the rustviz CLI (needed by
-# stage 2's prerender step).
+# can resolve + build playground. (rustviz-plugin's manifest is in the
+# workspace graph but not in playground's dep tree, so we include the
+# manifest for resolution but never compile its sources here.)
 COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
 COPY rustviz-plugin/Cargo.toml ./rustviz-plugin/Cargo.toml
 COPY rustviz-plugin/src/ ./rustviz-plugin/src/
@@ -43,23 +50,47 @@ COPY mdbook-rustviz/ ./mdbook-rustviz/
 COPY playground/Cargo.toml ./playground/Cargo.toml
 COPY playground/src/ ./playground/src/
 
-# Build the playground binary AND install rustviz-plugin + rustviz-cli
-# so the prerender script in stage 2 can shell out to `rustviz svg`.
-# `--locked` mirrors setup.sh: pinned-Cargo.lock-or-bust against the
-# workspace's pinned nightly.
-RUN cargo build --release --locked -p rustviz-playground \
- && cargo install --path rustviz-plugin --locked \
+RUN cargo build --release --locked -p rustviz-playground
+
+# ---------- 2. plugin-builder (glibc) ----------
+# rustc-dev ships rlibs for `*-unknown-linux-gnu` but not for musl, so
+# any stage that does `cargo install --path rustviz-plugin` (which links
+# against rustc internals via rustc_plugin / rustc_utils) needs a glibc
+# base. Bookworm matches the runner image (../runner/Dockerfile) so the
+# pinned nightly is exercised against the same target there too.
+FROM rust:1.83-bookworm AS plugin-builder
+ARG RUST_NIGHTLY
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        nodejs npm pkg-config \
+ && rm -rf /var/lib/apt/lists/* \
+ && rustup toolchain install ${RUST_NIGHTLY} --profile minimal \
+        --component rust-src,rustc-dev,llvm-tools-preview \
+ && rustup default ${RUST_NIGHTLY}
+
+WORKDIR /src
+COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
+COPY rustviz-plugin/ ./rustviz-plugin/
+COPY rustviz-lib/ ./rustviz-lib/
+COPY rustviz-cli/ ./rustviz-cli/
+COPY mdbook-rustviz/ ./mdbook-rustviz/
+COPY playground/Cargo.toml ./playground/Cargo.toml
+COPY playground/src/ ./playground/src/
+
+# Install the plugin + CLI so stage 3's prerender (which shells out to
+# `rustviz svg`) finds them on PATH at /usr/local/cargo/bin/.
+# `--locked` mirrors setup.sh: pinned Cargo.lock or bust.
+RUN cargo install --path rustviz-plugin --locked \
  && cargo install --path rustviz-cli --locked
 
-# ---------- 2. frontend-builder ----------
-# Inherits stage 1's filesystem so we get:
+# ---------- 3. frontend-builder ----------
+# Inherits plugin-builder's filesystem so we get:
 #   - the rustviz CLI on PATH at /usr/local/cargo/bin/rustviz (used by
 #     the prebuild prerender hook)
 #   - the workspace tree at /src/, which is what vite.config.ts'
 #     `resolve(__dirname, '../../rust-toolchain.toml')` already expects
 #     when invoked from a normal local checkout — no special-case
 #     copies into / required.
-FROM rust-builder AS frontend-builder
+FROM plugin-builder AS frontend-builder
 WORKDIR /src/playground/frontend
 COPY playground/frontend/package.json playground/frontend/package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -70,7 +101,7 @@ COPY playground/frontend/ ./
 # design.
 RUN npm run build
 
-# ---------- 3. final (docker:dind) ----------
+# ---------- 4. final (docker:dind) ----------
 FROM docker:27-dind
 # fuse-overlayfs is a userspace overlay implementation that lets dockerd's
 # storage driver work on top of the Fly Machine's overlay rootfs (the
@@ -78,8 +109,10 @@ FROM docker:27-dind
 # volume mounted at /var/lib/docker just for dockerd's storage.
 RUN apk add --no-cache bash curl tini fuse-overlayfs
 
-# playground binary (built on Alpine in stage 1, so already musl).
-COPY --from=rust-builder /src/target/release/rustviz-playground /usr/local/bin/rustviz-playground
+# playground binary (built on Alpine in stage 1, so already musl —
+# drops straight into the alpine docker:dind base without
+# cross-compilation).
+COPY --from=playground-builder /src/target/release/rustviz-playground /usr/local/bin/rustviz-playground
 
 # Frontend bundle (Vite output). The Vite build copies frontend/public/
 # into dist/, so ex-assets/{helpers.js,visualization.css} ride along.


### PR DESCRIPTION
## Summary

Fixes the post-#116 deploy failure (#121) by restructuring `playground/deploy/Dockerfile` so `cargo install --path rustviz-plugin` runs on a glibc base where rustc-dev rlibs are actually shipped.

## Diagnosis

\`2fb24b7\` (\"playground: install rustviz CLI in Fly Dockerfile so prerender runs in CI\") added two installs to the existing alpine rust-builder stage:

\`\`\`dockerfile
RUN cargo build --release --locked -p rustviz-playground \\
 && cargo install --path rustviz-plugin --locked \\
 && cargo install --path rustviz-cli --locked
\`\`\`

The plugin install fails on alpine with:

\`\`\`
error: crate \`rustc_driver\` required to be available in rlib format, but was not found in this form
error: crate \`rustc_driver_impl\` required to be available in rlib format, but was not found in this form
… (215 more)
\`\`\`

…because rustc-dev rlibs aren't shipped for the \`*-unknown-linux-musl\` target — only for glibc variants. The runner image's Dockerfile (\`playground/runner/Dockerfile\`) already uses \`rust:1.83-bookworm\` for the same reason; its inline comment notes the rustc-dev pin.

## Restructure

Four stages instead of three:

1. \`playground-builder\` (rust:1.83-alpine, **musl**) — builds \`rustviz-playground\` only. Drops directly into the docker:dind final stage without cross-compilation.
2. \`plugin-builder\` (rust:1.83-bookworm, **glibc**) — installs \`rustviz-plugin\` and \`rustviz-cli\` where rustc-dev rlibs exist. These binaries are only used by stage 3's prerender; they don't ride into the final image.
3. \`frontend-builder\` (FROM plugin-builder) — \`npm ci && npm run build\`. The prebuild hook finds rustviz on PATH and writes \`src/prerendered.json\` before vite picks it up.
4. final (docker:27-dind) — copies the playground binary from stage 1 and dist/ from stage 3.

The runtime image's musl shape is preserved; only the build-time plugin install moved off musl.

## Test plan
- [x] Local \`docker build -f playground/deploy/Dockerfile .\` reaches and clears the plugin install on bookworm. (Two unrelated transient failures earlier — rustup CDN download decode error mid-rustc-dev fetch, then an apt mirror timeout — neither caused by the Dockerfile.)
- [ ] CI rerun on this branch.
- [ ] Fly deploy from the new image.

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)