### PR TITLE
Deploy: copy xtask/ into deploy build stages

### DIFF
--- a/playground/deploy/Dockerfile
+++ b/playground/deploy/Dockerfile
@@ -49,6 +49,10 @@ COPY rustviz-cli/ ./rustviz-cli/
 COPY mdbook-rustviz/ ./mdbook-rustviz/
 COPY playground/Cargo.toml ./playground/Cargo.toml
 COPY playground/src/ ./playground/src/
+# xtask isn't compiled in either build stage, but cargo workspace
+# resolution reads every member's manifest. Copy the (tiny) xtask
+# crate so resolution succeeds without dragging its build in.
+COPY xtask/ ./xtask/
 
 RUN cargo build --release --locked -p rustviz-playground
 
@@ -75,6 +79,10 @@ COPY rustviz-cli/ ./rustviz-cli/
 COPY mdbook-rustviz/ ./mdbook-rustviz/
 COPY playground/Cargo.toml ./playground/Cargo.toml
 COPY playground/src/ ./playground/src/
+# Workspace resolution needs xtask's manifest readable; see stage
+# 1's note. Copying just the (small) crate dir keeps the cost
+# negligible and avoids touching the workspace Cargo.toml itself.
+COPY xtask/ ./xtask/
 
 # Install the plugin + CLI so stage 3's prerender (which shells out to
 # `rustviz svg`) finds them on PATH at /usr/local/cargo/bin/.


### PR DESCRIPTION
## Summary

Fixes the post-#124 deploy failure on main (auto-opened issue #125 from the deploy job).

After xtask landed in the workspace, both deploy build stages fail at \`cargo install --path rustviz-plugin --locked\` with:

\`\`\`
error: failed to load manifest for workspace member \`/src/xtask\`
  failed to read \`/src/xtask/Cargo.toml\`
\`\`\`

Cargo's workspace resolution reads every member's manifest even when only one member is being installed. Both stages of \`playground/deploy/Dockerfile\` curate the workspace subset they pull into the build context (the comment up top calls this out), and \`xtask/\` wasn't on the list.

\`COPY xtask/ ./xtask/\` in both stages. The xtask crate isn't compiled there (the deploy never runs \`cargo xtask\`), but its manifest now resolves so cargo can walk the workspace graph.

## Test plan
- [x] Local logic check: workspace member missing → exact error reproduced.
- [ ] CI rerun on this branch.
- [ ] Deploy after merge.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)