### PR TITLE
Surface mutable-reference reborrow + freeze semantics in tooltips

### DIFF
--- a/playground/frontend/src/examples.ts
+++ b/playground/frontend/src/examples.ts
@@ -226,6 +226,33 @@ fn f(s1: &String, s2: &String) {
 }`,
       },
       {
+        name: "Mutable reborrow",
+        // `&mut T` has move semantics, but the compiler implicitly
+        // reborrows when you pass a `&mut` variable to a function or
+        // write `&mut *r` — so `r` isn't consumed, just frozen for
+        // the borrow's duration. Hover the `f` icon and the borrow
+        // dots for the tooltips that spell that out.
+        code: `fn append_bang(s: &mut String) {
+    s.push_str("!");
+}
+
+fn main() {
+    let mut s = String::from("hello");
+    let r = &mut s;
+
+    // Implicit reborrow at the call site (r isn't moved).
+    append_bang(r);
+    append_bang(r);
+
+    // Explicit reborrow: same shape, spelled out.
+    let r2 = &mut *r;
+    r2.push_str("?");
+
+    // r2's last use was the line above, so r is usable again.
+    println!("{}", r);
+}`,
+      },
+      {
         name: "Non-lexical lifetimes",
         code: `fn main() {
     let mut x = String::from("Hello");

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -224,7 +224,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Mutable reborrow from r to r2",
             "Return mutably borrowed resource from r2 to *r",
             "Return mutably borrowed resource from r to s",
-            "push_str reads from/writes to r2",
+            // r2 is itself `&mut String`, so push_str's call-site
+            // dot picks up the implicit-reborrow suffix.
+            "push_str reads from/writes to r2 (mutable reborrow — r2 is frozen until push_str returns)",
         ],
         must_not_contain: &[],
     },
@@ -238,8 +240,10 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Return mutably borrowed resource from y to x",
             "Mutable borrow from x to z",
             "Return mutably borrowed resource from z to x",
-            "world reads from/writes to y",
-            "world reads from/writes to z",
+            // y and z are both `&mut String`, so the call-site
+            // dot picks up the implicit-reborrow suffix.
+            "world reads from/writes to y (mutable reborrow — y is frozen until world returns)",
+            "world reads from/writes to z (mutable reborrow — z is frozen until world returns)",
         ],
         must_not_contain: &[],
     },
@@ -359,7 +363,10 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // `print_area(&r)` arrow.
         must_contain: &[
             "print_area reads from r",
-            "area reads from rect",
+            // `print_area(rect: &Rectangle)` calls `rect.area()`
+            // — rect is itself a `&Rectangle`, so calling area on
+            // it picks up the static-reborrow suffix.
+            "area reads from rect (immutable reborrow — rect is read-only until area returns)",
             "r acquires ownership of a resource",
             "r goes out of scope. Its resource is dropped.",
         ],
@@ -943,7 +950,9 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // the loop variable. Inner merge classifies as Unchanged,
         // so no merge wording surfaces.
         must_contain: &[
-            "show reads from x",
+            // `for x in &xs` makes x: `&String`, so calling show
+            // on it picks up the static-reborrow suffix.
+            "show reads from x (immutable reborrow — x is read-only until show returns)",
         ],
         must_not_contain: &[
             "may have been moved",
@@ -975,7 +984,10 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         // no merge wording. Loop body's per-iteration destructure
         // shows as inline events.
         must_contain: &[
-            "show reads from inner",
+            // `if let Some(inner) = x` where x: `&Option<String>`
+            // partial-borrows out a `&String` for inner; calling
+            // show on it picks up the static-reborrow suffix.
+            "show reads from inner (immutable reborrow — inner is read-only until show returns)",
         ],
         must_not_contain: &[
             "may have been moved",

--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -218,7 +218,10 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         name: "reborrow",
         must_contain: &[
             "Mutable borrow from s to r",
-            "Mutable borrow from r to r2",
+            // r is itself `&mut String`, so the borrow into r2 is a
+            // reborrow — `let r2 = &mut *r` — not a fresh borrow off
+            // the owner. The wording reflects that.
+            "Mutable reborrow from r to r2",
             "Return mutably borrowed resource from r2 to *r",
             "Return mutably borrowed resource from r to s",
             "push_str reads from/writes to r2",

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1211,11 +1211,25 @@ pub fn string_of_external_event(e: &ExternalEvent) -> String {
         ExternalEvent::MutableDie{ .. } => {
            String::from("Return mutably borrowed resource")
         },
-        ExternalEvent::PassByMutableReference{ .. } => {
-            String::from("Pass by mutable reference")
+        // Implicit reborrow at call site: passing a `&mut T`
+        // variable (or chain of them) to a fn that itself takes
+        // `&mut T` doesn't move the reference — the compiler
+        // synthesizes `&mut *r` for the call. Same arrow shape as
+        // a fresh borrow but worth naming distinctly so the user
+        // sees that r isn't being consumed.
+        ExternalEvent::PassByMutableReference{ from, .. } => {
+            if from.is_mutref() {
+                String::from("Pass by mutable reborrow")
+            } else {
+                String::from("Pass by mutable reference")
+            }
         },
-        ExternalEvent::PassByStaticReference{ .. } => {
-            String::from("Pass by immutable reference")
+        ExternalEvent::PassByStaticReference{ from, .. } => {
+            if from.is_ref() && !from.is_mutref() {
+                String::from("Pass by immutable reborrow")
+            } else {
+                String::from("Pass by immutable reference")
+            }
         },
         _ => unreachable!(),
     }

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -1195,9 +1195,17 @@ pub fn string_of_external_event(e: &ExternalEvent) -> String {
         ExternalEvent::StaticDie{ .. } => {
             String::from("Return immutably borrowed resource")
         },
-        ExternalEvent::MutableBorrow{ is_partial, to, .. } => {
+        ExternalEvent::MutableBorrow{ is_partial, from, to, .. } => {
             if *is_partial { String::from("Partial Mutable borrow") }
             else if to.is_closure() { String::from("Closure capture (mutable borrow)") }
+            // Reborrow: the source itself is a `&mut T` binding, so
+            // we're borrowing-the-borrow (`let r2 = &mut *r;` — also
+            // what's implicitly synthesized at function-call sites).
+            // Distinct from a fresh borrow off an owner: the source
+            // gets frozen for the reborrow's lifetime and then
+            // reactivated, where a fresh borrow's source stays
+            // frozen until *its* last use.
+            else if from.is_mutref() { String::from("Mutable reborrow") }
             else { String::from("Mutable borrow") }
         },
         ExternalEvent::MutableDie{ .. } => {

--- a/rustviz-plugin/src/svg_generator/hover_messages.rs
+++ b/rustviz-plugin/src/svg_generator/hover_messages.rs
@@ -179,13 +179,18 @@ pub fn event_dot_copy_to_caller(my_name: &String, _target_name: &String) -> Stri
 //     |
 // o<--*   the star event (&)
 // |   |
-pub fn event_dot_static_lend(my_name: &String, _target_name: &String) -> String {
-    // update styling
+//
+// Source-side dot at the start of an immutable borrow. Names the
+// borrower so the tooltip ties back to the column the data is
+// flowing into (and reads as "X's resource is borrowed by Y, X is
+// read-only until Y's last use" — `&T` doesn't exclude further
+// `&T`s but does prevent any `&mut T` until the borrow ends).
+pub fn event_dot_static_lend(my_name: &String, target_name: &String) -> String {
     let my_name_fmt = fmt_style(my_name);
-
+    let target_name_fmt = fmt_style(target_name);
     format!(
-        "{0}'s resource is immutably borrowed",
-        my_name_fmt
+        "{0}'s resource is immutably borrowed by {1}; {0} is read-only until {1}'s last use",
+        my_name_fmt, target_name_fmt
     )
 }
 
@@ -193,13 +198,19 @@ pub fn event_dot_static_lend(my_name: &String, _target_name: &String) -> String 
 //     |
 // o<--*   the star event (&mut)
 // |
-pub fn event_dot_mut_lend(my_name: &String, _target_name: &String) -> String {
-    // update styling
+//
+// Source-side dot at the start of a mutable borrow. The freeze
+// note is the pedagogical payload — `&mut T` is exclusive, so X
+// is unusable (not just read-only) until the borrower's last
+// use. Same wording shape as `event_dot_static_lend`'s read-only
+// variant so a reader can spot the read-only-vs-frozen
+// distinction by hovering both kinds.
+pub fn event_dot_mut_lend(my_name: &String, target_name: &String) -> String {
     let my_name_fmt = fmt_style(my_name);
-
+    let target_name_fmt = fmt_style(target_name);
     format!(
-        "{0}'s resource is mutably borrowed",
-        my_name_fmt
+        "{0}'s resource is mutably borrowed by {1}; {0} is frozen until {1}'s last use",
+        my_name_fmt, target_name_fmt
     )
 }
 

--- a/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
+++ b/rustviz-plugin/src/svg_generator/svg_frontend/timeline_panel.rs
@@ -1588,11 +1588,42 @@ fn render_arrow (
                         ExternalEvent::PassByMutableReference { .. } => " reads from/writes to ",
                         _ => unreachable!()
                     };
-                    
+
+                    // Implicit-reborrow note for the call-dot
+                    // tooltip. `f(r)` where r: `&mut T` is
+                    // compiler-rewritten to `f(&mut *r)` — the
+                    // reference isn't moved, but r is frozen for
+                    // the call's duration. Surface that here so a
+                    // reader hovering the call-site dot sees the
+                    // freeze without having to understand NLL on
+                    // their own. Static (immutable) reborrows have
+                    // a weaker freeze (source stays read-only,
+                    // doesn't lose access entirely) — call that out
+                    // too but with read-only wording.
+                    let from_is_mutref = match from_variable {
+                        ResourceTy::Value(rap) | ResourceTy::Deref(rap) => rap.is_mutref(),
+                        _ => false,
+                    };
+                    let from_is_static_ref = match from_variable {
+                        ResourceTy::Value(rap) | ResourceTy::Deref(rap) => rap.is_ref() && !rap.is_mutref(),
+                        _ => false,
+                    };
+                    let reborrow_suffix: String = match external_event {
+                        ExternalEvent::PassByMutableReference { .. } if from_is_mutref => format!(
+                            " (mutable reborrow — {} is frozen until {} returns)",
+                            styled_from_name, styled_fn_name,
+                        ),
+                        ExternalEvent::PassByStaticReference { .. } if from_is_static_ref => format!(
+                            " (immutable reborrow — {} is read-only until {} returns)",
+                            styled_from_name, styled_fn_name,
+                        ),
+                        _ => String::new(),
+                    };
+
                     let function_dot_data = FunctionDotData {
                         x: from_timeline.x_val,
                         y: get_y_axis_pos(*line_number),
-                        title: styled_fn_name + title_fn + &styled_from_name,
+                        title: format!("{}{}{}{}", styled_fn_name, title_fn, styled_from_name, reborrow_suffix),
                         hash: from_variable.hash().to_owned() as u64,
                     };
 


### PR DESCRIPTION
Closes #127. Three layers of hover-message clarification around \`&mut T\`'s move-with-implicit-reborrow story:

## (1) Distinguish reborrow from fresh borrow on the borrow-arrow tooltip

When the source RAP is itself a \`&mut T\` (or \`&T\` for static), the borrow's arrow tooltip says \"reborrow\" instead of \"borrow\":

\`\`\`
let r = &mut s;     // \"Mutable borrow from s to r\"     (unchanged — fresh)
let r2 = &mut *r;   // \"Mutable reborrow from r to r2\"  (new — borrow-the-borrow)
let r2 = r;         // \"Move from r to r2\"              (unchanged — already clear)
\`\`\`

Same applies to the underlying \`Pass by *Reference\` arrow events — they read \"Pass by mutable reborrow\" / \"Pass by immutable reborrow\" when the source is itself a ref.

## (2) Freeze note on the source-side lend dot

\`X\`'s column dot at the line where the borrow begins now reports the lifetime impact:

\`\`\`
X's resource is mutably borrowed by Y; X is frozen until Y's last use
X's resource is immutably borrowed by Y; X is read-only until Y's last use
\`\`\`

\"Frozen\" for the \`&mut\` case (X unusable until Y's last use); \"read-only\" for \`&\` (X can still be read through other immutable borrows; just no \`&mut\` while Y lives). Same wording shape so a reader can spot the distinction by hovering both kinds.

## (3) Implicit-reborrow note on the function-call dot

\`f(r)\` where \`r: &mut T\` is compiler-rewritten to \`f(&mut *r)\` — r isn't moved, but it's frozen for the call. The function-call dot tooltip now surfaces that:

\`\`\`
f reads from/writes to r (mutable reborrow — r is frozen until f returns)
f reads from r (immutable reborrow — r is read-only until f returns)
\`\`\`

For owners (no-ref source, e.g. \`f(&r)\` where r is a String) the suffix is omitted — that's a fresh borrow, not a reborrow, and the existing brief wording stays accurate.

## Edge cases pinned in the corpus

- \`reborrow\` — explicit \`let r2 = &mut *r;\` then call \`r2.push_str(...)\`. Tests both the arrow wording (Mutable reborrow from r to r2) and the call-dot suffix on r2.
- \`nll_two_borrows\` — \`world(y); world(z);\` where y and z are both \`&mut\`. Both call-dots get the mut-reborrow suffix.
- \`inherent_method_rectangle\` — \`print_area(rect: &Rectangle) { rect.area() }\`. rect is \`&Rectangle\`, so calling area on it picks up the immutable-reborrow suffix.
- \`if_inside_for\`, \`if_let_inside_for\` — for-loop scrutinees borrowed via \`&xs\` produce \`&String\` loop variables; calling show on those is a static reborrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)