### PR TITLE
Support union types as opaque single-owner columns

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,10 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Union (#131): rendered as an opaque single-owner column,
+    //   same as enums. Pre-fix the plugin panicked at the
+    //   AdtKind::Union arm with "union not implemented yet".
+    "union_basic",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -993,6 +997,30 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         ],
         must_not_contain: &[
             "may have been moved (consumed in at least one branch above)",
+        ],
+    },
+
+    // ─── Unions (#131) ──────────────────────────────────────────────
+    TooltipExpect {
+        name: "union_basic",
+        // Opaque-owner treatment: `u` gets a single column, the
+        // construction is a Bind (acquires), passing `u` to show
+        // is a Move, and the post-move OOS reports no resource
+        // dropped. No per-field timelines for `_a` / `_b` —
+        // unions don't have a statically-known active field.
+        must_contain: &[
+            "u acquires ownership of a resource",
+            "u's resource is moved",
+            "Move from u to show",
+            "u goes out of scope. No resource is dropped.",
+        ],
+        must_not_contain: &[
+            // Pre-fix the AdtKind::Union arm panicked; a renderer
+            // that treated unions as structs would create field
+            // RAPs `u._a` / `u._b` with their own labels — guard
+            // against either regression.
+            "u._a",
+            "u._b",
         ],
     },
 ];

--- a/rustviz-plugin/src/annotated_source_gen.rs
+++ b/rustviz-plugin/src/annotated_source_gen.rs
@@ -207,12 +207,27 @@ pub fn annotate_expr(& mut self, expr: &'tcx Expr) {
         _ => {}
       }
       for field in fields.iter() {
-        self.annotate_src(field.ident.to_string(), field.ident.span, false, *self.id_map.get(field.ident.as_str()).unwrap() as u64);
+        // Field idents that aren't tied to a registered RAP — most
+        // commonly union fields, which we render as opaque single-
+        // owner columns and so don't add per-field id_map entries
+        // for — get the colorization skipped instead of panicking
+        // on an `id_map.get(...).unwrap()`. The expression in the
+        // initialiser is still walked normally below.
+        if let Some(hash) = self.id_map.get(field.ident.as_str()) {
+          self.annotate_src(field.ident.to_string(), field.ident.span, false, *hash as u64);
+        }
         self.annotate_expr(field.expr);
       }
     }
     ExprKind::Field(exp, ident) => {
-      self.annotate_src(ident.to_string(), ident.span, false, *self.id_map.get(ident.as_str()).unwrap() as u64);
+      // Same robustness: a field-access projection on a non-struct
+      // RAP (a union, an enum variant accessed through `unsafe`,
+      // etc.) won't have its field name in id_map. Skip the
+      // colorization for that token; the receiver expression is
+      // still walked.
+      if let Some(hash) = self.id_map.get(ident.as_str()) {
+        self.annotate_src(ident.to_string(), ident.span, false, *hash as u64);
+      }
       self.annotate_expr(exp);
     }
     ExprKind::DropTemps(exp) => {

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -572,10 +572,13 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
             expr,
           );
         },
-        AdtKind::Union => {
-          warn!("lhs union not implemented yet")
-        },
-        AdtKind::Enum => {
+        // Unions and enums both render as opaque single-owner columns:
+        // there's no statically-known discriminant we can attribute
+        // events to per-field, so we don't try. A union is a fixed
+        // memory slot whose interpretation depends on the active
+        // variant at runtime; modelling per-field timelines for it
+        // would be lying about which field is "the" field.
+        AdtKind::Union | AdtKind::Enum => {
           let is_copy = self.ty_is_copy(ty, expr.hir_id.owner);
           self.add_owner(name, mutability, is_copy, self.current_scope, !self.inside_branch);
         }
@@ -728,10 +731,9 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
                             self.add_struct(field_name, owner_hash, true, muta, field_is_copy, scope, false);
                         }
                     },
-                    AdtKind::Union => {
-                        panic!("union not implemented yet")
-                    },
-                    AdtKind::Enum => {
+                    // Unions render as opaque single-owner columns —
+                    // see the matching note on the LHS-of-expr arm.
+                    AdtKind::Union | AdtKind::Enum => {
                         let is_copy = self.ty_is_copy(ty, pat.hir_id.owner);
                         self.add_owner(name.clone(), muta, is_copy, scope, false);
                     }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -192,18 +192,32 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           }
         }
         else if ty.is_adt() && !is_special{ // kind of weird given we don't have a InitStructParam
-          let owner_hash = self.rap_hashes as u64;
-          let parent_is_copy = self.ty_is_copy(ty, param.hir_id.owner);
-          self.add_struct(name.clone(), owner_hash, false, bool_of_mut(binding_annotation.1), parent_is_copy, self.current_scope, !self.inside_branch);
-          let generic_args = match ty.kind() {
-            rustc_middle::ty::TyKind::Adt(_, args) => *args,
-            _ => unreachable!("ty.is_adt() but kind is not Adt"),
-          };
-          for field in ty.ty_adt_def().unwrap().all_fields() {
-            let field_name = format!("{}.{}", name.clone(), field.name.as_str());
-            let field_ty = field.ty(self.tcx, generic_args);
-            let field_is_copy = self.ty_is_copy(field_ty, param.hir_id.owner);
-            self.add_struct(field_name, owner_hash, true, bool_of_mut(binding_annotation.1), field_is_copy, self.current_scope, !self.inside_branch);
+          // Dispatch on the ADT kind so structs get per-field
+          // timelines while enums and unions stay opaque (same
+          // policy as the LHS-of-expr / pattern-binding sites in
+          // expr_visitor.rs). Without this branching, an enum or
+          // union parameter would silently get spurious field RAPs
+          // registered as if it were a struct.
+          match ty.ty_adt_def().unwrap().adt_kind() {
+            rustc_middle::ty::AdtKind::Struct => {
+              let owner_hash = self.rap_hashes as u64;
+              let parent_is_copy = self.ty_is_copy(ty, param.hir_id.owner);
+              self.add_struct(name.clone(), owner_hash, false, bool_of_mut(binding_annotation.1), parent_is_copy, self.current_scope, !self.inside_branch);
+              let generic_args = match ty.kind() {
+                rustc_middle::ty::TyKind::Adt(_, args) => *args,
+                _ => unreachable!("ty.is_adt() but kind is not Adt"),
+              };
+              for field in ty.ty_adt_def().unwrap().all_fields() {
+                let field_name = format!("{}.{}", name.clone(), field.name.as_str());
+                let field_ty = field.ty(self.tcx, generic_args);
+                let field_is_copy = self.ty_is_copy(field_ty, param.hir_id.owner);
+                self.add_struct(field_name, owner_hash, true, bool_of_mut(binding_annotation.1), field_is_copy, self.current_scope, !self.inside_branch);
+              }
+            }
+            rustc_middle::ty::AdtKind::Union | rustc_middle::ty::AdtKind::Enum => {
+              let is_copy = self.ty_is_copy(ty, param.hir_id.owner);
+              self.add_owner(name.clone(), bool_of_mut(binding_annotation.1), is_copy, self.current_scope, !self.inside_branch);
+            }
           }
         }
         else {

--- a/rustviz-plugin/tests/union_basic.rs
+++ b/rustviz-plugin/tests/union_basic.rs
@@ -1,0 +1,18 @@
+// Basic `union` use. Pre-fix the plugin panicked at the
+// AdtKind::Union arm with "union not implemented yet". We now
+// render unions as opaque single-owner columns (same shape as
+// enums) — the union has a column, but per-field timelines
+// aren't registered because there's no statically-known
+// discriminant.
+
+union Pair {
+    _a: i32,
+    _b: f32,
+}
+
+fn show(_p: Pair) {} // rustviz: hide
+
+fn main() {
+    let u = Pair { _a: 42 };
+    show(u);
+}


### PR DESCRIPTION
Closes #131.

## What changed

The visitor's three \`AdtKind\` dispatch sites — LHS-of-expr (\`expr_visitor.rs:561\`), pat-binding (\`expr_visitor.rs:715\`), function-param (\`visitor.rs:194\`) — handled \`Struct\` and \`Enum\` but were inconsistent on \`Union\`:

| Site | Before | After |
|---|---|---|
| LHS-of-expr | \`warn!(\"lhs union not implemented yet\")\` (silent no-op) | opaque owner |
| pat-binding | \`panic!(\"union not implemented yet\")\` | opaque owner |
| fn-param | unconditionally treated as struct (would register phantom field RAPs) | dispatch on AdtKind, opaque owner for unions |

Treat unions the same way enums are: register a single opaque owner column, no per-field RAPs. A union has no statically-known active discriminant, so attributing events to specific fields would be misleading. Same shape the limitations doc already describes for smart pointers / trait objects.

## Knock-on fix

The annotated source colorizer in \`annotated_source_gen.rs\` was unwrapping \`id_map.get(field.ident)\` for every field of an \`ExprKind::Struct\` (which covers union literals like \`Pair { _a: 42 }\`). Union fields aren't in \`id_map\` by design — no per-field RAPs — so the unwrap panicked downstream of the AdtKind fix.

Generalized the lookup to skip annotation when the ident isn't registered. Same robustness applied to \`ExprKind::Field\` for symmetry.

## Test

New \`union_basic.rs\` corpus snippet pins the opaque shape:

\`\`\`rust
union Pair { _a: i32, _b: f32 }
fn show(_p: Pair) {} // rustviz: hide

fn main() {
    let u = Pair { _a: 42 };
    show(u);
}
\`\`\`

\`EXPECTED_TOOLTIPS\` asserts:
- \`u\` gets a single owner column with the standard \"acquires ownership of a resource\" / \"resource is moved\" / \"goes out of scope. No resource is dropped.\" sequence.
- No \`u._a\` / \`u._b\` timelines (guards against treating unions as structs).
- The Move arrow into \`show\` fires correctly.

\`cargo install --path rustviz-plugin --locked\` clean, full corpus green (54 EXPECTED_OK + 58 tooltip assertions, including the new \`union_basic\`).

## Doc follow-up

#130 (the limitations refresh) lists \"Union types (which currently panic, expr_visitor.rs:732)\" under the not-supported bucket. Once that lands and this lands, the bullet should move out of \"not supported\" — unions render now, just opaquely. Trivial text edit; whoever merges second handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)