### PR TITLE
plugin: const/static support + corpus coverage for under-tested features

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,14 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Coverage gaps closed (#139): patterns the visitor has arms
+    //   for but which lacked corpus pinning, plus const/static and
+    //   unsafe blocks which were silently untested.
+    "match_range_pattern",
+    "match_with_guard",
+    "const_basic",
+    "static_basic",
+    "unsafe_raw_ptr",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -994,6 +1002,90 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_not_contain: &[
             "may have been moved (consumed in at least one branch above)",
         ],
+    },
+
+    // ─── Coverage gaps closed (#139) ───────────────────────────────
+    TooltipExpect {
+        name: "match_range_pattern",
+        // Range patterns in match arms (`0..=4`, `5..=9`, `_`).
+        // All three arms borrow `s`; merge classifies as Unchanged,
+        // so no merge wording. PatKind::Range is walked silently —
+        // no per-arm event from the range itself.
+        must_contain: &[
+            "Move from String::from to s",
+            "show reads from s",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+        ],
+    },
+    TooltipExpect {
+        name: "match_with_guard",
+        // Pattern guard (`x if x > 0`). The guard binds `x` from
+        // the scrutinee (`n`, Copy) — that's the "Copy from n to x"
+        // event. Both arms borrow `s`; merge is Unchanged.
+        must_contain: &[
+            "Move from String::from to s",
+            "Copy from n to x",
+            "show reads from s",
+        ],
+        must_not_contain: &[
+            "may have been moved",
+            "moved or dropped in every branch",
+        ],
+    },
+    TooltipExpect {
+        name: "const_basic",
+        // `let x = N;` where N is a const i32 → Copy treated as a
+        // Bind from Anonymous (the const has no column). Then
+        // `let y = x` is a regular Copy from x to y.
+        must_contain: &[
+            "x is bound to a value",
+            "y is initialized by copy from x",
+            "Copy from x to y",
+        ],
+        must_not_contain: &[
+            // The const itself shouldn't get a column or events.
+            "N is the owner",
+            "N holds a value",
+            "N goes out of scope",
+            // No Move from N — const reads aren't moves.
+            "Move from N to x",
+        ],
+    },
+    TooltipExpect {
+        name: "static_basic",
+        // `let s = GREETING;` where GREETING is a `&'static str`.
+        // The static itself isn't a function-local RAP; `s` borrows
+        // from an Anonymous source (external memory). show(s) reads
+        // through s.
+        must_contain: &[
+            "s holds a reference",
+            "show reads from s",
+        ],
+        must_not_contain: &[
+            // GREETING shouldn't get a column.
+            "GREETING is the owner",
+            "GREETING holds",
+            "GREETING goes out of scope",
+        ],
+    },
+    TooltipExpect {
+        name: "unsafe_raw_ptr",
+        // Raw-pointer code through an `unsafe` block. The plugin
+        // doesn't have explicit unsafe handling — this fixture
+        // pins what currently happens (binding x and p both
+        // surface as ordinary Bind events; the deref-write inside
+        // the unsafe block doesn't fire any event because the
+        // visitor doesn't model raw-pointer mutation). Guards
+        // against any future change accidentally panicking on raw
+        // pointers.
+        must_contain: &[
+            "x is bound to a value",
+            "*p is bound to a value",
+        ],
+        must_not_contain: &[],
     },
 ];
 

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -843,6 +843,25 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
   }
   match rhs.kind {
     ExprKind::Path(QPath::Resolved(_,p)) => {
+      // const / static items aren't function-local RAPs — they're
+      // compile-time values (or `'static` references) baked into
+      // the binary. Treat reading one on the RHS of a let as if
+      // the RHS were a literal: the LHS gets a Bind from an
+      // Anonymous source. Same handling as the path-arm in
+      // visitor.rs's main expression walker.
+      if matches!(
+        p.res,
+        Res::Def(
+          rustc_hir::def::DefKind::Const
+            | rustc_hir::def::DefKind::AssocConst
+            | rustc_hir::def::DefKind::Static { .. },
+          _
+        )
+      ) {
+        let line_num = span_to_line(&p.span, &self.tcx);
+        self.add_ev(line_num, Evt::Bind, lhs, ResourceTy::Anonymous, false);
+        return;
+      }
       let line_num = span_to_line(&p.span, &self.tcx);
       let rhs_name: String = match p.res {
         Res::Def(rustc_hir::def::DefKind::Ctor(_, _), _) => {

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -793,6 +793,24 @@ pub fn fetch_rap(expr: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>) -> 
 pub fn find_lender(rhs: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>, borrow_map: &HashMap<String, RefData>) -> ResourceTy {
   match rhs.kind {
     ExprKind::Path(QPath::Resolved(_,p)) => {
+      // const / static items aren't registered as RAPs — they're
+      // compile-time values / `'static` references baked into the
+      // binary. Treating them as `Anonymous` (the "external"
+      // source we already use for literals and fn-return values)
+      // gives `let s = GREETING;` a clean shape: s borrows from
+      // an external source rather than from a function-local
+      // lender.
+      if matches!(
+        p.res,
+        rustc_hir::def::Res::Def(
+          rustc_hir::def::DefKind::Const
+            | rustc_hir::def::DefKind::AssocConst
+            | rustc_hir::def::DefKind::Static { .. },
+          _
+        )
+      ) {
+        return ResourceTy::Anonymous;
+      }
       let name = tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
       if borrow_map.contains_key(&name) {
         borrow_map.get(&name).unwrap().to_owned().lender

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -595,7 +595,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
       //unary operator */! <expr>
       ExprKind::Unary(UnOp::Deref, exp) => { self.visit_expr(exp) }
 
-      // A path is a name for something 
+      // A path is a name for something
       // can be a variable, or a path to a definition (function)
       ExprKind::Path(QPath::Resolved(_,p)) => {
         match p.res {
@@ -608,6 +608,16 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
               }
             }
             self.add_fn(name);
+            return;
+          }
+          // `const` and `static` items don't get RAP timelines —
+          // they're compile-time values (or `'static` references)
+          // that exist outside the function-local ownership story.
+          // Reading one in `let x = N;` makes `x` an owner of the
+          // resulting copy / static borrow; the const/static itself
+          // doesn't need a column. Skip the path-expression event so
+          // the lookup below doesn't trip on the missing RAP.
+          Res::Def(DefKind::Const | DefKind::AssocConst | DefKind::Static { .. }, _) => {
             return;
           }
           _ => ()

--- a/rustviz-plugin/tests/const_basic.rs
+++ b/rustviz-plugin/tests/const_basic.rs
@@ -1,0 +1,12 @@
+// `const` items. Compile-time values; copying them into a binding
+// shouldn't leave a phantom "const item is moved" event on a
+// timeline for the const itself, and the receiving binding should
+// behave like a normal Copy.
+
+const N: i32 = 5;
+
+fn main() {
+    let x = N;
+    let y = x;
+    let _ = y; // rustviz: skip
+}

--- a/rustviz-plugin/tests/match_range_pattern.rs
+++ b/rustviz-plugin/tests/match_range_pattern.rs
@@ -1,0 +1,17 @@
+// Range patterns in match arms (`a..=b`). Pre-fix the visitor's
+// `PatKind::Range` arm at visitor.rs:1591 silently dropped the
+// pattern; this fixture verifies that the surrounding match still
+// renders coherently (each arm picks up the consume / borrow
+// events normally) and the merge classifier sees the arm endings.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 5; // rustviz: skip
+    match n {
+        0..=4 => show(&s),
+        5..=9 => show(&s),
+        _     => show(&s),
+    }
+}

--- a/rustviz-plugin/tests/match_with_guard.rs
+++ b/rustviz-plugin/tests/match_with_guard.rs
@@ -1,0 +1,16 @@
+// Pattern guard (`pat if cond`). Verifies that:
+//   * the bound pattern variable still gets a column,
+//   * any borrow / read inside the guard surfaces on the right
+//     timeline,
+//   * arm-body events still fire normally regardless of guard outcome.
+
+fn show(_s: &String) {} // rustviz: hide
+
+fn main() {
+    let s = String::from("hi");
+    let n = 5; // rustviz: skip
+    match n {
+        x if x > 0 => show(&s),
+        _          => show(&s),
+    }
+}

--- a/rustviz-plugin/tests/static_basic.rs
+++ b/rustviz-plugin/tests/static_basic.rs
@@ -1,0 +1,14 @@
+// `static` items with `'static` lifetime. The static itself isn't
+// owned by any function-local binding; uses copy or borrow into
+// local bindings depending on type. Verifies the plugin doesn't
+// trip on the special `'static` lifetime when borrowing from the
+// static.
+
+static GREETING: &str = "hello";
+
+fn show(_s: &str) {} // rustviz: hide
+
+fn main() {
+    let s = GREETING;
+    show(s);
+}

--- a/rustviz-plugin/tests/unsafe_raw_ptr.rs
+++ b/rustviz-plugin/tests/unsafe_raw_ptr.rs
@@ -1,0 +1,13 @@
+// Minimal `unsafe` block exercising raw-pointer mutation. The
+// visitor doesn't have explicit `unsafe`-block awareness; this
+// fixture pins what *currently* happens (whether the plugin
+// survives the input or panics) so any future change to unsafe
+// handling shows up as a regression rather than a silent shift.
+
+fn main() {
+    let mut x: i32 = 1;
+    let p: *mut i32 = &mut x as *mut i32;
+    unsafe {
+        *p = 2;
+    }
+}


### PR DESCRIPTION
Closes #139 (corpus under-testing).

## Summary
- Adds 5 fixtures pinning behavior for previously under-tested syntax: range patterns, match guards, const, static, and unsafe raw-pointer writes.
- The const and static fixtures surfaced 3 latent panics; each is fixed here with proper handling (const/static identifiers render as anonymous external sources rather than RAPs).

## Plugin fixes
- `visitor.rs` path-arm: early-return for `Const`/`AssocConst`/`Static` so the `raps.get(..).unwrap()` lookup is skipped.
- `expr_visitor.rs` `match_rhs` Path arm: emit `Evt::Bind` from `ResourceTy::Anonymous` so the LHS still gets initialized.
- `expr_visitor_utils.rs` `find_lender`: return `Anonymous` for const/static paths instead of attempting to resolve them as RAPs.

## Test plan
- [x] `cargo test -p rustviz-lib --test corpus` — all 5 new fixtures pass tooltip expectations
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)