### PR TITLE
plugin: register per-field RAPs for &Struct / &mut Struct params

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -380,6 +380,18 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         ],
         must_not_contain: &[],
     },
+    TooltipExpect {
+        name: "method_assigns_field",
+        // `&mut self` method that reassigns a field. After #147,
+        // `self.c` is registered as a per-field RAP whose column
+        // shows the reassignment Acquire event.
+        must_contain: &[
+            "self.c, mutable",
+            "self.c acquires ownership of a resource",
+            "self.c goes out of scope",
+        ],
+        must_not_contain: &[],
+    },
 
     // ─── Lifetimes ──────────────────────────────────────────────────
     TooltipExpect {

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -190,6 +190,32 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
           if let Some(rd) = self.borrow_map.get_mut(&name) {
             rd.lifetime = self.current_scope;
           }
+          // If the pointee is a user-defined ADT, register a member
+          // RAP for each field under the ref so projections like
+          // `self.x` / `r.field` resolve in both read and write
+          // positions (the assignment LHS path keys off the
+          // qualified `name.field` lookup). Without this, `&self` /
+          // `&mut self` methods that touch any field produce no
+          // event on that field's column (the read path's
+          // `fetch_rap` returns None and the write path returns
+          // None from `resource_of_lhs`). #147.
+          let pointee = ty.builtin_deref(true);
+          if let Some(pointee_ty) = pointee {
+            if pointee_ty.is_adt() && !ty_is_special_owner(&pointee_ty) {
+              let owner_hash = *self.raps.get(&name).unwrap().rap.hash();
+              let field_mut = matches!(ty.ref_mutability(), Some(Mutability::Mut));
+              let generic_args = match pointee_ty.kind() {
+                rustc_middle::ty::TyKind::Adt(_, args) => *args,
+                _ => unreachable!("pointee.is_adt() but kind is not Adt"),
+              };
+              for field in pointee_ty.ty_adt_def().unwrap().all_fields() {
+                let field_name = format!("{}.{}", name.clone(), field.name.as_str());
+                let field_ty = field.ty(self.tcx, generic_args);
+                let field_is_copy = self.ty_is_copy(field_ty, param.hir_id.owner);
+                self.add_struct(field_name, owner_hash, true, field_mut, field_is_copy, self.current_scope, !self.inside_branch);
+              }
+            }
+          }
         }
         else if ty.is_adt() && !is_special{ // kind of weird given we don't have a InitStructParam
           let owner_hash = self.rap_hashes as u64;


### PR DESCRIPTION
Closes #147. Stacked on #145 (which contains the corpus fixtures this PR pins tooltips against).

## Summary
- Extends \`visit_param\`'s ref-typed branch so that when the pointee is a user-defined ADT (non-special), each field is registered as a \`Struct\` member RAP whose \`owner\` is the ref RAP's hash.
- Field mutability follows the ref mutability (\`&mut T\` → mutable fields, \`&T\` → immutable), since \"can mutate through the ref\" is what determines whether \`r.field = …\` typechecks.
- Pins the new behavior on \`method_assigns_field\` (an \`&mut self\` method whose \`self.c = …\` assignment now surfaces as a tooltip event on the \`self.c\` column instead of being dropped).

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green
- [ ] Once merged, follow-up PR to also handle tuple-struct numeric field RAPs (\`tuple_struct_method\` still produces no event for \`self.0 + self.1\` reads since numeric fields aren't registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)