### PR TITLE
plugin: don't panic on &{} (#146)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,10 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Borrowing the unit value of an empty block (#146). Used to
+    //   panic in fetch_mutability; pinned here so the no-crash
+    //   floor doesn't regress.
+    "borrow_empty_block",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -548,13 +548,18 @@ pub fn fetch_mutability(expr: & Expr) -> Option<Mutability> {
   match expr.kind {
     ExprKind::Block(b, _) => {
       match b.expr {
-        Some(expr) => { fetch_mutability(expr) }
-        None => { panic!("invalid expr for fetching mutability") }
+        Some(expr) => fetch_mutability(expr),
+        // An empty block (`&{}`) has no inner expression to derive
+        // mutability from — propagate None so the outer `AddrOf` arm
+        // falls back to its own declared mutability. Borrowing a
+        // unit-valued empty block is valid Rust, so this branch is
+        // reachable on real user code; don't panic. (#146)
+        None => None,
       }
     }
     ExprKind::AddrOf(_, mutability, expr) => {
       match fetch_mutability(&expr) {
-        None => Some(mutability), 
+        None => Some(mutability),
         Some(m) => Some(m)
       }
     }
@@ -823,8 +828,11 @@ pub fn find_lender(rhs: &Expr, tcx: &TyCtxt, raps: &HashMap<String, RapData>, bo
     }
     ExprKind::Block(b, _) => {
       match b.expr {
-        Some(expr) => { find_lender(expr, tcx, raps, borrow_map) }
-        None => { panic!("invalid rhs lender block") }
+        Some(expr) => find_lender(expr, tcx, raps, borrow_map),
+        // Borrow of an empty block — `let r = &{};` borrows unit.
+        // No lender to attribute to; same `&{}` shape as #146's
+        // fetch_mutability fix.
+        None => ResourceTy::Anonymous,
       }
     }
     ExprKind::Unary(op, expr) => { 

--- a/rustviz-plugin/tests/borrow_empty_block.rs
+++ b/rustviz-plugin/tests/borrow_empty_block.rs
@@ -1,0 +1,8 @@
+// `&{}` — borrowing the unit value of an empty block. Used to
+// panic in fetch_mutability before #146; now propagates None
+// from the empty-block arm so the outer AddrOf falls back to
+// its declared mutability. Pins the no-crash baseline.
+
+fn main() {
+    let _r = &{};
+}


### PR DESCRIPTION
Closes #146.

## Summary
- `let r = &{}` (borrow of an empty block / unit) hit two panics on the way through the plugin:
  - `fetch_mutability` recursed into the inner Block and panicked when `b.expr` was None.
  - `find_lender` did the same for the same input on a different code path.
- Both now return None / Anonymous from the empty-block arm so the outer AddrOf falls back to its own declared mutability / no lender attribution.
- Adds `borrow_empty_block` corpus fixture pinning the no-crash floor.

## Test plan
- [x] `cargo test -p rustviz-lib --test corpus`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)