### PR TITLE
plugin: support chained field LHS via expr_to_rap_name walk (#143)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,10 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Chained field assignment (#143). `o.inner.x = …` now
+    //   resolves through `expr_to_rap_name` to the nested field's
+    //   pre-registered RAP and emits an Acquire event on that column.
+    "chained_field_assign",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -342,6 +346,15 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from String::from to s",
             "len reads from s",
             "Copy from len to n",
+        ],
+        must_not_contain: &[],
+    },
+
+    TooltipExpect {
+        name: "chained_field_assign",
+        must_contain: &[
+            "o.inner.x, mutable",
+            "o.inner.x acquires ownership of a resource",
         ],
         must_not_contain: &[],
     },

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -439,22 +439,24 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     *self.unique_id += 1;
   }
 
-  // Return the ResourceTy that corresponds to the LHS of a let stmt
-  pub fn resource_of_lhs(&mut self, expr: &'tcx Expr) -> ResourceTy {
+  // Return the ResourceTy that corresponds to the LHS of an assignment.
+  // `None` means the LHS is a shape the plugin doesn't model (e.g.
+  // `a[i] = …` index, `(a, b) = …` destructure — #144), or names a
+  // path the plugin never registered as a RAP (synthetic macro local,
+  // unregistered nested-field projection). The caller short-circuits
+  // the assignment instead of crashing.
+  pub fn resource_of_lhs(&mut self, expr: &'tcx Expr) -> Option<ResourceTy> {
     match expr.kind {
-      ExprKind::Path(QPath::Resolved(_, p)) => {
-        let name = self.tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-        ResourceTy::Value(self.raps.get(&name).unwrap().rap.to_owned())
-      }
-      ExprKind::Field(expr, ident) => {
-        match expr {
-          Expr{kind: ExprKind::Path(QPath::Resolved(_,p)), ..} => {
-            let name = self.tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
-            let total_name = format!("{}.{}", name, ident.as_str());
-            ResourceTy::Value(self.raps.get(&total_name).unwrap().rap.to_owned())
-          }
-          _ => { panic!("unexpected field expr") }
-        } 
+      // Path / Field (including chained `a.b.c`): walk the projection
+      // chain via `expr_to_rap_name` to get the qualified name and
+      // look it up. `register_struct_members` recursively registers
+      // nested struct fields under qualified names like `r.a.b`, so
+      // for value-typed locals chained-field LHS resolves directly.
+      // For ref-to-struct params, #147 adds per-field registration so
+      // `self.field = …` and `r.field = …` also resolve.
+      ExprKind::Path(_) | ExprKind::Field(..) => {
+        let name = expr_to_rap_name(expr, &self.tcx)?;
+        self.raps.get(&name).map(|rd| ResourceTy::Value(rd.rap.to_owned()))
       }
       ExprKind::Unary(UnOp::Deref, exp) => {
         let rhs_rap = fetch_rap(&expr, &self.tcx, &self.raps);
@@ -462,12 +464,16 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
         match rhs_rap {
           Some(x) => {
             self.update_rap(&x, line_num);
-            ResourceTy::Deref(x)
+            Some(ResourceTy::Deref(x))
           }
-          None => { ResourceTy::Anonymous }
+          None => Some(ResourceTy::Anonymous),
         }
       }
-      _ => panic!("invalid lhs")
+      // Index, tuple-destructure, etc. — see issue #144.
+      _ => {
+        warn!("unsupported assignment LHS shape (#144); skipping assignment at this location");
+        None
+      }
     }
   }
 

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -405,7 +405,13 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
         // typecheck to figure out what type of event is going to occur
         let line_num = expr_to_line(&lhs_expr, &self.tcx);
-        let lhs_rty = self.resource_of_lhs(lhs_expr);
+        // None means the LHS is an unsupported shape (e.g. index, tuple
+        // destructure — #144) or an unregistered name; short-circuit the
+        // assignment so the rest of the program still renders.
+        let lhs_rty = match self.resource_of_lhs(lhs_expr) {
+          Some(rty) => rty,
+          None => return,
+        };
         let lhs_rap = self.raps.get(&lhs_rty.real_name()).unwrap().rap.clone();
         let lhs_ty = self.tcx.typeck(lhs_expr.hir_id.owner).node_type(lhs_expr.hir_id);
         let is_copyable = self.tcx.type_is_copy_modulo_regions(rustc_middle::ty::TypingEnv::post_analysis(self.tcx, lhs_expr.hir_id.owner), lhs_ty);

--- a/rustviz-plugin/tests/chained_field_assign.rs
+++ b/rustviz-plugin/tests/chained_field_assign.rs
@@ -1,0 +1,19 @@
+// Chained field assignment (`o.inner.x = …`) now resolves
+// through `expr_to_rap_name` and emits an event on the nested
+// field's column. `register_struct_members` already recursively
+// registers nested struct fields like `o.inner.x`, so the
+// qualified-name lookup in `resource_of_lhs` finds the RAP.
+// (#143)
+
+struct Inner {
+    x: i32,
+}
+
+struct Outer {
+    inner: Inner,
+}
+
+fn main() {
+    let mut o = Outer { inner: Inner { x: 0 } };
+    o.inner.x = 5;
+}


### PR DESCRIPTION
Closes #143. Overlaps with #145's panic-conversion; if #145 lands first the resolution should keep this PR's \`resource_of_lhs\` rewrite (it's a strict superset).

## Summary
- \`resource_of_lhs\` previously only handled \`Path\` and the flat \`Field(Path, _)\` shape — chained projections like \`o.inner.x = 5\` hit the inner \`_ =>\` panic arm.
- \`register_struct_members\` already registers nested struct fields under qualified names; reusing \`expr_to_rap_name\` for the LHS walk gives us correct events for arbitrary projection depth.
- Side effect: returns \`Option<ResourceTy>\` so the caller can short-circuit on unsupported shapes (\`a[i] = …\`, \`(a, b) = …\` — #144) instead of crashing.
- Adds \`chained_field_assign\` fixture pinning the event on \`o.inner.x\`'s column.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)