### PR TITLE
plugin: support index assignment on LHS (#144)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -134,6 +134,9 @@ const EXPECTED_OK: &[&str] = &[
     //   resolves through `expr_to_rap_name` to the nested field's
     //   pre-registered RAP and emits an Acquire event on that column.
     "chained_field_assign",
+    // — Index assignment (#144). `v[i] = …` attributes the event
+    //   to the receiver's opaque single-owner column.
+    "index_assign",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -355,6 +358,17 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
         must_contain: &[
             "o.inner.x, mutable",
             "o.inner.x acquires ownership of a resource",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "index_assign",
+        // `v[0] = 9` attributes the event to `v`'s column. Pinned via
+        // the "acquires ownership" tooltip (the renderer treats index
+        // assignment as a reassignment of the receiver's opaque
+        // resource).
+        must_contain: &[
+            "v acquires ownership of a resource",
         ],
         must_not_contain: &[],
     },

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -447,14 +447,16 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
   // the assignment instead of crashing.
   pub fn resource_of_lhs(&mut self, expr: &'tcx Expr) -> Option<ResourceTy> {
     match expr.kind {
-      // Path / Field (including chained `a.b.c`): walk the projection
-      // chain via `expr_to_rap_name` to get the qualified name and
-      // look it up. `register_struct_members` recursively registers
-      // nested struct fields under qualified names like `r.a.b`, so
-      // for value-typed locals chained-field LHS resolves directly.
-      // For ref-to-struct params, #147 adds per-field registration so
-      // `self.field = …` and `r.field = …` also resolve.
-      ExprKind::Path(_) | ExprKind::Field(..) => {
+      // Path / Field (including chained `a.b.c`) / Index (`v[i]`).
+      // `expr_to_rap_name` walks the projection chain, collapsing
+      // indexing onto its receiver (the plugin renders Vec/array as
+      // an opaque single-owner column, so `v[i] = …` attributes the
+      // event to `v`'s column). `register_struct_members` recursively
+      // registers nested struct fields under qualified names like
+      // `r.a.b`, so chained-field LHS resolves directly. #147 adds
+      // per-field registration for ref-to-struct params so
+      // `self.field = …` / `r.field = …` also resolve.
+      ExprKind::Path(_) | ExprKind::Field(..) | ExprKind::Index(..) => {
         let name = expr_to_rap_name(expr, &self.tcx)?;
         self.raps.get(&name).map(|rd| ResourceTy::Value(rd.rap.to_owned()))
       }

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -397,7 +397,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         self.visit_expr(exp);
       }
 
-      // assignment 
+      // assignment
       // ex a = <expr> or a += <expr>
       ExprKind::Assign(lhs_expr, rhs_expr, _,) | ExprKind::AssignOp(_, lhs_expr, rhs_expr) => {
         self.visit_expr(lhs_expr);
@@ -405,9 +405,12 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
 
         // typecheck to figure out what type of event is going to occur
         let line_num = expr_to_line(&lhs_expr, &self.tcx);
-        // None means the LHS is an unsupported shape (e.g. index, tuple
-        // destructure — #144) or an unregistered name; short-circuit the
-        // assignment so the rest of the program still renders.
+        // None means the LHS is an unsupported shape or an unregistered
+        // name; short-circuit the assignment so the rest of the program
+        // still renders. Tuple destructuring assignment `(a, b) = expr`
+        // doesn't fall through here — rustc desugars it before HIR into
+        // a synthetic temporary plus per-element field assignments, each
+        // of which hits this Assign arm individually.
         let lhs_rty = match self.resource_of_lhs(lhs_expr) {
           Some(rty) => rty,
           None => return,

--- a/rustviz-plugin/tests/index_assign.rs
+++ b/rustviz-plugin/tests/index_assign.rs
@@ -1,0 +1,10 @@
+// Index assignment (`v[i] = …`). The plugin renders Vec /
+// array as an opaque single-owner column, so the assignment
+// attributes its event to the receiver's column rather than
+// fabricating a per-element timeline. (#144)
+
+fn main() {
+    let mut v = vec![1, 2, 3];
+    v[0] = 9;
+    println!("{}", v[0]);
+}


### PR DESCRIPTION
Stacked on #150 (chained field LHS). Closes #144's index sub-case. Filed follow-ups: #151 (tuple destructure synthetic column), #152 (deref-field through local ref).

## Summary
- Extends \`resource_of_lhs\` to accept \`ExprKind::Index\` alongside Path and Field. \`expr_to_rap_name\` already collapses indexing onto its receiver, so \`v[i] = …\` attributes its event to \`v\`'s column.
- Tuple destructure works through rustc's pre-HIR desugar — no plugin-side special-casing needed — but leaves a synthetic \`lhs\` column visible (tracked as #151).
- \`*p.f = …\` through local refs still silently skipped (tracked as #152, blocked on extending #147 to locals).
- Adds \`index_assign\` corpus fixture.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)