### PR TITLE
plugin: surface every call in a method chain (#132)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,10 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Chained method calls (#132): each call in `a.foo().bar()`
+    //   now surfaces as its own event, attributed to the base
+    //   receiver `a` instead of the synthetic intermediate.
+    "method_chain_two_calls",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -342,6 +346,18 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from String::from to s",
             "len reads from s",
             "Copy from len to n",
+        ],
+        must_not_contain: &[],
+    },
+
+    TooltipExpect {
+        name: "method_chain_two_calls",
+        // Both calls in the chain emit arrows, each attributed to
+        // the base receiver `b`. Previously the outer `push` arrow
+        // was silently dropped.
+        must_contain: &[
+            "get_mut reads from/writes to b",
+            "push reads from/writes to b",
         ],
         must_not_contain: &[],
     },

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -327,15 +327,21 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         let line_num = expr_to_line(&rcvr, &self.tcx);
         let fn_name = name_and_generic_args.ident.as_str().to_owned();
         self.add_fn(fn_name.clone());
-        // need to recurse down to the variable calling the methods 
+        // need to recurse down to the variable calling the methods
         // necessary for chained method calls scenarios: ie a.get().unwrap()
         self.visit_expr(rcvr);
-        match rcvr.kind {
-          ExprKind::MethodCall(p_seg, ..) => { // return early if not at the base
-            let _rcvr_name = p_seg.ident.as_str().to_owned();
-            return;
-          }
-          _ => {}
+        // Chained method calls like `a.get_mut().push(x)` (#132): the
+        // outer call's receiver is itself a MethodCall whose return
+        // value has no registered RAP. Walk down the chain to the
+        // base receiver — the user-named RAP at the bottom — and
+        // attribute the outer call to that. Pedagogical
+        // simplification: pretends each call operates on the base
+        // receiver, glossing over the intermediate return values.
+        // Without this, only the innermost call in a chain emits
+        // an event.
+        let mut base_rcvr: &Expr = rcvr;
+        while let ExprKind::MethodCall(_, inner, ..) = base_rcvr.kind {
+          base_rcvr = inner;
         }
         // The receiver of `r.s.method()` is a Field expression, not
         // a bare path, so `hirid_to_var_name` can't name it.
@@ -346,7 +352,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         // impl method, etc. — bail out of the rest of the
         // method-call processing rather than crash; the call site
         // simply produces no event for this method.
-        let rcvr_name = match expr_to_rap_name(rcvr, &self.tcx) {
+        let rcvr_name = match expr_to_rap_name(base_rcvr, &self.tcx) {
           Some(n) => n,
           None => return,
         };

--- a/rustviz-plugin/tests/method_chain_two_calls.rs
+++ b/rustviz-plugin/tests/method_chain_two_calls.rs
@@ -1,0 +1,20 @@
+// Chained method calls (#132). `b.get_mut().push(5)` is a
+// chain of two method calls — `get_mut` returns `&mut Vec<i32>`
+// and `push` is called on that return. Pre-#132 only the inner
+// `get_mut` arrow was rendered. Now both arrows surface, both
+// attributed (pedagogically) to the base receiver `b`.
+
+struct Buf {
+    v: Vec<i32>,
+}
+
+impl Buf {
+    fn get_mut(&mut self) -> &mut Vec<i32> {
+        &mut self.v
+    }
+}
+
+fn main() {
+    let mut b = Buf { v: Vec::new() };
+    b.get_mut().push(5);
+}


### PR DESCRIPTION
Closes #132.

## Summary
- The MethodCall arm bailed out (early return) when the receiver was itself a MethodCall, so chains like \`a.get_mut().push(5)\` rendered only the innermost call's event.
- Walks down to the base receiver and attributes each call's event to it. Pedagogical simplification: pretends each call operates on the base, glossing over the intermediate return-value temporary.
- Renders \`a → get_mut\` and \`a → push\` as two separate arrows.
- Adds \`method_chain_two_calls\` corpus fixture.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)