### PR TITLE
plugin: register per-field RAPs for ref-to-struct locals (#152)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -148,6 +148,10 @@ const EXPECTED_OK: &[&str] = &[
     //   program still renders.
     "method_assigns_field",
     "tuple_struct_method",
+    // — Per-field RAPs for ref-to-struct locals (#152, mirror of
+    //   the param-side fix in #147). `let p = &mut foo; p.x = …`
+    //   now resolves and emits an event on `p.x`'s column.
+    "local_ref_field_assign",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -377,6 +381,16 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "area reads from rect",
             "r acquires ownership of a resource",
             "r goes out of scope. Its resource is dropped.",
+        ],
+        must_not_contain: &[],
+    },
+    TooltipExpect {
+        name: "local_ref_field_assign",
+        // After #152, `p.x = 5` resolves to `p.x`'s registered RAP
+        // and emits the reassignment event on that column.
+        must_contain: &[
+            "p.x, mutable",
+            "p.x acquires ownership of a resource",
         ],
         must_not_contain: &[],
     },

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -568,13 +568,35 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     let is_special = ty_is_special_owner(&ty);
     if ty.is_ref() {
       let (lender, aliasing) = self.get_ref_data(&expr);
-      self.add_ref(name.clone(), 
-      bool_of_mut(ty.ref_mutability().unwrap()), 
-      mutability, 
+      self.add_ref(name.clone(),
+      bool_of_mut(ty.ref_mutability().unwrap()),
+      mutability,
       expr_to_line(&expr, &self.tcx),
       lender,
       aliasing,
       self.current_scope, !self.inside_branch);
+      // Mirror the visit_param ref-branch fix from #147: when the
+      // pointee is a user-defined ADT, register per-field member RAPs
+      // under the ref so `p.field` / `p.field = …` projections
+      // resolve. Without this, `let p = &mut foo; p.x = 5;` silently
+      // drops the assignment because `p.x` isn't in raps. (#152)
+      let pointee = ty.builtin_deref(true);
+      if let Some(pointee_ty) = pointee {
+        if pointee_ty.is_adt() && !ty_is_special_owner(&pointee_ty) {
+          let owner_hash = *self.raps.get(&name).unwrap().rap.hash();
+          let field_mut = matches!(ty.ref_mutability(), Some(Mutability::Mut));
+          let generic_args = match pointee_ty.kind() {
+            TyKind::Adt(_, args) => *args,
+            _ => unreachable!("pointee.is_adt() but kind is not Adt"),
+          };
+          for field in pointee_ty.ty_adt_def().unwrap().all_fields() {
+            let field_name = format!("{}.{}", name.clone(), field.name.as_str());
+            let field_ty = field.ty(self.tcx, generic_args);
+            let field_is_copy = self.ty_is_copy(field_ty, expr.hir_id.owner);
+            self.add_struct(field_name, owner_hash, true, field_mut, field_is_copy, self.current_scope, !self.inside_branch);
+          }
+        }
+      }
     }
     else if ty.is_adt() && !is_special {
       match ty.ty_adt_def().unwrap().adt_kind() {

--- a/rustviz-plugin/tests/local_ref_field_assign.rs
+++ b/rustviz-plugin/tests/local_ref_field_assign.rs
@@ -1,0 +1,14 @@
+// `let p = &mut foo; p.x = …` — per-field RAP registration
+// for ref-to-struct locals (mirror of the param-side fix in
+// #147). Without this, the assignment was silently dropped
+// because `p.x` wasn't in raps. (#152)
+
+struct Foo {
+    x: i32,
+}
+
+fn main() {
+    let mut foo = Foo { x: 0 };
+    let p = &mut foo;
+    p.x = 5;
+}


### PR DESCRIPTION
Stacked on #148 (the param-side fix). Closes #152.

## Summary
- Mirror of #147's param-side fix in \`define_lhs\`: when a \`let\` binding has a \`&Struct\` / \`&mut Struct\` type, register each pointee field as a \`Struct\` member RAP under the ref.
- Fixes the silently-dropped \`p.x = 5\` assignment shape that #152 documented.
- Adds \`local_ref_field_assign\` fixture pinning the new event on \`p.x\`'s column.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)