### PR TITLE
plugin: hide synthetic 'lhs' from tuple-destructure assignment (#151)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,11 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Tuple-destructure assignment (#151). `(a, b) = (b, a)`
+    //   surfaces per-element events on a and b; the synthetic
+    //   `lhs` temporary from rustc's desugar is hidden from the
+    //   timeline.
+    "tuple_destructure_assign",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -344,6 +349,24 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Copy from len to n",
         ],
         must_not_contain: &[],
+    },
+
+    TooltipExpect {
+        name: "tuple_destructure_assign",
+        // After #151, the rustc-synthesized `lhs` temporary from
+        // desugaring `(a, b) = (b, a)` doesn't appear as a column.
+        // `a` and `b` each pick up two "bound to a value" events
+        // (initial bind + swap-assignment).
+        must_contain: &[
+            "a, mutable",
+            "b, mutable",
+            "a is bound to a value",
+            "b is bound to a value",
+        ],
+        must_not_contain: &[
+            "lhs, immutable",
+            "lhs, mutable",
+        ],
     },
 
     // ─── User-defined inherent methods ──────────────────────────────

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -859,9 +859,21 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
           self.tcx.hir_name(p.segments[0].hir_id).as_str().to_owned()
         }
       };
-      let rhs_rap = self.raps.get(&rhs_name).unwrap().rap.to_owned();
-      self.update_rap(&rhs_rap, line_num);
-      self.add_ev(line_num, evt, lhs, ResourceTy::Value(rhs_rap), false);
+      // A path that doesn't resolve to a registered RAP — most
+      // commonly a synthetic local from a desugar (`?` operator's
+      // `val` continuation, tuple-destructure-assign's `lhs`
+      // temporary — #151) — gets an Anonymous-source Bind so the
+      // event still lands on the LHS column without crashing.
+      match self.raps.get(&rhs_name) {
+        Some(rd) => {
+          let rhs_rap = rd.rap.to_owned();
+          self.update_rap(&rhs_rap, line_num);
+          self.add_ev(line_num, evt, lhs, ResourceTy::Value(rhs_rap), false);
+        }
+        None => {
+          self.add_ev(line_num, Evt::Bind, lhs, ResourceTy::Anonymous, false);
+        }
+      }
     },
     // fn_expr: resolves to function itself (Path)
     // second arg, is a list of args to the function

--- a/rustviz-plugin/src/expr_visitor_utils.rs
+++ b/rustviz-plugin/src/expr_visitor_utils.rs
@@ -544,6 +544,24 @@ pub fn filter_ev((line_num, _ev): &(usize, ExternalEvent), split: usize, merge: 
 }
 
 // Fetch the mutability of the borrow
+/// True iff `pat` is a tuple-pattern of bindings all named `lhs` —
+/// the signature rustc uses when desugaring tuple-destructure
+/// assignment `(a, b) = (e1, e2)`. The desugar produces
+/// `let (lhs, lhs, ...) = (e1, e2, ...);` followed by per-element
+/// assignments. Detecting this lets visit_local skip the synthetic
+/// local so it doesn't get its own timeline column. (#151)
+pub fn is_tuple_destructure_desugar_pat(pat: &Pat<'_>) -> bool {
+  let pats = match pat.kind {
+    PatKind::Tuple(pats, _) => pats,
+    _ => return false,
+  };
+  if pats.is_empty() { return false; }
+  pats.iter().all(|p| matches!(
+    p.kind,
+    PatKind::Binding(_, _, ident, None) if ident.as_str() == "lhs"
+  ))
+}
+
 pub fn fetch_mutability(expr: & Expr) -> Option<Mutability> {
   match expr.kind {
     ExprKind::Block(b, _) => {

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -625,9 +625,16 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
         if expr.span.from_expansion() {
           return;
         }
-        let r = &self.raps.get(&name).unwrap().rap.clone();
+        // Path may reference a name we deliberately didn't register
+        // (the tuple-destructure desugar's `lhs` synthetic — #151 —
+        // is the canonical case). Skip the lifetime update rather
+        // than panic.
+        let r = match self.raps.get(&name) {
+          Some(rd) => rd.rap.clone(),
+          None => return,
+        };
         let line_num = span_to_line(&p.span, &self.tcx);
-        self.update_rap(r, line_num);
+        self.update_rap(&r, line_num);
       }
       
       // Don't know what this is honestly
@@ -1375,6 +1382,17 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
     // as the from_expansion check on ExprKind::If/Match: macro
     // internals shouldn't appear as user-visible variables.
     if local.span.from_expansion() {
+      return;
+    }
+    // Tuple-destructure assignment `(a, b) = (e1, e2)` (Rust ≥1.59)
+    // desugars before HIR into `{ let (lhs, lhs, …) = (e1, e2, …);
+    //   a = lhs; b = lhs; … }` — synthetic locals all named `lhs`.
+    // The desugar's spans aren't from_expansion (they're at the
+    // user's source line), so the macro guard above doesn't catch
+    // them. Detect the pattern structurally and skip registration so
+    // the synthetic doesn't show up as its own timeline column.
+    // (#151)
+    if is_tuple_destructure_desugar_pat(local.pat) {
       return;
     }
     let local_line = self.tcx.sess.source_map().lookup_char_pos(local.span.lo()).line;

--- a/rustviz-plugin/tests/tuple_destructure_assign.rs
+++ b/rustviz-plugin/tests/tuple_destructure_assign.rs
@@ -1,0 +1,13 @@
+// Tuple destructure assignment `(a, b) = (b, a)` (Rust ≥1.59).
+// rustc desugars to `{ let (lhs, lhs) = (b, a); a = lhs; b = lhs; }`,
+// so the per-element assignments hit the existing Assign + Path
+// path. Before #151 the synthetic `lhs` local got registered as its
+// own RAP and surfaced as a phantom column on the diagram. Now the
+// desugar's pattern is detected and the local skipped — only `a`
+// and `b` show timelines, each picking up the swap event.
+
+fn main() {
+    let mut a = 1;
+    let mut b = 2;
+    (a, b) = (b, a);
+}


### PR DESCRIPTION
Closes #151.

## Summary
- \`(a, b) = (e1, e2)\` desugars to \`{ let (lhs, lhs, ...) = (e1, e2, ...); a = lhs; b = lhs; ... }\`. The synthetic \`lhs\` locals weren't \`from_expansion=true\`, so the existing macro guard didn't catch them — they showed up as phantom timeline columns with copy events the user never wrote.
- Detect the desugar's pattern structurally (a Tuple of Bindings all named \`lhs\`) and skip the synthetic let. Two downstream Path lookups got graceful-None fallbacks since \`lhs\` is no longer registered (mirrors the \`?\` fix in #155).
- Adds \`tuple_destructure_assign\` fixture pinning that \`a\` and \`b\` show events while \`lhs\` produces no column.

## Test plan
- [x] \`cargo test -p rustviz-lib --test corpus\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)