### PR TITLE
plugin: replay closure body events at call sites (#133)

### DIFF
--- a/rustviz-lib/tests/corpus.rs
+++ b/rustviz-lib/tests/corpus.rs
@@ -130,6 +130,10 @@ const EXPECTED_OK: &[&str] = &[
     "if_let_inside_for",
     "cond_with_move_closure",
     "match_with_closure_arms",
+    // — Closure body events replay at call sites (#133).
+    //   `show(&s)` inside `let f = || show(&s); f();` now surfaces
+    //   as an event on `s`'s column at the `f()` call line.
+    "closure_body_event_replay",
 ];
 
 /// Tooltip-level expectations per snippet. `must_contain` strings have to
@@ -342,6 +346,19 @@ const EXPECTED_TOOLTIPS: &[TooltipExpect] = &[
             "Move from String::from to s",
             "len reads from s",
             "Copy from len to n",
+        ],
+        must_not_contain: &[],
+    },
+
+    TooltipExpect {
+        name: "closure_body_event_replay",
+        // The `show(&s)` call inside the closure body emits its
+        // PassByStaticReference event on `s`'s column at the f()
+        // call line, just as if the user had written `show(&s)`
+        // directly on that line.
+        must_contain: &[
+            "show reads from s",
+            "s's resource is captured (immutably borrowed) by closure f",
         ],
         must_not_contain: &[],
     },

--- a/rustviz-plugin/src/expr_visitor.rs
+++ b/rustviz-plugin/src/expr_visitor.rs
@@ -11,7 +11,7 @@ use rustc_middle::{
   mir::Body,
   ty::*,
 };
-use rustc_hir::{Expr, ExprKind, QPath, PatKind, Mutability, UnOp, def::*, Pat};
+use rustc_hir::{Expr, ExprKind, QPath, PatKind, Mutability, UnOp, def::*, Pat, intravisit::Visitor};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use crate::expr_visitor_utils::*;
 use crate::svg_generator::data::*;
@@ -135,6 +135,25 @@ pub struct ExprVisitor<'a, 'tcx:'a> {
   // it reaches the renderer — which is what gives the variable no
   // timeline column.
   pub skip_raps: std::collections::HashSet<String>,
+
+  // Events emitted while walking a closure body. Keyed by closure
+  // binding name. Buffered here instead of dispatching directly into
+  // preprocessed_events / event_line_map, then replayed at each call
+  // site of the closure (#133). For `move` closures, events whose
+  // source / destination is a captured upvar are dropped at replay
+  // time — the upvar's column ended at the capture, so re-adding
+  // events later would be misleading.
+  pub closure_body_events: HashMap<String, Vec<(usize, ExternalEvent)>>,
+
+  // Names of upvars captured `move` by each closure binding. Used
+  // to filter the captured-upvar events out when replaying a move
+  // closure's body at the call site.
+  pub closure_move_captures: HashMap<String, std::collections::HashSet<String>>,
+
+  // While walking a closure body, this is set to the closure binding's
+  // name. add_external_event redirects events into closure_body_events
+  // under this key instead of preprocessed_events.
+  pub current_closure: Option<String>,
 }
 
 impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
@@ -343,6 +362,42 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     }
   }
 
+  /// Replay every event captured during a closure body walk on this
+  /// call-site line. Events whose source or destination is a
+  /// move-captured upvar are dropped (the upvar's column ended at
+  /// the capture line — re-emitting later would be misleading). No-op
+  /// if the binding name isn't a known closure. Idempotent across
+  /// repeat call sites: each replay produces fresh `unique_id`s so
+  /// the renderer's id → event map stays consistent. (#133)
+  pub fn replay_closure_body(&mut self, closure_name: &str, call_line: usize) {
+    let events = match self.closure_body_events.get(closure_name) {
+      Some(events) => events.clone(),
+      None => return,
+    };
+    let empty = std::collections::HashSet::new();
+    let move_set = self.closure_move_captures
+      .get(closure_name)
+      .unwrap_or(&empty)
+      .clone();
+    let touches_move_upvar = |ty: &ResourceTy| -> bool {
+      match ty {
+        ResourceTy::Value(rap) | ResourceTy::Deref(rap) => move_set.contains(rap.name()),
+        _ => false,
+      }
+    };
+    for (_orig_line, mut ev) in events.into_iter() {
+      let (from, to) = ResourceAccessPoint_extract(&ev);
+      if touches_move_upvar(from) || touches_move_upvar(to) {
+        continue;
+      }
+      // Rewrite the event's id so each replay produces a unique id
+      // (the renderer uses ids as event-tree keys).
+      ev.set_id(*self.unique_id);
+      *self.unique_id += 1;
+      self.add_external_event(call_line, ev);
+    }
+  }
+
   pub fn add_external_event(&mut self, line_num: usize, event: ExternalEvent) {
     // Drop events whose source or destination is a `// rustviz: skip`-
     // marked variable. The marked RAP still exists (so non-skipped
@@ -352,6 +407,19 @@ impl<'a, 'tcx> ExprVisitor<'a, 'tcx>{
     // renderer only materialises a timeline when a hash sees its
     // first event, a RAP with zero events never gets a column.
     if self.event_touches_skipped(&event) {
+      return;
+    }
+
+    // While walking a closure body, buffer events under the closure's
+    // binding name instead of dispatching directly into the main event
+    // streams. The buffer is replayed at each visible call site of
+    // the closure so body events surface at the call site line
+    // rather than at the closure literal. (#133)
+    if let Some(closure_name) = self.current_closure.clone() {
+      self.closure_body_events
+        .entry(closure_name)
+        .or_default()
+        .push((line_num, event));
       return;
     }
 
@@ -1114,6 +1182,10 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       // ownership of a resource" dot like other Bind sites.
       self.add_ev(line_num, Evt::Bind, lhs.clone(), ResourceTy::Anonymous, false);
 
+      // Closure binding name. Used to key the body-event buffer for
+      // call-site replay (#133).
+      let closure_name = lhs.real_name();
+
       // MIR loan facts for the enclosing fn body. Each ref capture
       // becomes one polonius loan whose `borrowed_place` is the
       // upvar and whose `region.1` is the NLL kill line — the line
@@ -1123,6 +1195,12 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
       // the captured borrow visually returns to its lender on the
       // line the user expects.
       let mir_b_data = self.gather_borrow_data(self.bwf);
+
+      // Collect move-captured upvar names so we can filter their
+      // events from the body replay later. Move captures end the
+      // upvar's column at the capture line — surfacing further
+      // events at the call site would be visually inconsistent.
+      let mut move_captured: HashSet<String> = HashSet::new();
 
       let typeck = self.tcx.typeck(closure.def_id);
       for capture in typeck.closure_min_captures_flattened(closure.def_id) {
@@ -1154,6 +1232,9 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
             _ => Evt::SBorrow,
           },
         };
+        if matches!(evt_kind, Evt::Move) {
+          move_captured.insert(upvar_name.clone());
+        }
         self.add_ev(line_num, evt_kind.clone(), to, from.clone(), false);
 
         // For ref captures, find the matching MIR loan and emit
@@ -1190,6 +1271,18 @@ pub fn match_rhs(&mut self, lhs: ResourceTy, rhs:&'tcx Expr, evt: Evt){
           }
         }
       }
+
+      // Record move-captures keyed by closure name, then walk the
+      // body once with `current_closure` set so events emitted by
+      // body expressions buffer under the closure name instead of
+      // surfacing immediately. The call-site Call arm in visit_expr
+      // replays the buffer at the call line. (#133)
+      self.closure_move_captures.insert(closure_name.clone(), move_captured);
+      let prev_closure = self.current_closure.take();
+      self.current_closure = Some(closure_name);
+      let body = self.tcx.hir_body(closure.body);
+      self.visit_expr(body.value);
+      self.current_closure = prev_closure;
     }
     _ => {
       warn!("unmatched rhs {:#?}", rhs);

--- a/rustviz-plugin/src/plugin.rs
+++ b/rustviz-plugin/src/plugin.rs
@@ -173,6 +173,9 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
               fn_ret: output,
               skip_lines: &skip_lines,
               skip_raps: HashSet::new(),
+              closure_body_events: HashMap::new(),
+              closure_move_captures: HashMap::new(),
+              current_closure: None,
             };
             visitor.visit_body(hir_body);
             visitor.print_lifetimes();
@@ -248,6 +251,9 @@ pub fn rv_visitor(tcx: TyCtxt, args: &RVPluginArgs) {
           fn_ret: output,
           skip_lines: &skip_lines,
           skip_raps: HashSet::new(),
+          closure_body_events: HashMap::new(),
+          closure_move_captures: HashMap::new(),
+          current_closure: None,
         };
         visitor.visit_body(hir_body);
         visitor.print_lifetimes();

--- a/rustviz-plugin/src/svg_generator/data.rs
+++ b/rustviz-plugin/src/svg_generator/data.rs
@@ -560,6 +560,23 @@ impl ExternalEvent {
             &ExternalEvent::InitRefParam { id, .. }=> id
         }
     }
+
+    /// Overwrite the event's id. Used by the closure-body replay path
+    /// (#133): a buffered event is cloned for each call site and
+    /// stamped with a fresh id so the renderer's id-keyed event tree
+    /// has unique entries per replay.
+    pub fn set_id(&mut self, new_id: usize) {
+        match self {
+            ExternalEvent::Copy { id, .. } | ExternalEvent::Move { id, .. } |
+            ExternalEvent::StaticBorrow { id, .. } | ExternalEvent::StaticDie { id, .. } |
+            ExternalEvent::MutableBorrow { id, .. } | ExternalEvent::MutableDie { id, .. } |
+            ExternalEvent::Branch { id, .. } | ExternalEvent::GoOutOfScope { id, .. } |
+            ExternalEvent::OwnerDropAtReassign { id, .. } |
+            ExternalEvent::RefDie { id, .. } | ExternalEvent::Bind { id, .. } |
+            ExternalEvent::PassByStaticReference { id, .. } | ExternalEvent::PassByMutableReference { id, .. } |
+            ExternalEvent::InitRefParam { id, .. } => *id = new_id,
+        }
+    }
 }
 
 // Each branch has a history of events (e_data)

--- a/rustviz-plugin/src/visitor.rs
+++ b/rustviz-plugin/src/visitor.rs
@@ -261,12 +261,23 @@ impl<'a, 'tcx> Visitor<'tcx> for ExprVisitor<'a, 'tcx> {
     match expr.kind {
       // fn call <expr>[<expr>]
       ExprKind::Call(fn_expr, args) => {
+        // If this Call invokes a local closure binding, replay the
+        // closure's buffered body events at this call site so reads
+        // / writes / borrows performed inside the body surface on
+        // the touched RAPs' columns. Done first so the events land
+        // on the call line before any arg processing below (which
+        // can update RAP lifetimes past it). (#133)
+        if let ExprKind::Path(QPath::Resolved(_, p)) = fn_expr.kind {
+          let call_line = expr_to_line(expr, &self.tcx);
+          let name = self.tcx.hir_name(p.segments[0].hir_id).as_str().to_owned();
+          self.replay_closure_body(&name, call_line);
+        }
 
         // need to specifically handle println! macro because it's common
         // note that other macros will need to be resolved similarly (vec![], assert!, etc)
         // Need to match through all the desugaring and onto the args to the format ({}) function
         match fn_expr.kind {
-          ExprKind::Path(QPath::Resolved(_,rustc_hir::Path{res: rustc_hir::def::Res::Def(_, id), ..})) 
+          ExprKind::Path(QPath::Resolved(_,rustc_hir::Path{res: rustc_hir::def::Res::Def(_, id), ..}))
           if !id.is_local() => {
             // to see what the macro expansion looks like:
             // println!("{:#?}", expr);

--- a/rustviz-plugin/tests/closure_body_event_replay.rs
+++ b/rustviz-plugin/tests/closure_body_event_replay.rs
@@ -1,0 +1,12 @@
+// Closure body events surface on captured-upvar timelines at the
+// closure's call site (#133). Before this, `show(&s)` inside the
+// closure body produced no event on `s`'s column even though the
+// borrow was exercised at call time.
+
+fn show(_s: &String) {}
+
+fn main() {
+    let s = String::from("hi");
+    let f = || show(&s);
+    f();
+}


### PR DESCRIPTION
Closes #133.

## Summary
A closure's capture events render at the literal, but body events — `show(&s)` inside `let f = || show(&s); f();` — produced nothing on `s`'s column. After this change, body events surface at each visible call site.

## Design decisions
Per the issue's open design questions:

* **When do body events happen?** At the **call site** (`f()`), closer to runtime semantics. Closures that never get called emit nothing — there's no call line to attach to.
* **Move closures.** Body events whose source or destination is a move-captured upvar are dropped at replay. The upvar's column already ended at the capture line; surfacing further events on it would contradict the move-ownership story.
* **Borrow closures.** All body events replay on captured upvars — the borrow is live across the call, so the additional events are accurate.
* **Out of scope** today: closures passed to higher-order fns (`xs.iter().for_each(|x| ...)`), closures stored in struct fields (`s.f()` where `f` is a closure field), immediately-invoked closures (`(|| { ... })()`). Only `Path`-shaped Call receivers — `f()` where `f` is a local binding — trigger replay. Each of these is a sensible follow-up.

## Implementation
- New visitor state: `closure_body_events: HashMap<String, Vec<(usize, ExternalEvent)>>`, `closure_move_captures: HashMap<String, HashSet<String>>`, `current_closure: Option<String>`.
- During the closure literal's `match_rhs` walk, after the capture events, the body is walked with `current_closure` set. `add_external_event` redirects buffered events under that name.
- At a Call whose `fn_expr` is a `Path`, `replay_closure_body(name, call_line)` clones each buffered event, filters move-captured-upvar events, stamps fresh `unique_id`s via the new `ExternalEvent::set_id`, and re-dispatches.

Adds `closure_body_event_replay` corpus fixture pinning that `show reads from s` and `s's resource is captured (immutably borrowed) by closure f` both appear.

## Test plan
- [x] `cargo test -p rustviz-lib --test corpus`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)