### PR TITLE
playground: strip trailing-on-each-line whitespace before hashing + POST

### DIFF
--- a/playground/frontend/scripts/prerender.ts
+++ b/playground/frontend/scripts/prerender.ts
@@ -31,6 +31,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { exampleGroups } from '../src/examples';
+import { normalizeCode } from '../src/normalizeCode';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -140,7 +141,10 @@ function tryReuseExisting(): Record<string, Pair> | null {
   const reused: Record<string, Pair> = {};
   for (const group of exampleGroups) {
     for (const ex of group.examples) {
-      const hash = sha256Hex(ex.code);
+      // Match the runtime cache: hash the normalized source so a
+      // dropdown click and a paste-with-trailing-spaces collapse to
+      // the same key.
+      const hash = sha256Hex(normalizeCode(ex.code));
       const existing = parsed.entries[hash];
       if (
         !existing ||
@@ -172,7 +176,8 @@ function main(): void {
   for (const group of exampleGroups) {
     for (const ex of group.examples) {
       total += 1;
-      const hash = sha256Hex(ex.code);
+      const normalized = normalizeCode(ex.code);
+      const hash = sha256Hex(normalized);
       const label = `${group.chapter} / ${ex.name}`;
       if (entries[hash]) {
         // Two curated examples with byte-identical code is a sign of
@@ -186,7 +191,10 @@ function main(): void {
       }
       process.stdout.write(`prerender: ${label.padEnd(50)} `);
       const t0 = Date.now();
-      entries[hash] = renderOne(ex.code, label);
+      // Render the normalized form so the SVG that comes back
+      // corresponds to exactly what `rustviz svg` would emit for the
+      // user's submission (with their trailing whitespace stripped).
+      entries[hash] = renderOne(normalized, label);
       console.log(`${Date.now() - t0} ms`);
     }
   }

--- a/playground/frontend/src/App.tsx
+++ b/playground/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import ErrorCard from './ErrorCard';
 import { exampleGroups } from './examples';
 import { get as cacheGet, put as cachePut } from './svgCache';
+import { normalizeCode } from './normalizeCode';
 import {
   codeForSelection,
   DEFAULT_SELECTION,
@@ -542,7 +543,12 @@ const App: React.FC = () => {
     const controller = new AbortController();
     inflightRef.current = controller;
 
-    const code = editor.getCurrentCode();
+    // Strip trailing-on-each-line whitespace before hashing and
+    // POSTing. The editor often gets terminal-pasted snippets with
+    // invisible right-padding, which would otherwise miss the
+    // dropdown / user-side cache and force an API round-trip for
+    // visually-identical input.
+    const code = normalizeCode(editor.getCurrentCode());
 
     // Cache lookup before we set the spinner. If we've rendered this
     // exact source before — either at build time (any dropdown

--- a/playground/frontend/src/normalizeCode.ts
+++ b/playground/frontend/src/normalizeCode.ts
@@ -1,0 +1,25 @@
+// Normalize Rust source before hashing and submitting it. Trailing
+// whitespace on a line is invisible in the editor but changes the
+// sha256 the cache uses to key entries, so without this normalization
+// two snippets that look identical render through the API twice
+// (once for each whitespace variant) — and dropdown / cached-user
+// snippets miss the cache every time the user copy-pastes code out
+// of a terminal that strips through its scrollback buffer or adds
+// alignment spaces.
+//
+// Only trailing-on-each-line is stripped. Leading whitespace
+// (indentation) and interior whitespace are load-bearing for Rust
+// parsers and for the user's mental model. Trailing newlines at
+// end-of-file are also left alone — many `let x = …;` snippets need
+// the final newline for `rustc` to accept them as a valid module.
+//
+// The same normalization runs at prerender time so the build-time
+// SVG cache's keys are consistent with the runtime ones; see
+// `scripts/prerender.ts`.
+export function normalizeCode(code: string): string {
+  // Match a run of trailing horizontal whitespace at end-of-line.
+  // `^` / `$` with `m` flag scope to each line; `[ \t]+` deliberately
+  // avoids `\s+` since `\s` also matches `\n` and would eat the
+  // line break itself.
+  return code.replace(/[ \t]+$/gm, '');
+}


### PR DESCRIPTION
## Summary

Pasting Rust out of a terminal often drags trailing alignment spaces along on each line — invisible in the editor but bytes-different from the dropdown examples, so the SVG cache (build-time prerender + localStorage runtime tier) missed every time. The user then pays the cold-start ~45 s for visually-identical code.

## Change

New `src/normalizeCode.ts` exports a one-line helper:

\`\`\`ts
export function normalizeCode(code: string): string {
  return code.replace(/[ \t]+$/gm, '');
}
\`\`\`

Strips only trailing horizontal whitespace on each line. Leading whitespace (indentation) and EOF newlines are load-bearing for the Rust parser, so neither is touched.

`App.tsx` normalizes the editor's current code once before both the cache lookup and the API POST. The cache hash is computed on the normalized form, so dropdown clicks and copy-pasted variants of the same snippet collapse to the same key.

`scripts/prerender.ts` applies the same normalization so build-time cache entries use the same hashes the runtime would compute. `examples.ts` has no trailing whitespace today, so this is a no-op for the current dropdown set — the change is forward-looking, ensuring that any future trailing whitespace doesn't silently de-correlate the build-time and runtime keys.

## Test plan

- [x] `npx tsc -b` passes
- [x] `npm run build` produces the SPA bundle cleanly
- [x] Unit-style sanity on `normalizeCode` (6 cases incl. mixed tabs/spaces, indentation preserved, trailing newlines preserved)
- [ ] Reviewers can paste `let x = 5;  ` (with two trailing spaces) into the playground and verify it hits the cache same as the unsuffixed form

## Out of scope

- Backend-side normalization. Pointless: the frontend already strips before POST, and any other client we don't control isn't ours to police.
- `prerendered.json` refresh — its content depends only on `examples.ts` (which is whitespace-clean), so the existing hashes are unchanged. A separate refresh for the new Conditionals entries already-merged in main is its own commit.